### PR TITLE
[Bugfix] Make app remember audio option (if available) from the previous call.

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/Manager/AudioSessionManager.swift
@@ -14,16 +14,28 @@ class AppAudioSessionManager: AudioSessionManager {
     private let logger: Logger
     private let store: Store<AppState>
     var cancellables = Set<AnyCancellable>()
+    var isSpeakerphoneOn: Bool = false
 
     init(store: Store<AppState>,
          logger: Logger) {
         self.store = store
         self.logger = logger
+        initializeAudioDeviceState()
         self.setupAudioSession()
         store.$state
             .sink { [weak self] state in
                 self?.receive(state: state)
             }.store(in: &cancellables)
+
+    }
+
+    private func initializeAudioDeviceState() {
+        isSpeakerphoneOn = getCurrentAudioDevice() == .speaker
+        if isSpeakerphoneOn {
+             store.dispatch(action: LocalUserAction.AudioDeviceChangeSucceeded(device: .speaker))
+        } else {
+             store.dispatch(action: LocalUserAction.AudioDeviceChangeSucceeded(device: .receiver))
+        }
     }
 
     private func receive(state: AppState) {
@@ -50,6 +62,7 @@ class AppAudioSessionManager: AudioSessionManager {
                                                            .interruptSpokenAudioAndMixWithOthers,
                                                            .allowBluetoothA2DP]
             try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: options)
+            try audioSession.overrideOutputAudioPort(isSpeakerphoneOn ? .speaker : .none)
             try audioSession.setActive(true)
         } catch let error {
             logger.error("Failed to set audio session category:\(error.localizedDescription)")
@@ -84,10 +97,12 @@ class AppAudioSessionManager: AudioSessionManager {
         do {
             try audioSession.setActive(true)
             try audioSession.overrideOutputAudioPort(audioPort)
+            isSpeakerphoneOn = audioPort == .speaker
             store.dispatch(action: LocalUserAction.AudioDeviceChangeSucceeded(device: selectedAudioDevice))
         } catch let error {
             logger.error("Failed to select audio device, reason:\(error.localizedDescription)")
             store.dispatch(action: LocalUserAction.AudioDeviceChangeFailed(error: error))
+            isSpeakerphoneOn = false
         }
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/Manager/AudioSessionManager.swift
@@ -26,7 +26,6 @@ class AppAudioSessionManager: AudioSessionManager {
             .sink { [weak self] state in
                 self?.receive(state: state)
             }.store(in: &cancellables)
-
     }
 
     private func receive(state: AppState) {


### PR DESCRIPTION
## Purpose
Make app remember audio option (if available) from the previous call. The OS currently default the audio option to **speaker** if there is no previous call. 

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Launch the app, fill the call info
* go to setup screen, 
* check the audio option
* join the call, (try changing the audio option)
* and then leave it call,
* rejoin the call
* check audio option in setup screen
```
```

## What to Check
Verify that the following are valid
* check the audio option in setup screen is set to the option from the previously established call. 

## Other Information
<!-- Add any other helpful information that may be needed here. -->