### PR TITLE
[Bugfix] Prevent Incorrect Failure Handling Calling SDK Error

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
@@ -94,9 +94,7 @@ class ACSCallingSDKWrapper: NSObject, CallingSDKWrapper {
             }
 
             self.callAgent?.join(with: joinLocator, joinCallOptions: joinCallOptions) { [weak self] (call, error) in
-                guard let self = self,
-                      let call = call else {
-                    self?.logger.error( "Join call failed")
+                guard let self = self else {
                     return promise(.failure(CompositeError.invalidSDKWrapper))
                 }
 
@@ -104,6 +102,12 @@ class ACSCallingSDKWrapper: NSObject, CallingSDKWrapper {
                     self.logger.error( "Join call failed with error")
                     return promise(.failure(error))
                 }
+
+                guard let call = call else {
+                    self.logger.error( "Join call failed")
+                    return promise(.failure(CompositeError.invalidSDKWrapper))
+                }
+
                 call.delegate = self.callingEventsHandler
                 self.call = call
                 self.setupCallRecordingAndTranscriptionFeature()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.0.0-beta.2 (Upcoming)
+
+### Bug Fixes
+- Updating logic to check against the error first before checking the call object
+
 ## 1.0.0-beta.1 (2021-12-09)
 This is the initial release of Azure Communication UI Library. For more information, please see the [README](README.md) and [QuickStart](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/ui-library/get-started-call?tabs=kotlin&pivots=platform-ios).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.2 (Upcoming)
 
+### New Features
+
+### Breaking Changes
+
 ### Bug Fixes
 - Updating logic to check against the error first before checking the call object
 


### PR DESCRIPTION
## Purpose
Updating logic to check against the error first before checking the call object
Calling SDK has an upcoming task where they will no longer be creating a call object when they return us an error. 
So when that change comes down we will actually fail incorrectly and not bubble the error up to the user. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
