### PR TITLE
[Refactor] Update cameraStatus after triggering camera preview 

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -41,17 +41,18 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
                 guard let self = self else {
                     return
                 }
-
                 switch completion {
                 case .failure(let error):
                     self.handle(error: error, errorCode: CallCompositeErrorCode.callJoin, dispatch: dispatch)
                 case .finished:
-                    if state.permissionState.cameraPermission == .granted,
-                       state.localUserState.cameraState.operation == .off {
-                        dispatch(LocalUserAction.CameraPreviewOnTriggered())
-                    }
+                    break
                 }
-            }, receiveValue: { _ in })
+            }, receiveValue: {
+                if state.permissionState.cameraPermission == .granted,
+                   state.localUserState.cameraState.operation == .off {
+                    dispatch(LocalUserAction.CameraPreviewOnTriggered())
+                }
+            })
             .store(in: cancelBag)
     }
 
@@ -227,7 +228,8 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
     }
 
     func onCameraPermissionIsSet(state: ReduxState?, dispatch: @escaping ActionDispatch) {
-        if let state = state as? AppState {
+        if let state = state as? AppState,
+           state.permissionState.cameraPermission == .requesting {
             switch state.localUserState.cameraState.transmission {
             case .local:
                 dispatch(LocalUserAction.CameraPreviewOnTriggered())

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/LocalUserReducer.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/LocalUserReducer.swift
@@ -21,6 +21,7 @@ struct LocalUserReducer: Reducer {
         switch action {
         case _ as LocalUserAction.CameraPreviewOnTriggered:
             cameraTransmissionStatus = .local
+            cameraStatus = .pending
         case _ as LocalUserAction.CameraOnTriggered:
             cameraTransmissionStatus = .remote
             cameraStatus = .pending

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
@@ -414,6 +414,33 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                                                                  cameraDeviceStatus: .front),
                                                  dispatch: dispatch)
     }
+
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionLocal_cameraPermissionRequesting_then_updateCameraPreviewOnTriggered() {
+        func dispatch(action: Action) {
+            XCTAssertTrue(action is LocalUserAction.CameraPreviewOnTriggered)
+        }
+        callingMiddlewareHandler.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
+                                                                         cameraTransmissionStatus: .local),
+                                                 dispatch: dispatch)
+    }
+
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionRequesting_then_updateCameraOnTriggered() {
+        func dispatch(action: Action) {
+            XCTAssertTrue(action is LocalUserAction.CameraOnTriggered)
+        }
+        callingMiddlewareHandler.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
+                                                                         cameraTransmissionStatus: .remote),
+                                                 dispatch: dispatch)
+    }
+
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionNotRequesting_then_updateCameraOnTriggered() {
+        func dispatch(action: Action) {
+            XCTFail()
+        }
+        callingMiddlewareHandler.onCameraPermissionIsSet(state: getState(cameraPermission: .granted,
+                                                                         cameraTransmissionStatus: .remote),
+                                                 dispatch: dispatch)
+    }
 }
 
 extension CallingMiddlewareHandlerTests {
@@ -422,14 +449,15 @@ extension CallingMiddlewareHandlerTests {
         return AppState()
     }
 
-    private func getState(callingState: CallingStatus,
-                          cameraStatus: LocalUserState.CameraOperationalStatus,
-                          cameraDeviceStatus: LocalUserState.CameraDeviceSelectionStatus,
-                          cameraPermission: AppPermission.Status = .unknown) -> ReduxState {
+    private func getState(callingState: CallingStatus = .none,
+                          cameraStatus: LocalUserState.CameraOperationalStatus = .on,
+                          cameraDeviceStatus: LocalUserState.CameraDeviceSelectionStatus = .front,
+                          cameraPermission: AppPermission.Status = .unknown,
+                          cameraTransmissionStatus: LocalUserState.CameraTransmissionStatus = .local) -> ReduxState {
         let callState = CallingState(status: callingState)
         let cameraState = LocalUserState.CameraState(operation: cameraStatus,
                                                      device: cameraDeviceStatus,
-                                                     transmission: .local)
+                                                     transmission: cameraTransmissionStatus)
         let audioState = LocalUserState.AudioState(operation: .off,
                                                    device: .receiverSelected)
         let localState = LocalUserState(cameraState: cameraState,

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/LocalUserReducerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/LocalUserReducerTests.swift
@@ -167,6 +167,41 @@ class LocalUserReducerTests: XCTestCase {
         XCTAssertEqual(resultState.audioState.device, expectedAudioDeviceStatus)
     }
 
+    func test_localUserReducer_reduce_when_localUserActionCameraPreviewOnTriggered_then_cameraTransmissionStatusIsLocal_cameraStatusIsPending() {
+        let state = LocalUserState()
+        let expectedCameraTransmissionStatus = LocalUserState.CameraTransmissionStatus.local
+        let expectedCameraStatus = LocalUserState.CameraOperationalStatus.pending
+        let action = LocalUserAction.CameraPreviewOnTriggered()
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action) as! LocalUserState
+
+        XCTAssertEqual(resultState.cameraState.transmission, expectedCameraTransmissionStatus)
+        XCTAssertEqual(resultState.cameraState.operation, expectedCameraStatus)
+
+    }
+
+    func test_localUserReducer_reduce_when_localUserActionCameraOnTriggered_then_cameraTransmissionStatusIsRemote_cameraStatusIsPending() {
+        let state = LocalUserState()
+        let expectedCameraTransmissionStatus = LocalUserState.CameraTransmissionStatus.remote
+        let expectedCameraStatus = LocalUserState.CameraOperationalStatus.pending
+        let action = LocalUserAction.CameraOnTriggered()
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action) as! LocalUserState
+
+        XCTAssertEqual(resultState.cameraState.transmission, expectedCameraTransmissionStatus)
+        XCTAssertEqual(resultState.cameraState.operation, expectedCameraStatus)
+    }
+
+    func test_localUserReducer_reduce_when_localUserActionCameraOffTriggered_then_cameraStatusIsPending() {
+        let state = LocalUserState()
+        let expectedCameraStatus = LocalUserState.CameraOperationalStatus.pending
+        let action = LocalUserAction.CameraOffTriggered()
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action) as! LocalUserState
+
+        XCTAssertEqual(resultState.cameraState.operation, expectedCameraStatus)
+    }
+
     func test_localUserReducer_reduce_when_mockingAction_then_stateNotUpdate() {
         let expectedVideoId = "expected"
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Bug: the local camera preview in setup view failed to open if the `localUserState.cameraState.operation` is updated to `.pending`
* The causes of the bug are:
1.  whenever the camera permission status is updated to `.granted` (when the composite is initialized in this bug scenario), we dispatch `CameraPreviewOnTriggered` action. 
2. However, this action is dispatched before `deviceManager` created inside `CallingSDK`. So this action is always failed and useless. 
3. The actual action open the setup view's camera preview is another `CameraPreviewOnTriggered` action triggered after `setupCall`, but we only send this action when the `cameraState.operation` is `off` which indicates there is no pending action in opening the local camera. 
  
* The fix is:

1. When camera permission status update to `.granted`, we check the current `cameraPermission`, only when the status is `requesting` which indicates that the `.granted` permission is newly requested from users ( like users first time tap the camera button, the app would ask camera permission and change status to `requesting`), we would dispatch `CameraPreviewOnTriggered` action. Otherwise, it just updates permission status without any following actions. 
2. Update `cameraState.operation` to `.pending` when the action `CameraPreviewOnTriggered` is received inside Redux
3. Move the logic of sending `CameraPreviewOnTriggered` inside `setupCall` completion closure to receiveValue closure. The reason is the completion closure is used to indicated the subscription is finished, and it doesn't comes with any values. Because the `setupCall` function return `Void` value, the composite would behave same no matter putting codes in completion or receiveValue closure. But by taking the [reference from Apple](https://developer.apple.com/documentation/combine/using-combine-for-your-app-s-asynchronous-code), receiveValue closure is the right place to put the follow up action. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1. Test local camera preview on setup view
2. Test ask camera permission on setup/calling view