### PR TITLE
[Bugfix] Fix the title view appearance for unnamed users

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -15,9 +15,6 @@ struct ParticipantGridCellVideoView: View {
     @Environment(\.screenSizeClass) var screenSizeClass: ScreenSizeClassType
 
     let borderColor = Color(StyleProvider.color.primaryColor)
-    var isTitleViewEmpty: Bool {
-        return !isMuted && displayName?.trimmingCharacters(in: .whitespaces).isEmpty == true
-    }
 
     var body: some View {
         ZStack(alignment: .bottomLeading) {
@@ -30,8 +27,7 @@ struct ParticipantGridCellVideoView: View {
                                  titleFont: Fonts.caption1.font,
                                  mutedIconSize: 14)
                 .padding(.vertical, 2)
-                .padding(.horizontal, 4)
-                .background(isTitleViewEmpty ? .clear : Color(StyleProvider.color.overlay))
+                .background(Color(StyleProvider.color.overlay))
                 .clipShape(RoundedRectangle(cornerRadius: 3))
                 .padding(.leading, 4)
                 .padding(.bottom, screenSizeClass == .iphoneLandscapeScreenSize

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -15,6 +15,9 @@ struct ParticipantGridCellVideoView: View {
     @Environment(\.screenSizeClass) var screenSizeClass: ScreenSizeClassType
 
     let borderColor = Color(StyleProvider.color.primaryColor)
+    var isTitleViewEmpty: Bool {
+        return !isMuted && displayName?.trimmingCharacters(in: .whitespaces).isEmpty == true
+    }
 
     var body: some View {
         ZStack(alignment: .bottomLeading) {
@@ -28,7 +31,7 @@ struct ParticipantGridCellVideoView: View {
                                  mutedIconSize: 14)
                 .padding(.vertical, 2)
                 .padding(.horizontal, 4)
-                .background(Color(StyleProvider.color.overlay))
+                .background(isTitleViewEmpty ? .clear : Color(StyleProvider.color.overlay))
                 .clipShape(RoundedRectangle(cornerRadius: 3))
                 .padding(.leading, 4)
                 .padding(.bottom, screenSizeClass == .iphoneLandscapeScreenSize

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -81,6 +81,9 @@ struct ParticipantTitleView: View {
     let titleFont: Font
     let mutedIconSize: CGFloat
     private let hSpace: CGFloat = 4
+    private var isEmpty: Bool {
+        return !isMuted && displayName?.trimmingCharacters(in: .whitespaces).isEmpty == true
+    }
 
     var body: some View {
         HStack(alignment: .center, spacing: hSpace, content: {
@@ -95,6 +98,7 @@ struct ParticipantTitleView: View {
                 Icon(name: .micOff, size: mutedIconSize)
             }
         })
+        .padding(.horizontal, isEmpty ? 0 : 4)
         .animation(.default)
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Changed the background color for the title view when a user's name is empty and a microphone isn't muted.
![Incorrect_background](https://user-images.githubusercontent.com/98852890/154385923-c543860b-f118-40bf-8e39-33795be279b0.PNG)
![No_background_shown](https://user-images.githubusercontent.com/98852890/154385931-f5977fb6-dfab-48fb-9432-41c8b647883e.PNG)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Connect to a meeting 
2. Connect to the same meeting on an another device without specifying your "Displya Name"
3. Unmute your microphone on the device from step 2
4. Check the title view on the device from the step 1
```

## What to Check
Verify that the following are valid
* a user's name and a mute status are shown correctly