### PR TITLE
[Bugfix] Dispatch camera preview no matter the current state

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -46,8 +46,7 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
                 case .failure(let error):
                     self.handle(error: error, errorCode: CallCompositeErrorCode.callJoin, dispatch: dispatch)
                 case .finished:
-                    if state.permissionState.cameraPermission == .granted,
-                       state.localUserState.cameraState.operation == .off {
+                    if state.permissionState.cameraPermission == .granted {
                         dispatch(LocalUserAction.CameraPreviewOnTriggered())
                     }
                 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Current state may be .on or .paused (background mode) prior to network disconnect

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Setup screen video preview shows camera feed when navigating back to setup on error (if camera permission granted)
  * when video is off during call
  * when video is on during call
  * when app is in background mode during call