### PR TITLE
[Bug] LocalVideoViewModelTest has unit test failure randomly

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/ViewComponents/LocalVideoViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/ViewComponents/LocalVideoViewModelTests.swift
@@ -45,7 +45,6 @@ class LocalVideoViewModelTests: XCTestCase {
     // MARK: Camera switch tests
     func test_localVideoVideModel_toggleCameraSwitch_when_cameraStatusOn_then_shouldRequestCameraOnTriggered() {
         let expectation = XCTestExpectation(description: "Dispatch the new action")
-        localVideoViewModel.toggleCameraSwitchTapped()
 
         storeFactory.store.$state
             .dropFirst(1)
@@ -53,6 +52,8 @@ class LocalVideoViewModelTests: XCTestCase {
                 XCTAssertTrue(self?.storeFactory.actions.first is LocalUserAction.CameraSwitchTriggered)
                 expectation.fulfill()
             }.store(in: cancellable)
+
+        localVideoViewModel.toggleCameraSwitchTapped()
         wait(for: [expectation], timeout: 1)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix for the local video rotation in setup view when device orientation is locked. [#13](https://github.com/Azure/communication-ui-library-ios/pull/13)
 - Fix the display of the participant with an empty name in the participant list. [#24](https://github.com/Azure/communication-ui-library-ios/pull/24)
 - Fix the default audio selection when the UI Composite is launched. [#21](https://github.com/Azure/communication-ui-library-ios/pull/21)
+- Fixing consistency of unit test. [#35](https://github.com/Azure/communication-ui-library-ios/pull/35)
 
 ### Other Changes
 - Update Redux State when initializing the local video preview in the setup view. [#23](https://github.com/Azure/communication-ui-library-ios/pull/23)


### PR DESCRIPTION
## Purpose
Seems like periodically a unit test `test_localVideoVideModel_toggleCameraSwitch_when_cameraStatusOn_then_shouldRequestCameraOnTriggered` will fail on the pipeline. Fixing the consistency by calling the tap function only after the store closure has been set. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
