### PR TITLE
[Refactor] Clean up unused property in ErrorAction

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Action/CallingAction.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Action/CallingAction.swift
@@ -34,12 +34,10 @@ struct ParticipantListUpdated: Action {
 struct ErrorAction: Action {
     struct FatalErrorUpdated: Action {
         let error: ErrorEvent
-        let errorCode: String
     }
 
     struct CallStateErrorUpdated: Action {
         let error: ErrorEvent
-        let errorCode: String
     }
 }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareErrorHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareErrorHandler.swift
@@ -6,8 +6,7 @@ extension CallingMiddlewareHandler {
     func handle(error: Error, errorCode: String, dispatch: @escaping ActionDispatch) {
         let compositeError = ErrorEvent(code: errorCode, error: error)
 
-        let action = ErrorAction.FatalErrorUpdated(error: compositeError,
-                                                   errorCode: errorCode)
+        let action = ErrorAction.FatalErrorUpdated(error: compositeError)
         dispatch(action)
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -259,9 +259,9 @@ extension CallingMiddlewareHandler {
                     let action: Action
                     let error = ErrorEvent(code: errorCode, error: nil)
                     if errorCode == CallCompositeErrorCode.tokenExpired {
-                        action = ErrorAction.FatalErrorUpdated(error: error, errorCode: errorCode)
+                        action = ErrorAction.FatalErrorUpdated(error: error)
                     } else {
-                        action = ErrorAction.CallStateErrorUpdated(error: error, errorCode: errorCode)
+                        action = ErrorAction.CallStateErrorUpdated(error: error)
                     }
 
                     dispatch(action)

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/ErrorReducer.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/ErrorReducer.swift
@@ -18,11 +18,11 @@ struct ErrorReducer: Reducer {
         switch action {
         case let action as ErrorAction.FatalErrorUpdated:
             error = action.error
-            errorCode = action.errorCode
+            errorCode = action.error.code
             errorCategory = .fatal
         case let action as ErrorAction.CallStateErrorUpdated:
             error = action.error
-            errorCode = action.errorCode
+            errorCode = action.error.code
             errorCategory = .callState
         default:
             return state

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -79,7 +79,6 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
         for participant in remoteParticipants {
             if let userIdentifier = participant.identifier.stringValue {
                 self.remoteParticipants.removeValue(forKey: userIdentifier)?.delegate = nil
-
             }
         }
         removeRemoteParticipantsInfoModel(remoteParticipants)

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/ErrorReducerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/ErrorReducerTests.swift
@@ -13,8 +13,7 @@ class ErrorReducerTests: XCTestCase {
     func test_handleErrorReducer_reduce_when_notErrorState_then_return() {
         let state = StateMocking()
         let action = ErrorAction.FatalErrorUpdated(error: ErrorEvent(code: "",
-                                                                     error: nil),
-                                                   errorCode: "")
+                                                                     error: nil))
         let sut = getSUT()
 
         let resultState = sut.reduce(state, action)
@@ -25,8 +24,7 @@ class ErrorReducerTests: XCTestCase {
         let state = ErrorState(error: nil, errorCode: CallCompositeErrorCode.callJoin, errorCategory: .callState)
         let error = ErrorEvent(code: CallCompositeErrorCode.callJoin, error: nil)
 
-        let action = ErrorAction.FatalErrorUpdated(error: error,
-                                                   errorCode: CallCompositeErrorCode.callJoin)
+        let action = ErrorAction.FatalErrorUpdated(error: error)
         let sut = getSUT()
 
         let resultState = sut.reduce(state, action)


### PR DESCRIPTION
## Purpose
ErrorAction had an unused property for the code. The code is already in the error event. 
 
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
