### PR TITLE
[Bug] Fix the local pip view not showing the video stream

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 class CallingViewModel: ObservableObject {
     @Published var isLobbyOverlayDisplayed: Bool = false
     @Published var isConfirmLeaveOverlayDisplayed: Bool = false
-    @Published var isParticipantGridDisplayed: Bool = false
+    @Published var isParticipantGridDisplayed: Bool
 
     private let compositeViewModelFactory: CompositeViewModelFactory
     private let logger: Logger
@@ -35,7 +35,9 @@ class CallingViewModel: ObservableObject {
 
         infoHeaderViewModel = compositeViewModelFactory
             .makeInfoHeaderViewModel(localUserState: store.state.localUserState)
-
+        let isCallConnected = store.state.callingState.status == .connected
+        let hasRemoteParticipants = store.state.remoteParticipantsState.participantInfoList.count > 0
+        isParticipantGridDisplayed = isCallConnected && hasRemoteParticipants
         controlBarViewModel = compositeViewModelFactory
             .makeControlBarViewModel(dispatchAction: actionDispatch, endCallConfirm: { [weak self] in
                 guard let self = self else {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The local pip view doesn't show the video renderView when user joining a meeting with more than 1 participant. After some debugging, find the root cause is the quick shift from `false` to `true` in `isParticipantGridDisplayed` after the view navigate to the calling view
* When the `isParticipantGridDisplayed` update from `false` to `true`, the calling view would show `localVideoFullscreenView` first and then immediately convert into `localVideoPipView`
* This would cause the `localVideoRenderView` quickly being pass to `localVideoPipView` from `localVideoFullscreenView`, and failed to be renderer for unknown reason(may related to the SwiftUI internal bridging). The `localVideoRenderView` is always correctly attached inside the `localVideoPipView` UIViewRepresentable, but just failed for renderering (don't know why)
* Prevent the shift from `isParticipantGridDisplayed` could fix this issue

![MicrosoftTeams-image (24)](https://user-images.githubusercontent.com/75647512/155570331-393b1b8d-5a18-45be-8080-69a9ba8ffebc.png)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```
