### PR TITLE
[Bug] participantsInfoListSubject clean up 

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -50,7 +50,7 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
     }
 
     func setupProperties() {
-        participantsInfoListSubject = .init([])
+        participantsInfoListSubject.value.removeAll()
         recordingCallFeature = nil
         transcriptionCallFeature = nil
         remoteParticipants = MappedSequence<String, RemoteParticipant>()


### PR DESCRIPTION
## Purpose
`participantsInfoListSubject` was being reinitialized when we really just wanted to clean up the values

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Join a call and make sure the `participantsInfoListSubject.send` fires off correctly
