### PR TITLE
[BugFix] Clean up the states and participants on calling view launched 

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/AppStateReducer.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/AppStateReducer.swift
@@ -67,6 +67,8 @@ struct AppStateReducer: Reducer {
         switch action {
         case let action as ParticipantListUpdated:
             remoteParticipantState = RemoteParticipantsState(participantInfoList: action.participantsInfoList)
+        case _ as CallingViewLaunched:
+            remoteParticipantState = RemoteParticipantsState(participantInfoList: [])
         default:
             break
         }

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/CallingReducer.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/CallingReducer.swift
@@ -21,6 +21,10 @@ struct CallingReducer: Reducer {
             isRecordingActive = action.isRecordingActive
         case let action as CallingAction.TranscriptionStateUpdated:
             isTranscriptionActive = action.isTranscriptionActive
+        case _ as CallingViewLaunched:
+            coreStatus = .none
+            isRecordingActive = false
+            isTranscriptionActive = false
         default:
             return state
         }

--- a/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/ErrorReducer.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Redux/Reducer/ErrorReducer.swift
@@ -24,6 +24,10 @@ struct ErrorReducer: Reducer {
             error = action.error
             errorCode = action.error.code
             errorCategory = .callState
+        case _ as CallingViewLaunched:
+            error = nil
+            errorCode = ""
+            errorCategory = .none
         default:
             return state
         }

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -11,7 +11,7 @@ protocol CallingSDKEventsHandling: CallDelegate {
     func assign(_ recordingCallFeature: RecordingCallFeature)
     func assign(_ transcriptionCallFeature: TranscriptionCallFeature)
     func resetSubjects()
-    
+
     var participantsInfoListSubject: CurrentValueSubject<[ParticipantInfoModel], Never> { get }
     var callInfoSubject: PassthroughSubject<CallInfoModel, Never> { get }
     var isRecordingActiveSubject: PassthroughSubject<Bool, Never> { get }

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -10,7 +10,8 @@ import AzureCommunicationCalling
 protocol CallingSDKEventsHandling: CallDelegate {
     func assign(_ recordingCallFeature: RecordingCallFeature)
     func assign(_ transcriptionCallFeature: TranscriptionCallFeature)
-
+    func resetSubjects()
+    
     var participantsInfoListSubject: CurrentValueSubject<[ParticipantInfoModel], Never> { get }
     var callInfoSubject: PassthroughSubject<CallInfoModel, Never> { get }
     var isRecordingActiveSubject: PassthroughSubject<Bool, Never> { get }
@@ -46,6 +47,10 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
     func assign(_ transcriptionCallFeature: TranscriptionCallFeature) {
         self.transcriptionCallFeature = transcriptionCallFeature
         transcriptionCallFeature.delegate = self
+    }
+
+    func resetSubjects() {
+        self.participantsInfoListSubject = .init([])
     }
 
     private func setupRemoteParticipantEventsAdapter() {

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -10,7 +10,7 @@ import AzureCommunicationCalling
 protocol CallingSDKEventsHandling: CallDelegate {
     func assign(_ recordingCallFeature: RecordingCallFeature)
     func assign(_ transcriptionCallFeature: TranscriptionCallFeature)
-    func resetSubjects()
+    func setupProperties()
 
     var participantsInfoListSubject: CurrentValueSubject<[ParticipantInfoModel], Never> { get }
     var callInfoSubject: PassthroughSubject<CallInfoModel, Never> { get }
@@ -49,8 +49,12 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
         transcriptionCallFeature.delegate = self
     }
 
-    func resetSubjects() {
-        self.participantsInfoListSubject = .init([])
+    func setupProperties() {
+        participantsInfoListSubject = .init([])
+        recordingCallFeature = nil
+        transcriptionCallFeature = nil
+        remoteParticipants = MappedSequence<String, RemoteParticipant>()
+        previousCallingStatus = .none
     }
 
     private func setupRemoteParticipantEventsAdapter() {

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
@@ -59,6 +59,8 @@ class ACSCallingSDKWrapper: NSObject, CallingSDKWrapper {
     }
 
     func startCall(isCameraPreferred: Bool, isAudioPreferred: Bool) -> AnyPublisher<Void, Error> {
+        logger.debug("Reset Subjects in callingEventsHandler")
+        callingEventsHandler.resetSubjects()
         self.logger.debug( "Starting call")
         return setupCallAgent()
             .flatMap { [weak self] _ -> AnyPublisher<Void, Error> in

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKWrapper.swift
@@ -60,7 +60,7 @@ class ACSCallingSDKWrapper: NSObject, CallingSDKWrapper {
 
     func startCall(isCameraPreferred: Bool, isAudioPreferred: Bool) -> AnyPublisher<Void, Error> {
         logger.debug("Reset Subjects in callingEventsHandler")
-        callingEventsHandler.resetSubjects()
+        callingEventsHandler.setupProperties()
         self.logger.debug( "Starting call")
         return setupCallAgent()
             .flatMap { [weak self] _ -> AnyPublisher<Void, Error> in

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/AppStateReducerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/AppStateReducerTests.swift
@@ -176,6 +176,28 @@ class AppStateReducerTests: XCTestCase {
         XCTAssertEqual(result.remoteParticipantsState.participantInfoList.count, 1)
         XCTAssertEqual(result.remoteParticipantsState.participantInfoList.first?.userIdentifier, userId)
     }
+
+    func test_appStateReducer_reduce_when_CallingViewLaunched_then_remoteParticipantStateCleanup() {
+        let userId = UUID().uuidString
+        let action = CallingViewLaunched()
+        let sut = getSUT()
+        let participant = ParticipantInfoModel(displayName: "displayname",
+                                               isSpeaking: false,
+                                               isMuted: true,
+                                               isRemoteUser: false,
+                                               userIdentifier: userId,
+                                               recentSpeakingStamp: Date(),
+                                               screenShareVideoStreamModel: nil,
+                                               cameraVideoStreamModel: nil)
+        let remoteParticipantsState = RemoteParticipantsState(participantInfoList: [participant])
+        let state = getAppState(remoteParticipantsState: remoteParticipantsState)
+        let result = sut.reduce(state, action)
+        guard let result = result as? AppState else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(result.remoteParticipantsState.participantInfoList.count, 0)
+    }
 }
 
 extension AppStateReducerTests {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/CallingReducerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/CallingReducerTests.swift
@@ -115,6 +115,24 @@ class CallingReducerTests: XCTestCase {
         }
         XCTAssertEqual(resultState, expectedState)
     }
+
+    func test_callingReducer_reduce_when_callingViewLaunched_then_cleanup() {
+        let expectedState = CallingState(status: .none,
+                                         isRecordingActive: false,
+                                         isTranscriptionActive: false)
+        let state = CallingState(status: .connected,
+                                 isRecordingActive: true,
+                                 isTranscriptionActive: true)
+        let action = CallingViewLaunched()
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        guard let resultState = resultState as? CallingState else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(resultState, expectedState)
+    }
 }
 
 extension CallingReducerTests {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/ErrorReducerTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Redux/Reducer/ErrorReducerTests.swift
@@ -36,6 +36,26 @@ class ErrorReducerTests: XCTestCase {
 
         XCTAssertEqual(errorState.errorCode, CallCompositeErrorCode.callJoin)
     }
+
+    func test_handleErrorReducer_reduce_when_callingViewLaunched_then_cleanup() {
+        let error = ErrorEvent(code: CallCompositeErrorCode.callJoin, error: nil)
+        let state = ErrorState(error: error, errorCode: CallCompositeErrorCode.callJoin, errorCategory: .callState)
+
+        let action = CallingViewLaunched()
+        let sut = getSUT()
+
+        let resultState = sut.reduce(state, action)
+        XCTAssertTrue(resultState is ErrorState)
+        guard let errorState = resultState as? ErrorState else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(errorState.error, nil)
+        XCTAssertEqual(errorState.errorCode, "")
+        XCTAssertEqual(errorState.errorCategory, .none)
+
+    }
 }
 
 extension ErrorReducerTests {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bug Fixes
+- Cleaning up Calling State and Call Error when joining or returning to a call from error. [#28](https://github.com/Azure/communication-ui-library-ios/pull/28)
 - Fix the order of CompositeError throwing in joining a call. [#11](https://github.com/Azure/communication-ui-library-ios/pull/11)
 - Fix for info header doesn't disappear when bottom drawer is displayed. [#12](https://github.com/Azure/communication-ui-library-ios/pull/12)
 - Fix for the local video rotation in setup view when device orientation is locked. [#13](https://github.com/Azure/communication-ui-library-ios/pull/13)


### PR DESCRIPTION
## Purpose
Clean up our error state and call states when we receive the calling view launched action. 
New function to reset `participantsInfoListSubject` in the sdk event handler
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
User A and User B join teams call
User A begins recording and transcription
User B loses internet and is kicked out into the set up view
User A stops the recording and transcription
User B turns on internet and rejoins call
Verify the banner is not showing in call
