### PR TITLE
[Refactor] Bundle Short Version String Update

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
@@ -1654,7 +1654,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-alpha.2";
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.ios.communication.ui.meetings.AzureCommunicationUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1684,7 +1684,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = "1.0.0-alpha.2";
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.azure.ios.communication.ui.meetings.AzureCommunicationUI;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
@@ -9,7 +9,7 @@ struct DiagnosticConfig {
     var tags = [String]()
     private let callCompositeTagPrefix: String = "aci110"
     private var callCompositeTag: String {
-        let version = Bundle(for: CallComposite.self).infoDictionary?["CompositeSemVersion"]
+        let version = Bundle(for: CallComposite.self).infoDictionary?["UILibrarySemVersion"]
         let versionStr = version as? String ?? "unknown"
         return "\(callCompositeTagPrefix)/\(versionStr)"
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
@@ -8,9 +8,10 @@ import Foundation
 struct DiagnosticConfig {
     var tags = [String]()
     private let callCompositeTagPrefix: String = "aci110"
-    private let semVersionString: String = "1.0.0-alpha.2"
     private var callCompositeTag: String {
-        return "\(callCompositeTagPrefix)/\(semVersionString)"
+        let version = Bundle(for: CallComposite.self).infoDictionary?["CompositeSemVersion"]
+        let versionStr = version as? String ?? "unknown"
+        return "\(callCompositeTagPrefix)/\(versionStr)"
     }
 
     init() {

--- a/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/DiagnosticConfig.swift
@@ -8,11 +8,9 @@ import Foundation
 struct DiagnosticConfig {
     var tags = [String]()
     private let callCompositeTagPrefix: String = "aci110"
+    private let semVersionString: String = "1.0.0-alpha.2"
     private var callCompositeTag: String {
-        let version = Bundle(for: CallComposite.self).infoDictionary?["CFBundleShortVersionString"]
-        let versionStr = version as? String ?? "unknown"
-
-        return "\(callCompositeTagPrefix)/\(versionStr)"
+        return "\(callCompositeTagPrefix)/\(semVersionString)"
     }
 
     init() {

--- a/AzureCommunicationUI/AzureCommunicationUI/Info.plist
+++ b/AzureCommunicationUI/AzureCommunicationUI/Info.plist
@@ -22,7 +22,7 @@
 	<string>RequireCamera</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This is required for calling.</string>
-	<key>CompositeSemVersion</key>
+	<key>UILibrarySemVersion</key>
 	<string>1.0.0-alpha.2</string>
 </dict>
 </plist>

--- a/AzureCommunicationUI/AzureCommunicationUI/Info.plist
+++ b/AzureCommunicationUI/AzureCommunicationUI/Info.plist
@@ -22,5 +22,7 @@
 	<string>RequireCamera</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This is required for calling.</string>
+	<key>CompositeSemVersion</key>
+	<string>1.0.0-alpha.2</string>
 </dict>
 </plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
 ### Breaking Changes
 
 ### Bug Fixes
-- Fix the order of CompositeError throwing in joining a call.
-- Fix for info header doesn't disappear when bottom drawer is displayed.
-- Fix for the local video rotation in setup view when device orientation is locked.
-- Fix the display of the participant with an empty name in the participant list. 
-- Fix the default audio selection when the UI Composite is launched. 
+- Fix the order of CompositeError throwing in joining a call. [#11](https://github.com/Azure/communication-ui-library-ios/pull/11)
+- Fix for info header doesn't disappear when bottom drawer is displayed. [#12](https://github.com/Azure/communication-ui-library-ios/pull/12)
+- Fix for the local video rotation in setup view when device orientation is locked. [#13](https://github.com/Azure/communication-ui-library-ios/pull/13)
+- Fix the display of the participant with an empty name in the participant list. [#24](https://github.com/Azure/communication-ui-library-ios/pull/24)
+- Fix the default audio selection when the UI Composite is launched. [#21](https://github.com/Azure/communication-ui-library-ios/pull/21)
+
+### Project improvements
+- Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)
+- Code cleanup and refactoring.
+
 
 ## 1.0.0-beta.1 (2021-12-09)
 This is the initial release of Azure Communication UI Library. For more information, please see the [README](README.md) and [QuickStart](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/ui-library/get-started-call?tabs=kotlin&pivots=platform-ios).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Project improvements
 - Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)
+- Remove alphabet in CFBundleShortVersionString. [#27](https://github.com/Azure/communication-ui-library-ios/pull/27)
 - Code cleanup and refactoring.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Project improvements
 - Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)
-- Remove alphabet in CFBundleShortVersionString. [#27](https://github.com/Azure/communication-ui-library-ios/pull/27)
+- Remove alphabet in CFBundleShortVersionString and add CompositeSemVersion inside info.plist. [#27](https://github.com/Azure/communication-ui-library-ios/pull/27)
 - Code cleanup and refactoring.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
 ### Breaking Changes
 
 ### Bug Fixes
-- Fix the order of CompositeError throwing in joining a call
-- Fix for info header doesn't disappear when bottom drawer is displayed
-- Fix for the local video rotation in setup view when device orientation is locked
-- Fix the display of the participant with empty name in the participant list. 
+- Fix the order of CompositeError throwing in joining a call.
+- Fix for info header doesn't disappear when bottom drawer is displayed.
+- Fix for the local video rotation in setup view when device orientation is locked.
+- Fix the display of the participant with an empty name in the participant list. 
 - Fix the default audio selection when the UI Composite is launched. 
 
 ## 1.0.0-beta.1 (2021-12-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix the display of the participant with an empty name in the participant list. [#24](https://github.com/Azure/communication-ui-library-ios/pull/24)
 - Fix the default audio selection when the UI Composite is launched. [#21](https://github.com/Azure/communication-ui-library-ios/pull/21)
 
-### Project improvements
+### Other Changes
 - Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)
 - Code cleanup and refactoring.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 ### Breaking Changes
 
 ### Bug Fixes
-- Updating logic to check against the error first before checking the call object
+- Fix the order of CompositeError throwing in joining a call
+- Fix for info header doesn't disappear when bottom drawer is displayed
+- Fix for the local video rotation in setup view when device orientation is locked
+- Fix the display of the participant with empty name in the participant list. 
+- Fix the default audio selection when the UI Composite is launched. 
 
 ## 1.0.0-beta.1 (2021-12-09)
 This is the initial release of Azure Communication UI Library. For more information, please see the [README](README.md) and [QuickStart](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/ui-library/get-started-call?tabs=kotlin&pivots=platform-ios).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Other Changes
 - Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)
-- Remove alphabet in CFBundleShortVersionString and add CompositeSemVersion inside info.plist. [#27](https://github.com/Azure/communication-ui-library-ios/pull/27)
+- Remove alphabet in CFBundleShortVersionString and add UILibrarySemVersion inside info.plist. [#27](https://github.com/Azure/communication-ui-library-ios/pull/27)
 - Code cleanup and refactoring.
 
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove alphabet in CFBundleShortVersionString
* Use a static version string including alphabet when sending the tags to Telemetry

Based on the Apple [requirement](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring), only `numeric characters (0-9) and periods` are allowed in CFBundleShortVersionString. `Cocoapods` would trim the CFBundleShortVersionString to make it only contains number when customers install our Library. However, the `DiagnosticConfig.swift` which is reading CFBundleShortVersionString would not be accurate when the library is installed through Cocoapods and the version got trimmed. So we have to use a static version string (like [CallingSDK](https://skype.visualstudio.com/SCC/_git/client_calling_spool-native?path=%2FlibShared%2Fsrc%2FPAL.cpp&version=GBmaster&_a=contents)) when sending the versioning to Telemetry, and not dynamically rely on reading CFBundleShortVersionString.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
