### PR TITLE
[Feature] Apply Localization to CallingView to replace hardcoded string values

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/AzureCommunicationUI/Localization/en.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 "AzureCommunicationUI.SetupView.PreviewArea.AudioDisabled"="Your audio is disabled. To enable, please go to Settings to allow access. You must enable audio to start this call.";
 
 /* LobbyView */
-"AzureCommunicationUI.LobbyView.Text.WaitingForHost"="Waiting for host";
+"AzureCommunicationUI.LobbyView.Text.WaitingForHost"="Waiting for host"; // host (people not server) of a meeting
 "AzureCommunicationUI.LobbyView.Text.WaitingDetails"="Someone in the meeting will let you in soon";
 
 /* CallingView */

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/Factories/CompositeViewModelFactory.swift
@@ -150,7 +150,8 @@ class ACSCompositeViewModelFactory: CompositeViewModelFactory {
     func makeInfoHeaderViewModel(localUserState: LocalUserState) -> InfoHeaderViewModel {
         InfoHeaderViewModel(compositeViewModelFactory: self,
                             logger: logger,
-                            localUserState: localUserState)
+                            localUserState: localUserState,
+                            localizationProvider: localizationProvider)
     }
     func makeParticipantCellViewModel(participantModel: ParticipantInfoModel) -> ParticipantGridCellViewModel {
         ParticipantGridCellViewModel(compositeViewModelFactory: self, participantModel: participantModel)
@@ -160,13 +161,14 @@ class ACSCompositeViewModelFactory: CompositeViewModelFactory {
     }
 
     func makeParticipantsListViewModel(localUserState: LocalUserState) -> ParticipantsListViewModel {
-        ParticipantsListViewModel(localUserState: localUserState)
+        ParticipantsListViewModel(localUserState: localUserState,
+                                  localizationProvider: localizationProvider)
     }
     func makeBannerViewModel() -> BannerViewModel {
         BannerViewModel(compositeViewModelFactory: self)
     }
     func makeBannerTextViewModel() -> BannerTextViewModel {
-        BannerTextViewModel()
+        BannerTextViewModel(localizationProvider: localizationProvider)
     }
 
     // MARK: SetupViewModels

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
@@ -11,6 +11,7 @@ struct CompositeParticipantsList: UIViewControllerRepresentable {
     @Binding var isInfoHeaderDisplayed: Bool
     @ObservedObject var viewModel: ParticipantsListViewModel
     let sourceView: UIView
+    let localizationProvider: LocalizationProvider
 
     func makeCoordinator() -> Coordinator {
         Coordinator(isPresented: $isPresented,
@@ -19,7 +20,8 @@ struct CompositeParticipantsList: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> DrawerContainerViewController<ParticipantsListCellViewModel> {
         let controller = ParticipantsListViewController(items: getParticipantsList(),
-                                                        sourceView: sourceView)
+                                                        sourceView: sourceView,
+                                                        localizationProvider: localizationProvider)
         controller.delegate = context.coordinator
         return controller
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -11,7 +11,7 @@ class CompositeParticipantsListCell: TableViewCell {
     /// Set up the participant list item  in the participant list
     /// - Parameter viewModel: the participant view model needed to set up participant list cell
     func setup(viewModel: ParticipantsListCellViewModel,
-               localizationProvider: LocalizationProvider) {
+               displayName: String) {
         let isNameEmpty = viewModel.displayName.trimmingCharacters(in: .whitespaces).isEmpty
 
         let avatar = MSFAvatar(style: isNameEmpty ? .outlined : .accent, size: .medium)
@@ -35,26 +35,8 @@ class CompositeParticipantsListCell: TableViewCell {
                                :
                                 UIColor.compositeColor(CompositeColor.onSurface))
 
-        setup(title: displayName(displayName: viewModel.displayName,
-                                 isLocalParticipant: viewModel.isLocalParticipant,
-                                 localizationProvider: localizationProvider),
+        setup(title: displayName,
               customView: avatarView,
               customAccessoryView: micImageView)
-    }
-
-    private func displayName(displayName: String,
-                             isLocalParticipant: Bool,
-                             localizationProvider: LocalizationProvider) -> String {
-        let isNameEmpty = displayName.trimmingCharacters(in: .whitespaces).isEmpty
-        if isLocalParticipant {
-            let localDisplayName = isNameEmpty
-            ? localizationProvider.getLocalizedString(.unnamedParticipant)
-            : displayName
-            return localizationProvider.getLocalizedString(.localeParticipantWithSuffix, localDisplayName)
-        } else {
-            return isNameEmpty
-            ? localizationProvider.getLocalizedString(.unnamedParticipant)
-            : displayName
-        }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -10,7 +10,8 @@ class CompositeParticipantsListCell: TableViewCell {
 
     /// Set up the participant list item  in the participant list
     /// - Parameter viewModel: the participant view model needed to set up participant list cell
-    func setup(viewModel: ParticipantsListCellViewModel) {
+    func setup(viewModel: ParticipantsListCellViewModel,
+               localizationProvider: LocalizationProvider) {
         let isNameEmpty = viewModel.displayName.trimmingCharacters(in: .whitespaces).isEmpty
 
         let avatar = MSFAvatar(style: isNameEmpty ? .outlined : .accent, size: .medium)
@@ -35,22 +36,25 @@ class CompositeParticipantsListCell: TableViewCell {
                                 UIColor.compositeColor(CompositeColor.onSurface))
 
         setup(title: displayName(displayName: viewModel.displayName,
-                                 isLocalParticipant: viewModel.isLocalParticipant),
+                                 isLocalParticipant: viewModel.isLocalParticipant,
+                                 localizationProvider: localizationProvider),
               customView: avatarView,
               customAccessoryView: micImageView)
     }
 
-    private func displayName(displayName: String, isLocalParticipant: Bool) -> String {
+    private func displayName(displayName: String,
+                             isLocalParticipant: Bool,
+                             localizationProvider: LocalizationProvider) -> String {
         let isNameEmpty = displayName.trimmingCharacters(in: .whitespaces).isEmpty
         if isLocalParticipant {
-            return isNameEmpty ?
-            "\(StringConstants.defaultEmptyName) \(StringConstants.localParticipantNamePostfix)"
-            :
-            "\(displayName) \(StringConstants.localParticipantNamePostfix)"
+            let localDisplayName = isNameEmpty
+            ? localizationProvider.getLocalizedString(.unnamedParticipant)
+            : displayName
+            return localizationProvider.getLocalizedString(.localeParticipantWithSuffix, localDisplayName)
         } else {
-            return isNameEmpty ? "\(StringConstants.defaultEmptyName)"
-            :
-            displayName
+            return isNameEmpty
+            ? localizationProvider.getLocalizedString(.unnamedParticipant)
+            : displayName
         }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
@@ -56,7 +56,7 @@ extension ParticipantsListViewController: UITableViewDataSource, UITableViewDele
         }
         let participantViewModel = self.items[indexPath.row]
 
-        let displayName = participantViewModel.getCellDisplayName(localizationProvider: localizationProvider)
+        let displayName = participantViewModel.getCellDisplayName()
         cell.setup(viewModel: participantViewModel,
                    displayName: displayName)
         return cell

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
@@ -56,8 +56,9 @@ extension ParticipantsListViewController: UITableViewDataSource, UITableViewDele
         }
         let participantViewModel = self.items[indexPath.row]
 
+        let displayName = participantViewModel.getCellDisplayName(localizationProvider: localizationProvider)
         cell.setup(viewModel: participantViewModel,
-                   localizationProvider: localizationProvider)
+                   displayName: displayName)
         return cell
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
@@ -6,6 +6,19 @@
 import FluentUI
 
 class ParticipantsListViewController: DrawerContainerViewController<ParticipantsListCellViewModel> {
+    private let localizationProvider: LocalizationProvider
+
+    init(items: [ParticipantsListCellViewModel],
+         sourceView: UIView,
+         localizationProvider: LocalizationProvider) {
+        self.localizationProvider = localizationProvider
+        super.init(items: items, sourceView: sourceView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     private lazy var participantsListTableView: UITableView? = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.backgroundColor = backgroundColor
@@ -43,7 +56,8 @@ extension ParticipantsListViewController: UITableViewDataSource, UITableViewDele
         }
         let participantViewModel = self.items[indexPath.row]
 
-        cell.setup(viewModel: participantViewModel)
+        cell.setup(viewModel: participantViewModel,
+                   localizationProvider: localizationProvider)
         return cell
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerInfoType.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerInfoType.swift
@@ -13,62 +13,62 @@ enum BannerInfoType: Equatable {
     case recordingStopped
     case recordingAndTranscriptionStopped
 
-    func getTitle(_ localizationProvider: LocalizationProvider) -> String {
+    var title: StringKey {
         switch self {
         case .recordingAndTranscriptionStarted:
-            return localizationProvider.getLocalizedString(.bannerTitleRecordingAndTranscriptionStarted)
+            return .bannerTitleRecordingAndTranscriptionStarted
         case .recordingStarted:
-            return localizationProvider.getLocalizedString(.bannerTitleReordingStarted)
+            return .bannerTitleReordingStarted
         case .transcriptionStoppedStillRecording:
-            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStoppedStillRecording)
+            return .bannerTitleTranscriptionStoppedStillRecording
         case .transcriptionStarted:
-            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStarted)
+            return .bannerTitleTranscriptionStarted
         case .transcriptionStoppedAndSaved:
-            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStopped)
+            return .bannerTitleTranscriptionStopped
         case .recordingStoppedStillTranscribing:
-            return localizationProvider.getLocalizedString(.bannerTitleRecordingStoppedStillTranscribing)
+            return .bannerTitleRecordingStoppedStillTranscribing
         case .recordingStopped:
-            return localizationProvider.getLocalizedString(.bannerTitleRecordingStopped)
+            return .bannerTitleRecordingStopped
         case .recordingAndTranscriptionStopped:
-            return localizationProvider.getLocalizedString(.bannerTitleRecordingAndTranscribingStopped)
+            return .bannerTitleRecordingAndTranscribingStopped
         }
     }
 
-    func getBody(_ localizationProvider: LocalizationProvider) -> String {
+    var body: StringKey {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,
              .transcriptionStarted:
-            return localizationProvider.getLocalizedString(.bannerBodyConsent)
+            return .bannerBodyConsent
         case .transcriptionStoppedStillRecording:
-            return localizationProvider.getLocalizedString(.bannerBodyRecording)
+            return .bannerBodyRecording
         case .transcriptionStoppedAndSaved:
-            return localizationProvider.getLocalizedString(.bannerBodyTranscriptionStopped)
+            return .bannerBodyTranscriptionStopped
         case .recordingStoppedStillTranscribing:
-            return localizationProvider.getLocalizedString(.bannerBodyOnlyTranscribing)
+            return .bannerBodyOnlyTranscribing
         case .recordingStopped:
-            return localizationProvider.getLocalizedString(.bannerBodyRecordingStopped)
+            return .bannerBodyRecordingStopped
         case .recordingAndTranscriptionStopped:
-            return localizationProvider.getLocalizedString(.bannerBodyRecordingAndTranscriptionStopped)
+            return .bannerBodyRecordingAndTranscriptionStopped
         }
     }
 
-    func getLinkDisplay(_ localizationProvider: LocalizationProvider) -> String {
+    var linkDisplay: StringKey {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,
              .transcriptionStoppedStillRecording,
              .transcriptionStarted,
              .recordingStoppedStillTranscribing:
-            return localizationProvider.getLocalizedString(.bannerDisplayLinkPrivacyPolicy)
+            return .bannerDisplayLinkPrivacyPolicy
         case .transcriptionStoppedAndSaved,
              .recordingStopped,
              .recordingAndTranscriptionStopped:
-            return localizationProvider.getLocalizedString(.bannerDisplayLinkLearnMore)
+            return .bannerDisplayLinkLearnMore
         }
     }
 
-    func getLink() -> String {
+    var link: String {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerInfoType.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerInfoType.swift
@@ -13,74 +13,73 @@ enum BannerInfoType: Equatable {
     case recordingStopped
     case recordingAndTranscriptionStopped
 
-    var title: String {
+    func getTitle(_ localizationProvider: LocalizationProvider) -> String {
         switch self {
         case .recordingAndTranscriptionStarted:
-            return "Recording and transcription have started. "
+            return localizationProvider.getLocalizedString(.bannerTitleRecordingAndTranscriptionStarted)
         case .recordingStarted:
-            return "Recording has started. "
+            return localizationProvider.getLocalizedString(.bannerTitleReordingStarted)
         case .transcriptionStoppedStillRecording:
-            return "Transcription has stopped. "
+            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStoppedStillRecording)
         case .transcriptionStarted:
-            return "Transcription has started. "
+            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStarted)
         case .transcriptionStoppedAndSaved:
-            return "Transcription is being saved. "
+            return localizationProvider.getLocalizedString(.bannerTitleTranscriptionStopped)
         case .recordingStoppedStillTranscribing:
-            return "Recording has stopped. "
+            return localizationProvider.getLocalizedString(.bannerTitleRecordingStoppedStillTranscribing)
         case .recordingStopped:
-            return "Recording is being saved. "
+            return localizationProvider.getLocalizedString(.bannerTitleRecordingStopped)
         case .recordingAndTranscriptionStopped:
-            return "Recording and transcription are being saved. "
+            return localizationProvider.getLocalizedString(.bannerTitleRecordingAndTranscribingStopped)
         }
     }
 
-    var body: String {
+    func getBody(_ localizationProvider: LocalizationProvider) -> String {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,
              .transcriptionStarted:
-            return "By joining, you are giving consent for this meeting to be transcribed. "
+            return localizationProvider.getLocalizedString(.bannerBodyConsent)
         case .transcriptionStoppedStillRecording:
-            return "You are now only recording this meeting. "
+            return localizationProvider.getLocalizedString(.bannerBodyRecording)
         case .transcriptionStoppedAndSaved:
-            return "Transcription has stopped. "
+            return localizationProvider.getLocalizedString(.bannerBodyTranscriptionStopped)
         case .recordingStoppedStillTranscribing:
-            return "You are now only transcribing this meeting. "
+            return localizationProvider.getLocalizedString(.bannerBodyOnlyTranscribing)
         case .recordingStopped:
-            return "Recording has stopped. "
+            return localizationProvider.getLocalizedString(.bannerBodyRecordingStopped)
         case .recordingAndTranscriptionStopped:
-            return "Recording and transcription have stopped. "
+            return localizationProvider.getLocalizedString(.bannerBodyRecordingAndTranscriptionStopped)
         }
     }
 
-    var linkDisplay: String {
+    func getLinkDisplay(_ localizationProvider: LocalizationProvider) -> String {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,
              .transcriptionStoppedStillRecording,
              .transcriptionStarted,
              .recordingStoppedStillTranscribing:
-            return "Privacy policy"
+            return localizationProvider.getLocalizedString(.bannerDisplayLinkPrivacyPolicy)
         case .transcriptionStoppedAndSaved,
              .recordingStopped,
              .recordingAndTranscriptionStopped:
-            return "Learn more"
+            return localizationProvider.getLocalizedString(.bannerDisplayLinkLearnMore)
         }
     }
 
-    var link: String {
+    func getLink() -> String {
         switch self {
         case .recordingAndTranscriptionStarted,
              .recordingStarted,
              .transcriptionStoppedStillRecording,
              .transcriptionStarted,
              .recordingStoppedStillTranscribing:
-            return "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
+            return StringConstants.privacyPolicyLink
         case .transcriptionStoppedAndSaved,
              .recordingStopped,
              .recordingAndTranscriptionStopped:
-            return ("https://support.microsoft.com/office/"
-                + "record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24")
+            return StringConstants.learnMoreLink
         }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextView.swift
@@ -12,8 +12,10 @@ struct BannerTextView: View {
     var body: some View {
         Group {
             Text(viewModel.title).bold()
-                + Text(viewModel.body)
-                + Text(viewModel.linkDisplay).underline()
+            + Text(" ")
+            + Text(viewModel.body)
+            + Text(" ")
+            + Text(viewModel.linkDisplay).underline()
         }
         .font(Fonts.footnote.font)
         .onTapGesture {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextViewModel.swift
@@ -6,17 +6,22 @@
 import Foundation
 
 class BannerTextViewModel: ObservableObject {
+    private let localizationProvider: LocalizationProvider
     var title: String = ""
     var body: String = ""
     var linkDisplay: String = ""
     var link: String = ""
 
+    init(localizationProvider: LocalizationProvider) {
+        self.localizationProvider = localizationProvider
+    }
+
     func update(bannerInfoType: BannerInfoType?) {
         if let bannerInfoType = bannerInfoType {
-            self.title = bannerInfoType.title
-            self.body = bannerInfoType.body
-            self.linkDisplay = bannerInfoType.linkDisplay
-            self.link = bannerInfoType.link
+            self.title = bannerInfoType.getTitle(localizationProvider)
+            self.body = bannerInfoType.getBody(localizationProvider)
+            self.linkDisplay = bannerInfoType.getLinkDisplay(localizationProvider)
+            self.link = bannerInfoType.getLink()
         } else {
             self.title = ""
             self.body = ""

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/Banner/BannerTextViewModel.swift
@@ -18,10 +18,10 @@ class BannerTextViewModel: ObservableObject {
 
     func update(bannerInfoType: BannerInfoType?) {
         if let bannerInfoType = bannerInfoType {
-            self.title = bannerInfoType.getTitle(localizationProvider)
-            self.body = bannerInfoType.getBody(localizationProvider)
-            self.linkDisplay = bannerInfoType.getLinkDisplay(localizationProvider)
-            self.link = bannerInfoType.getLink()
+            self.title = localizationProvider.getLocalizedString(bannerInfoType.title)
+            self.body = localizationProvider.getLocalizedString(bannerInfoType.body)
+            self.linkDisplay = localizationProvider.getLocalizedString(bannerInfoType.linkDisplay)
+            self.link = bannerInfoType.link
         } else {
             self.title = ""
             self.body = ""

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
@@ -60,7 +60,8 @@ struct InfoHeaderView: View {
         CompositeParticipantsList(isPresented: $viewModel.isParticipantsListDisplayed,
                                   isInfoHeaderDisplayed: $viewModel.isInfoHeaderDisplayed,
                                   viewModel: viewModel.participantsListViewModel,
-                                  sourceView: participantsListButtonSourceView)
+                                  sourceView: participantsListButtonSourceView,
+                                  localizationProvider: viewModel.getLocalizationProvider())
             .modifier(LockPhoneOrientation())
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
@@ -7,10 +7,11 @@ import Foundation
 import Combine
 
 class InfoHeaderViewModel: ObservableObject {
-    @Published var infoLabel: String = "Waiting for others to join"
+    @Published var infoLabel: String
     @Published var isInfoHeaderDisplayed: Bool = true
     @Published var isParticipantsListDisplayed: Bool = false
     private let logger: Logger
+    private let localizationProvider: LocalizationProvider
     private var infoHeaderDismissTimer: Timer?
     private var participantsCount: Int = 0
 
@@ -20,8 +21,11 @@ class InfoHeaderViewModel: ObservableObject {
 
     init(compositeViewModelFactory: CompositeViewModelFactory,
          logger: Logger,
-         localUserState: LocalUserState) {
+         localUserState: LocalUserState,
+         localizationProvider: LocalizationProvider) {
         self.logger = logger
+        self.localizationProvider = localizationProvider
+        self.infoLabel = localizationProvider.getLocalizedString(.callWith0Person)
         self.participantsListViewModel = compositeViewModelFactory.makeParticipantsListViewModel(
             localUserState: localUserState)
         self.participantListButtonViewModel = compositeViewModelFactory.makeIconButtonViewModel(
@@ -52,6 +56,10 @@ class InfoHeaderViewModel: ObservableObject {
         self.isInfoHeaderDisplayed ? hideInfoHeader() : displayWithTimer()
     }
 
+    func getLocalizationProvider() -> LocalizationProvider {
+        return localizationProvider
+    }
+
     func update(localUserState: LocalUserState, remoteParticipantsState: RemoteParticipantsState) {
         if participantsCount != remoteParticipantsState.participantInfoList.count {
             participantsCount = remoteParticipantsState.participantInfoList.count
@@ -65,11 +73,11 @@ class InfoHeaderViewModel: ObservableObject {
         let content: String
         switch participantsCount {
         case 0:
-            content = "Waiting for others to join"
+            content = localizationProvider.getLocalizedString(.callWith0Person)
         case 1:
-            content = "Call with 1 person"
+            content = localizationProvider.getLocalizedString(.callWith1Person)
         default:
-            content = "Call with \(participantsCount) people"
+            content = localizationProvider.getLocalizedString(.callWithNPerson, participantsCount)
         }
         infoLabel = content
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -9,20 +9,25 @@ class ParticipantsListCellViewModel {
     let displayName: String
     let isMuted: Bool
     let isLocalParticipant: Bool
+    let localizationProvider: LocalizationProvider
 
-    init(localUserState: LocalUserState) {
+    init(localUserState: LocalUserState,
+         localizationProvider: LocalizationProvider) {
+        self.localizationProvider = localizationProvider
         self.displayName = localUserState.displayName ?? ""
         self.isMuted = localUserState.audioState.operation != .on
         self.isLocalParticipant = true
     }
 
-    init(participantInfoModel: ParticipantInfoModel) {
+    init(participantInfoModel: ParticipantInfoModel,
+         localizationProvider: LocalizationProvider) {
+        self.localizationProvider = localizationProvider
         self.displayName = participantInfoModel.displayName
         self.isMuted = participantInfoModel.isMuted
         self.isLocalParticipant = false
     }
 
-    func getCellDisplayName(localizationProvider: LocalizationProvider) -> String {
+    func getCellDisplayName() -> String {
         let isNameEmpty = displayName.trimmingCharacters(in: .whitespaces).isEmpty
         if isLocalParticipant {
             let localDisplayName = isNameEmpty

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -21,4 +21,18 @@ class ParticipantsListCellViewModel {
         self.isMuted = participantInfoModel.isMuted
         self.isLocalParticipant = false
     }
+
+    func getCellDisplayName(localizationProvider: LocalizationProvider) -> String {
+        let isNameEmpty = displayName.trimmingCharacters(in: .whitespaces).isEmpty
+        if isLocalParticipant {
+            let localDisplayName = isNameEmpty
+            ? localizationProvider.getLocalizedString(.unnamedParticipant)
+            : displayName
+            return localizationProvider.getLocalizedString(.localeParticipantWithSuffix, localDisplayName)
+        } else {
+            return isNameEmpty
+            ? localizationProvider.getLocalizedString(.unnamedParticipant)
+            : displayName
+        }
+    }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -15,7 +15,8 @@ class ParticipantsListViewModel: ObservableObject {
 
     init(localUserState: LocalUserState,
          localizationProvider: LocalizationProvider) {
-        localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState)
+        localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState,
+                                                                           localizationProvider: localizationProvider)
         self.localizationProvider = localizationProvider
     }
 
@@ -23,13 +24,16 @@ class ParticipantsListViewModel: ObservableObject {
                 remoteParticipantsState: RemoteParticipantsState) {
 
         if localParticipantsListCellViewModel.isMuted != (localUserState.audioState.operation == .off) {
-            localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState)
+            localParticipantsListCellViewModel = ParticipantsListCellViewModel(
+                localUserState: localUserState,
+                localizationProvider: localizationProvider)
         }
 
         if lastUpdateTimeStamp != remoteParticipantsState.lastUpdateTimeStamp {
             lastUpdateTimeStamp = remoteParticipantsState.lastUpdateTimeStamp
             participantsList = remoteParticipantsState.participantInfoList.map {
-                ParticipantsListCellViewModel(participantInfoModel: $0)
+                ParticipantsListCellViewModel(participantInfoModel: $0,
+                                              localizationProvider: localizationProvider)
             }
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -11,9 +11,12 @@ class ParticipantsListViewModel: ObservableObject {
     @Published var participantsList: [ParticipantsListCellViewModel] = []
     @Published var localParticipantsListCellViewModel: ParticipantsListCellViewModel
     var lastUpdateTimeStamp = Date()
+    private let localizationProvider: LocalizationProvider
 
-    init(localUserState: LocalUserState) {
+    init(localUserState: LocalUserState,
+         localizationProvider: LocalizationProvider) {
         localParticipantsListCellViewModel = ParticipantsListCellViewModel(localUserState: localUserState)
+        self.localizationProvider = localizationProvider
     }
 
     func update(localUserState: LocalUserState,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -62,7 +62,7 @@ class CallingViewModel: ObservableObject {
     func getLeaveCallButtonViewModel() -> PrimaryButtonViewModel {
         let leaveCallButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
             buttonStyle: .primaryFilled,
-            buttonLabel: "Leave call",
+            buttonLabel: localizationProvider.getLocalizedString(.leaveCall),
             iconName: nil,
             isDisabled: false,
             action: { [weak self] in
@@ -78,7 +78,7 @@ class CallingViewModel: ObservableObject {
     func getCancelButtonViewModel() -> PrimaryButtonViewModel {
         let cancelButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
             buttonStyle: .primaryOutline,
-            buttonLabel: "Cancel",
+            buttonLabel: localizationProvider.getLocalizedString(.cancel),
             iconName: nil,
             isDisabled: false,
             action: { [weak self] in

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
@@ -8,4 +8,8 @@ import Foundation
 struct StringConstants {
     static let defaultEmptyName: String = "Unnamed participant"
     static let localParticipantNamePostfix: String = "(me)"
+
+    static let privacyPolicyLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
+    static let learnMoreLink = "https://support.microsoft.com/office/"
+    + "record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringConstants.swift
@@ -9,7 +9,7 @@ struct StringConstants {
     static let defaultEmptyName: String = "Unnamed participant"
     static let localParticipantNamePostfix: String = "(me)"
 
-    static let privacyPolicyLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
-    static let learnMoreLink = "https://support.microsoft.com/office/"
+    static let privacyPolicyLink: String = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
+    static let learnMoreLink: String = "https://support.microsoft.com/office/"
     + "record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringKeys.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/StringKeys.swift
@@ -37,7 +37,7 @@ enum StringKey: String {
 
     case unnamedParticipant = "AzureCommunicationUI.CallingView.ParticipantDrawer.Unnamed"
     // %@ is local participant name
-    case localeParticipant =
+    case localeParticipantWithSuffix =
             "AzureCommunicationUI.CallingView.ParticipantDrawer.LocalParticipant"
 
     case leaveCall = "AzureCommunicationUI.CallingView.Overlay.LeaveCall"
@@ -58,7 +58,7 @@ enum StringKey: String {
             "AzureCommunicationUI.CallingView.BannerTitle.RecordingStoppedStillTranscribing"
     case bannerTitleRecordingStopped =
             "AzureCommunicationUI.CallingView.BannerTitle.RecordingStopped"
-    case bannerTitleRecordingAndTranscriptionStopped =
+    case bannerTitleRecordingAndTranscribingStopped =
             "AzureCommunicationUI.CallingView.BannerTitle.RecordingAndTranscribingStopped"
 
     /* ComplianceBanner body */

--- a/AzureCommunicationUI/AzureCommunicationUITests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/CompositeViewModelFactoryMocking.swift
@@ -114,7 +114,8 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactory {
     func makeInfoHeaderViewModel(localUserState: LocalUserState) -> InfoHeaderViewModel {
         return infoHeaderViewModel ?? InfoHeaderViewModel(compositeViewModelFactory: self,
                                                           logger: logger,
-                                                          localUserState: localUserState)
+                                                          localUserState: localUserState,
+                                                          localizationProvider: LocalizationProviderMocking())
     }
 
     func makeParticipantCellViewModel(participantModel: ParticipantInfoModel) -> ParticipantGridCellViewModel {
@@ -127,7 +128,8 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactory {
     }
 
     func makeParticipantsListViewModel(localUserState: LocalUserState) -> ParticipantsListViewModel {
-        return participantsListViewModel ?? ParticipantsListViewModel(localUserState: localUserState)
+        return participantsListViewModel ?? ParticipantsListViewModel(localUserState: localUserState,
+                                                                      localizationProvider: LocalizationProviderMocking())
     }
 
     func makeBannerViewModel() -> BannerViewModel {
@@ -135,7 +137,7 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactory {
     }
 
     func makeBannerTextViewModel() -> BannerTextViewModel {
-        return bannerTextViewModel ?? BannerTextViewModel()
+        return bannerTextViewModel ?? BannerTextViewModel(localizationProvider: LocalizationProviderMocking())
     }
 
     // MARK: SetupViewModels

--- a/AzureCommunicationUI/AzureCommunicationUITests/Mocking/ViewModels/BannerTextViewModelMocking.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Mocking/ViewModels/BannerTextViewModelMocking.swift
@@ -14,6 +14,7 @@ class BannerTextViewModelMocking: BannerTextViewModel {
 
     init(updateBannerInfoType: ((BannerInfoType?) -> Void)? = nil) {
         self.updateBannerInfoType = updateBannerInfoType
+        super.init(localizationProvider: LocalizationProviderMocking())
     }
 
     override func update(bannerInfoType: BannerInfoType?) {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Mocking/ViewModels/InfoHeaderViewModelMocking.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Mocking/ViewModels/InfoHeaderViewModelMocking.swift
@@ -16,7 +16,8 @@ class InfoHeaderViewModelMocking: InfoHeaderViewModel {
         self.updateState = updateState
         super.init(compositeViewModelFactory: compositeViewModelFactory,
                    logger: logger,
-                   localUserState: localUserState)
+                   localUserState: localUserState,
+                   localizationProvider: LocalizationProviderMocking())
     }
 
     override func update(localUserState: LocalUserState, remoteParticipantsState: RemoteParticipantsState) {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerInfoTypeTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerInfoTypeTests.swift
@@ -22,10 +22,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStarted_then_shouldEqualExpectedString() {
@@ -35,10 +35,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStoppedStillRecording_then_shouldEqualExpectedString() {
@@ -48,10 +48,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStarted_then_shouldEqualExpectedString() {
@@ -61,10 +61,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStoppedAndSaved_then_shouldEqualExpectedString() {
@@ -74,10 +74,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStoppedStillTranscribing_then_shouldEqualExpectedString() {
@@ -87,10 +87,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStopped_then_shouldEqualExpectedString() {
@@ -100,10 +100,10 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 
     func test_bannerInfoType_when_recordingAndTranscriptionStopped_then_shouldEqualExpectedString() {
@@ -113,9 +113,9 @@ class BannerInfoTypeTests: XCTestCase {
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
-        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
-        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.title), expectedTitle)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.body), expectedBody)
+        XCTAssertEqual(localizationProvider.getLocalizedString(bannerInfoType.linkDisplay), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.link, expectedLink)
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerInfoTypeTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerInfoTypeTests.swift
@@ -8,107 +8,114 @@ import XCTest
 @testable import AzureCommunicationUI
 
 class BannerInfoTypeTests: XCTestCase {
+    private var localizationProvider: LocalizationProvider!
+
+    override func setUp() {
+        super.setUp()
+        localizationProvider = AppLocalizationProvider(logger: LoggerMocking())
+    }
+
     func test_bannerInfoType_when_recordingAndTranscriptionStarted_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingAndTranscriptionStarted
-        let expectedTitle = "Recording and transcription have started. "
-        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed. "
+        let expectedTitle = "Recording and transcription have started."
+        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed."
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStarted_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingStarted
-        let expectedTitle = "Recording has started. "
-        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed. "
+        let expectedTitle = "Recording has started."
+        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed."
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStoppedStillRecording_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .transcriptionStoppedStillRecording
-        let expectedTitle = "Transcription has stopped. "
-        let expectedBody = "You are now only recording this meeting. "
+        let expectedTitle = "Transcription has stopped."
+        let expectedBody = "You are now only recording this meeting."
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStarted_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .transcriptionStarted
-        let expectedTitle = "Transcription has started. "
-        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed. "
+        let expectedTitle = "Transcription has started."
+        let expectedBody = "By joining, you are giving consent for this meeting to be transcribed."
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_transcriptionStoppedAndSaved_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .transcriptionStoppedAndSaved
-        let expectedTitle = "Transcription is being saved. "
-        let expectedBody = "Transcription has stopped. "
+        let expectedTitle = "Transcription is being saved."
+        let expectedBody = "Transcription has stopped."
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStoppedStillTranscribing_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingStoppedStillTranscribing
-        let expectedTitle = "Recording has stopped. "
-        let expectedBody = "You are now only transcribing this meeting. "
+        let expectedTitle = "Recording has stopped."
+        let expectedBody = "You are now only transcribing this meeting."
         let expectedLinkDisplay = "Privacy policy"
         let expectedLink = "https://privacy.microsoft.com/privacystatement#mainnoticetoendusersmodule"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_recordingStopped_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingStopped
-        let expectedTitle = "Recording is being saved. "
-        let expectedBody = "Recording has stopped. "
+        let expectedTitle = "Recording is being saved."
+        let expectedBody = "Recording has stopped."
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 
     func test_bannerInfoType_when_recordingAndTranscriptionStopped_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingAndTranscriptionStopped
-        let expectedTitle = "Recording and transcription are being saved. "
-        let expectedBody = "Recording and transcription have stopped. "
+        let expectedTitle = "Recording and transcription are being saved."
+        let expectedBody = "Recording and transcription have stopped."
         let expectedLinkDisplay = "Learn more"
         let expectedLink = "https://support.microsoft.com/office/record-a-meeting-in-teams-34dfbe7f-b07d-4a27-b4c6-de62f1348c24"
 
-        XCTAssertEqual(bannerInfoType.title, expectedTitle)
-        XCTAssertEqual(bannerInfoType.body, expectedBody)
-        XCTAssertEqual(bannerInfoType.linkDisplay, expectedLinkDisplay)
-        XCTAssertEqual(bannerInfoType.link, expectedLink)
+        XCTAssertEqual(bannerInfoType.getTitle(localizationProvider), expectedTitle)
+        XCTAssertEqual(bannerInfoType.getBody(localizationProvider), expectedBody)
+        XCTAssertEqual(bannerInfoType.getLinkDisplay(localizationProvider), expectedLinkDisplay)
+        XCTAssertEqual(bannerInfoType.getLink(), expectedLink)
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerTextViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerTextViewModelTests.swift
@@ -9,18 +9,20 @@ import XCTest
 
 class BannerTextViewModelTests: XCTestCase {
 
-    var bannerTextViewModel: BannerTextViewModel!
+    private var bannerTextViewModel: BannerTextViewModel!
+    private var localizationProvider: LocalizationProvider!
 
     override func setUp() {
         super.setUp()
-        bannerTextViewModel = BannerTextViewModel()
+        localizationProvider = AppLocalizationProvider(logger: LoggerMocking())
+        bannerTextViewModel = BannerTextViewModel(localizationProvider: localizationProvider)
     }
 
     func test_bannerTextViewModel_update_when_withBannerInfoType_then_shouldBePublish() {
-        let expectedTitle = BannerInfoType.recordingAndTranscriptionStarted.title
-        let expectedBody = BannerInfoType.recordingAndTranscriptionStarted.body
-        let expectedLinkDisplay = BannerInfoType.recordingAndTranscriptionStarted.linkDisplay
-        let expectedLink = BannerInfoType.recordingAndTranscriptionStarted.link
+        let expectedTitle = BannerInfoType.recordingAndTranscriptionStarted.getTitle(localizationProvider)
+        let expectedBody = BannerInfoType.recordingAndTranscriptionStarted.getBody(localizationProvider)
+        let expectedLinkDisplay = BannerInfoType.recordingAndTranscriptionStarted.getLinkDisplay(localizationProvider)
+        let expectedLink = BannerInfoType.recordingAndTranscriptionStarted.getLink()
         let expectation = XCTestExpectation(description: "Should publish bannerTextViewModel")
         let cancel = bannerTextViewModel.objectWillChange
             .sink(receiveValue: {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerTextViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/BannerTextViewModelTests.swift
@@ -19,10 +19,13 @@ class BannerTextViewModelTests: XCTestCase {
     }
 
     func test_bannerTextViewModel_update_when_withBannerInfoType_then_shouldBePublish() {
-        let expectedTitle = BannerInfoType.recordingAndTranscriptionStarted.getTitle(localizationProvider)
-        let expectedBody = BannerInfoType.recordingAndTranscriptionStarted.getBody(localizationProvider)
-        let expectedLinkDisplay = BannerInfoType.recordingAndTranscriptionStarted.getLinkDisplay(localizationProvider)
-        let expectedLink = BannerInfoType.recordingAndTranscriptionStarted.getLink()
+        let expectedTitle = localizationProvider
+            .getLocalizedString(BannerInfoType.recordingAndTranscriptionStarted.title)
+        let expectedBody = localizationProvider
+            .getLocalizedString(BannerInfoType.recordingAndTranscriptionStarted.body)
+        let expectedLinkDisplay = localizationProvider
+            .getLocalizedString(BannerInfoType.recordingAndTranscriptionStarted.linkDisplay)
+        let expectedLink = BannerInfoType.recordingAndTranscriptionStarted.link
         let expectation = XCTestExpectation(description: "Should publish bannerTextViewModel")
         let cancel = bannerTextViewModel.objectWillChange
             .sink(receiveValue: {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/CallingViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/CallingViewModelTests.swift
@@ -179,11 +179,12 @@ class CallingViewModelTests: XCTestCase {
 
 extension CallingViewModelTests {
     func makeSUT(storeFactory: StoreFactoryMocking = StoreFactoryMocking()) -> CallingViewModel {
-        let factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(), store: storeFactory.store)
+        let logger = LoggerMocking()
+        let factoryMocking = CompositeViewModelFactoryMocking(logger: logger, store: storeFactory.store)
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,
-                                localizationProvider: LocalizationProviderMocking())
+                                localizationProvider: AppLocalizationProvider(logger: logger))
     }
 
     func makeSUT(updateControlBarViewModel: @escaping ((LocalUserState, PermissionState) -> Void)) -> CallingViewModel {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/InfoHeaderViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/InfoHeaderViewModelTests.swift
@@ -12,11 +12,13 @@ class InfoHeaderViewModelTests: XCTestCase {
     var storeFactory: StoreFactoryMocking!
     var cancellable: CancelBag!
     var infoHeaderViewModel: InfoHeaderViewModel!
+    var localizationProvider: LocalizationProvider!
 
     override func setUp() {
         super.setUp()
         storeFactory = StoreFactoryMocking()
         cancellable = CancelBag()
+        localizationProvider = AppLocalizationProvider(logger: LoggerMocking())
 
         func dispatch(action: Action) {
             storeFactory.store.dispatch(action: action)
@@ -25,7 +27,8 @@ class InfoHeaderViewModelTests: XCTestCase {
         let factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(), store: storeFactory.store)
         infoHeaderViewModel = InfoHeaderViewModel(compositeViewModelFactory: factoryMocking,
                                                   logger: LoggerMocking(),
-                                                  localUserState: LocalUserState())
+                                                  localUserState: LocalUserState(),
+                                                  localizationProvider: localizationProvider)
     }
 
     func test_infoHeaderViewModel_update_when_participantInfoListCountSame_then_shouldNotBePublished() {

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -10,12 +10,14 @@ import XCTest
 class ParticipantsListViewModelTests: XCTestCase {
     var cancellable: CancelBag!
     var participantsListViewModel: ParticipantsListViewModel!
+    var localizationProvider: LocalizationProvider!
 
     override func setUp() {
         super.setUp()
         cancellable = CancelBag()
+        localizationProvider = AppLocalizationProvider(logger: LoggerMocking())
         participantsListViewModel = ParticipantsListViewModel(localUserState: LocalUserState(),
-                                                              localizationProvider: LocalizationProviderMocking())
+                                                              localizationProvider: localizationProvider)
     }
 
     // MARK: localParticipantsListCellViewModel test
@@ -38,7 +40,8 @@ class ParticipantsListViewModelTests: XCTestCase {
         let audioStateOn = LocalUserState.AudioState(operation: .on,
                                                      device: .receiverSelected)
         participantsListViewModel.localParticipantsListCellViewModel = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOn))
+            localUserState: LocalUserState(audioState: audioStateOn),
+            localizationProvider: localizationProvider)
         XCTAssertFalse(participantsListViewModel.localParticipantsListCellViewModel.isMuted)
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)
@@ -64,7 +67,8 @@ class ParticipantsListViewModelTests: XCTestCase {
             participantInfoList: participantInfoModel, lastUpdateTimeStamp: Date())
 
         participantsListViewModel.localParticipantsListCellViewModel = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOn))
+            localUserState: LocalUserState(audioState: audioStateOn),
+            localizationProvider: localizationProvider)
         XCTAssertFalse(participantsListViewModel.localParticipantsListCellViewModel.isMuted)
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)
@@ -91,7 +95,8 @@ class ParticipantsListViewModelTests: XCTestCase {
         let audioStateOff = LocalUserState.AudioState(operation: .off,
                                                       device: .receiverSelected)
         participantsListViewModel.localParticipantsListCellViewModel = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOff))
+            localUserState: LocalUserState(audioState: audioStateOff),
+            localizationProvider: localizationProvider)
         XCTAssertTrue(participantsListViewModel.localParticipantsListCellViewModel.isMuted)
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)
@@ -117,7 +122,8 @@ class ParticipantsListViewModelTests: XCTestCase {
             participantInfoList: participantInfoModel, lastUpdateTimeStamp: Date())
 
         participantsListViewModel.localParticipantsListCellViewModel = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOff))
+            localUserState: LocalUserState(audioState: audioStateOff),
+            localizationProvider: localizationProvider)
         XCTAssertTrue(participantsListViewModel.localParticipantsListCellViewModel.isMuted)
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)
@@ -156,7 +162,8 @@ class ParticipantsListViewModelTests: XCTestCase {
                                                      device: .receiverSelected)
         participantsListViewModel.lastUpdateTimeStamp = timestamp
         let localParticipant = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOn))
+            localUserState: LocalUserState(audioState: audioStateOn),
+            localizationProvider: localizationProvider)
         participantsListViewModel.localParticipantsListCellViewModel = localParticipant
         XCTAssertEqual(participantsListViewModel.participantsList.count, 0)
         participantsListViewModel.update(localUserState: localUserState,
@@ -200,7 +207,8 @@ class ParticipantsListViewModelTests: XCTestCase {
                                                      device: .receiverSelected)
         participantsListViewModel.lastUpdateTimeStamp = timestamp
         participantsListViewModel.localParticipantsListCellViewModel = ParticipantsListCellViewModel(
-            localUserState: LocalUserState(audioState: audioStateOn))
+            localUserState: LocalUserState(audioState: audioStateOn),
+            localizationProvider: localizationProvider)
         XCTAssertEqual(participantsListViewModel.participantsList.count, 0)
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -14,7 +14,8 @@ class ParticipantsListViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         cancellable = CancelBag()
-        participantsListViewModel = ParticipantsListViewModel(localUserState: LocalUserState())
+        participantsListViewModel = ParticipantsListViewModel(localUserState: LocalUserState(),
+                                                              localizationProvider: LocalizationProviderMocking())
     }
 
     // MARK: localParticipantsListCellViewModel test


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Replace hard coded string value to read localized value with LocalizationProvider
* Unit test for localized strings for components in callingView remain not breaking (Separate PR will convert test case to use LocalizationProviderMocking instead of AppLocalizationProvider in unit test)

eg. locale = "fr"
<img width="360" alt="image" src="https://user-images.githubusercontent.com/77021369/157766836-8be190a5-9c7b-4cef-aa1c-9de5caa022ab.png">
<img width="355" alt="image" src="https://user-images.githubusercontent.com/77021369/157766972-0761797e-ff82-4178-abda-a16380028029.png">


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Ensure all unit test are still passing
* Can see callingView text in different languages (change in Settings page in EntryView)

## Other Information
<!-- Add any other helpful information that may be needed here. -->