### PR TITLE
[BugFix] Handle edge case for empty display name

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		5A31497E0DEBAB0256AD0B91 /* ErrorMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3146B0B684264EB57EDA69 /* ErrorMocking.swift */; };
 		5A314D26A09E235A6509C1C7 /* ACSCameraFacingExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A31447C18BC49B691800C9D /* ACSCameraFacingExtension.swift */; };
 		5A314F66ED6C53A7EFC6EDA3 /* LobbyOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3148DD49F9B22A8E1C3D3F /* LobbyOverlayView.swift */; };
+		883D12DA2784F0B1005021E2 /* StringConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883D12D92784F0B1005021E2 /* StringConstants.swift */; };
 		88701EB42742D54C00660EAB /* ErrorReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88701EB32742D54C00660EAB /* ErrorReducerTests.swift */; };
 		88701EB8274C29C600660EAB /* CallingMiddlewareErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88701EB7274C29C600660EAB /* CallingMiddlewareErrorHandler.swift */; };
 		88A70180270E50D100F817B8 /* PopupModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A7017F270E50D100F817B8 /* PopupModalView.swift */; };
@@ -324,6 +325,7 @@
 		5A314F041B5D1869C41C242E /* DependencyContainerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyContainerTests.swift; sourceTree = "<group>"; };
 		5A314F62143032D2313CB616 /* GroupCallOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupCallOptionsTests.swift; sourceTree = "<group>"; };
 		5CFD410F47A7F36849928867 /* Pods-AzureCommunicationUI-AzureCommunicationUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationUI-AzureCommunicationUITests.release.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationUI-AzureCommunicationUITests/Pods-AzureCommunicationUI-AzureCommunicationUITests.release.xcconfig"; sourceTree = "<group>"; };
+		883D12D92784F0B1005021E2 /* StringConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringConstants.swift; sourceTree = "<group>"; };
 		88701EB32742D54C00660EAB /* ErrorReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReducerTests.swift; sourceTree = "<group>"; };
 		88701EB7274C29C600660EAB /* CallingMiddlewareErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingMiddlewareErrorHandler.swift; sourceTree = "<group>"; };
 		88A7017F270E50D100F817B8 /* PopupModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupModalView.swift; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 				1FE1BE7E26FE38C9000A8D18 /* CompositeError.swift */,
 				1B70D52727191073007CC933 /* DeviceExtension.swift */,
 				1B79BD4F273F2D87002D5A36 /* UIViewControllerExtension.swift */,
+				883D12D92784F0B1005021E2 /* StringConstants.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1439,6 +1442,7 @@
 				985DF378269E07F400CFDA55 /* PrimaryButtonViewModel.swift in Sources */,
 				1FC30846266949E8007EC537 /* ColorExtension.swift in Sources */,
 				1F6470AC2639FE670008B9E9 /* CancelBag.swift in Sources */,
