### PR TITLE
[Bugfix] Corrected the screen orientation update when the screen should update orientation

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Container/ContainerUIHostingController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Container/ContainerUIHostingController.swift
@@ -55,12 +55,14 @@ class ContainerUIHostingController: UIHostingController<ContainerUIHostingContro
             .receive(on: RunLoop.main)
             .removeDuplicates()
             .sink(receiveValue: { orientation in
-                if orientation == .portrait || orientation == .landscape {
+                let portrait = orientation == .portrait
+                let landscape = orientation == .landscapeLeft || orientation == .landscapeRight
+                if  portrait || landscape {
                     // Apply a delay here to allow the previous orientation change to finish,
                     // then reset orientations
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                         let rotateOrientation: UIInterfaceOrientation = orientation == .portrait ?
-                            .portrait : (orientation == .landscapeLeft ? .landscapeLeft : .landscapeRight)
+                            .portrait : (orientation == .landscapeLeft ? .landscapeRight : .landscapeLeft)
                         UIDevice.current.rotateTo(oritation: rotateOrientation)
                         UIDevice.current.endGeneratingDeviceOrientationNotifications()
                     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/LockPhoneOrientation.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/LockPhoneOrientation.swift
@@ -18,7 +18,7 @@ struct LockPhoneOrientation: ViewModifier {
         case .iphonePortraitScreenSize:
             return .portrait
         case .iphoneLandscapeScreenSize:
-            return .landscape
+            return UIDevice.current.orientation == .landscapeLeft ? .landscapeRight : .landscapeLeft
         default:
             return SupportedOrientationsPreferenceKey.defaultValue
         }


### PR DESCRIPTION
## Purpose
This PR fixes the issue in the calling screen, such that tapping on a participant drawer would trigger an orientation change due to incorrect orientation mapping from the orientation update logic.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Launch the app, join a call (group or teams)
* In calling screen, switch device orientation to landscape (try landscape left and landscape right)
* Launch participant drawer or audio selection drawer 
* Follow **What to Check** section


## What to Check
Verify that the following are valid
* Make sure there is no further orientation switch when user launch participant drawer or audio selection drawer, during a call.

## Other Information
<!-- Add any other helpful information that may be needed here. -->