### PR TITLE
[Bugfix] Resume orientation notification upon landing back to sample screen from the setup screen

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Container/ContainerUIHostingController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Container/ContainerUIHostingController.swift
@@ -59,7 +59,6 @@ class ContainerUIHostingController: UIHostingController<ContainerUIHostingContro
                     // Apply a delay here to allow the previous orientation change to finish,
                     // then reset orientations
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-
                         let rotateOrientation: UIInterfaceOrientation = orientation == .portrait ?
                             .portrait : (orientation == .landscapeLeft ? .landscapeLeft : .landscapeRight)
                         UIDevice.current.rotateTo(oritation: rotateOrientation)
@@ -83,9 +82,7 @@ class ContainerUIHostingController: UIHostingController<ContainerUIHostingContro
         UIApplication.shared.isIdleTimerDisabled = false
         UIDevice.current.toggleProximityMonitoringStatus(isEnabled: false)
 
-        if (environmentProperties.supportedOrientations == .all
-            || environmentProperties.supportedOrientations == .allButUpsideDown)
-            && !UIDevice.current.isGeneratingDeviceOrientationNotifications {
+        if !UIDevice.current.isGeneratingDeviceOrientationNotifications {
             UIDevice.current.beginGeneratingDeviceOrientationNotifications()
         }
     }


### PR DESCRIPTION
## Purpose
Resume orientation notification when a user leave setup screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Run the app, rotate device a few times, then rotate back
* go to set up screen
* rotate device a few times
* navigate back to setup screen
* proceed to **What to Check** section
```

## What to Check
Verify that the following are valid
* Check the screen is able to switch orientation in demo screen, when a user lands back on demo screen (from calling or from setup screen
* Check the camera scene orientation is not changed in setup screen, when device is rotated.

## Other Information
<!-- Add any other helpful information that may be needed here. -->