+				883D12DA2784F0B1005021E2 /* StringConstants.swift in Sources */,
 				1F4B0F0526A6469F00E87014 /* RemoteParticipantsEventsAdapter.swift in Sources */,
 				1F11D2B2263CA10000D33838 /* CommunicationIdentifierExtension.swift in Sources */,
 				1F4B0F0126A2025900E87014 /* ParticipantGridLayoutView.swift in Sources */,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -8,6 +8,7 @@ import FluentUI
 
 class CompositeParticipantsListCell: TableViewCell {
     func setup(displayName: String, isMuted: Bool, accessoryType: TableViewCellAccessoryType = .none) {
+        let isNameEmpty = displayName.trimmingCharacters(in: .whitespaces).isEmpty
         let avatar = MSFAvatar(style: .accent, size: .medium)
         avatar.state.primaryText = displayName
         let avatarView = avatar.view
@@ -23,7 +24,11 @@ class CompositeParticipantsListCell: TableViewCell {
             ? StyleProvider.color.popoverColor
             : StyleProvider.color.drawerColor
 
-        setup(title: displayName,
+        if isNameEmpty {
+            setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.mute))
+        }
+
+        setup(title: isNameEmpty ? "Unnamed Participant" : displayName,
               customView: avatarView,
               customAccessoryView: micImageView)
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -27,7 +27,7 @@ class CompositeParticipantsListCell: TableViewCell {
         if isNameEmpty {
             setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.mute))
         } else {
-            setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.onWarning))
+            setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.onSurface))
         }
 
         setup(title: isNameEmpty ? StringConstants.defaultEmptyName : displayName,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -26,6 +26,8 @@ class CompositeParticipantsListCell: TableViewCell {
 
         if isNameEmpty {
             setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.mute))
+        } else {
+            setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.onWarning))
         }
 
         setup(title: isNameEmpty ? "Unnamed Participant" : displayName,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -30,7 +30,7 @@ class CompositeParticipantsListCell: TableViewCell {
             setTitleLabelTextColor(color: UIColor.compositeColor(CompositeColor.onWarning))
         }
 
-        setup(title: isNameEmpty ? "Unnamed Participant" : displayName,
+        setup(title: isNameEmpty ? StringConstants.defaultEmptyName : displayName,
               customView: avatarView,
               customAccessoryView: micImageView)
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -9,16 +9,12 @@ class ParticipantsListCellViewModel {
     let displayName: String
     let isMuted: Bool
 
-    struct Constants {
-        static let localParticipantNamePostfix: String = "(You)"
-    }
-
     init(localUserState: LocalUserState) {
         if let displayName = localUserState.displayName,
            !displayName.trimmingCharacters(in: .whitespaces).isEmpty {
-            self.displayName = "\(displayName) \(Constants.localParticipantNamePostfix)"
+            self.displayName = "\(displayName) \(StringConstants.localParticipantNamePostfix)"
         } else {
-            self.displayName = "\(Constants.localParticipantNamePostfix)"
+            self.displayName = "\(StringConstants.localParticipantNamePostfix)"
         }
 
         self.isMuted = localUserState.audioState.operation != .on

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -14,7 +14,8 @@ class ParticipantsListCellViewModel {
     }
 
     init(localUserState: LocalUserState) {
-        if let displayName = localUserState.displayName {
+        if let displayName = localUserState.displayName,
+           !displayName.trimmingCharacters(in: .whitespaces).isEmpty {
             self.displayName = "\(displayName) \(Constants.localParticipantNamePostfix)"
         } else {
             self.displayName = "\(Constants.localParticipantNamePostfix)"

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -10,9 +10,11 @@ class ParticipantsListViewModel: ObservableObject {
 
     @Published var participantsList: [ParticipantsListCellViewModel] = []
     @Published var localParticipantsListCellViewModel: ParticipantsListCellViewModel
-
-    let defaultEmptyName: String = "Unnamed Participant"
     var lastUpdateTimeStamp = Date()
+
+    struct Constants {
+        static let defaultEmptyName: String = "Unnamed Participant"
+    }
 
     init(localUserState: LocalUserState) {
         localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState)
@@ -37,9 +39,9 @@ class ParticipantsListViewModel: ObservableObject {
         // alphabetical order
         return ([localParticipantsListCellViewModel] + participantsList).sorted {
             let name = $0.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                defaultEmptyName : $0.displayName
+                Constants.defaultEmptyName : $0.displayName
             let nextName = $1.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                defaultEmptyName : $1.displayName
+                Constants.defaultEmptyName : $1.displayName
             return name.localizedCaseInsensitiveCompare(nextName) == .orderedAscending
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -12,10 +12,6 @@ class ParticipantsListViewModel: ObservableObject {
     @Published var localParticipantsListCellViewModel: ParticipantsListCellViewModel
     var lastUpdateTimeStamp = Date()
 
-    struct Constants {
-        static let defaultEmptyName: String = "Unnamed Participant"
-    }
-
     init(localUserState: LocalUserState) {
         localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState)
     }
@@ -39,9 +35,9 @@ class ParticipantsListViewModel: ObservableObject {
         // alphabetical order
         return ([localParticipantsListCellViewModel] + participantsList).sorted {
             let name = $0.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                Constants.defaultEmptyName : $0.displayName
+                StringConstants.defaultEmptyName : $0.displayName
             let nextName = $1.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                Constants.defaultEmptyName : $1.displayName
+                StringConstants.defaultEmptyName : $1.displayName
             return name.localizedCaseInsensitiveCompare(nextName) == .orderedAscending
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -35,7 +35,11 @@ class ParticipantsListViewModel: ObservableObject {
     func sortedParticipants() -> [ParticipantsListCellViewModel] {
         // alphabetical order
         return ([localParticipantsListCellViewModel] + participantsList).sorted {
-            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            let name = $0.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
+                "Unnamed Participant" : $0.displayName
+            let nextName = $1.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
+                "Unnamed Participant" : $1.displayName
+            return name.localizedCaseInsensitiveCompare(nextName) == .orderedAscending
         }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -11,6 +11,7 @@ class ParticipantsListViewModel: ObservableObject {
     @Published var participantsList: [ParticipantsListCellViewModel] = []
     @Published var localParticipantsListCellViewModel: ParticipantsListCellViewModel
 
+    let defaultEmptyName: String = "Unnamed Participant"
     var lastUpdateTimeStamp = Date()
 
     init(localUserState: LocalUserState) {
@@ -36,9 +37,9 @@ class ParticipantsListViewModel: ObservableObject {
         // alphabetical order
         return ([localParticipantsListCellViewModel] + participantsList).sorted {
             let name = $0.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                "Unnamed Participant" : $0.displayName
+                defaultEmptyName : $0.displayName
             let nextName = $1.displayName.trimmingCharacters(in: .whitespaces).isEmpty ?
-                "Unnamed Participant" : $1.displayName
+                defaultEmptyName : $1.displayName
             return name.localizedCaseInsensitiveCompare(nextName) == .orderedAscending
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -84,7 +84,8 @@ struct ParticipantTitleView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: hSpace, content: {
-            if let displayName = displayName {
+            if let displayName = displayName,
+               !displayName.trimmingCharacters(in: .whitespaces).isEmpty {
                 Text(displayName)
                     .font(titleFont)
                     .lineLimit(1)

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+struct StringConstants {
+    static let defaultEmptyName: String = "Unnamed Participant"
+    static let localParticipantNamePostfix: String = "(You)"
+}


### PR DESCRIPTION
## Purpose
As per discussion, adding in new logic to handle if a participant has an empty display name. 
<img width="502" alt="Screen Shot 2021-12-22 at 3 40 21 PM" src="https://user-images.githubusercontent.com/9044372/147153140-423767c5-9063-43d4-a550-dbe8c4f1625a.png">
<img width="502" alt="Screen Shot 2021-12-22 at 3 40 38 PM" src="https://user-images.githubusercontent.com/9044372/147153141-d5e61238-0b58-4b07-aefc-52a81c590ce3.png">
<img width="502" alt="Screen Shot 2021-12-22 at 3 41 58 PM" src="https://user-images.githubusercontent.com/9044372/147153144-1ff8910d-d20f-4b87-9a27-05e3e10bc706.png">

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
User A sets display name to ""
User B can have any display name 
Join a call together 

## What to Check
Verify that the following are valid
Participants list displays an "Unnamed Participant" 
Participant is still in alphabetical order
Participant in the grid without a name should not display an empty grey square. 
