### PR TITLE
[Bug] Fix UI localized text constraint for setupView button text and lobbyView text

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/LobbyOverlayView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/LobbyOverlayView.swift
@@ -12,6 +12,7 @@ struct LobbyOverlayView: View {
 
     private let layoutSpacing: CGFloat = 24
     private let iconImageSize: CGFloat = 24
+    private let horizontalPaddingSize: CGFloat = 16
 
     var body: some View {
         Color(StyleProvider.color.overlay)
@@ -22,6 +23,8 @@ struct LobbyOverlayView: View {
                         .font(Fonts.headline.font)
                     Text(viewModel.subtitle)
                         .font(Fonts.subhead.font)
+                        .multilineTextAlignment(.center)
                 })
+            .padding(.horizontal, horizontalPaddingSize)
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
@@ -11,8 +11,8 @@ struct IconWithLabelButton: View {
 
     private let iconImageSize: CGFloat = 25
     private let verticalSpacing: CGFloat = 8
-    private let width: CGFloat = 80
-    private let height: CGFloat = 65
+    private let width: CGFloat = 85
+    private let height: CGFloat = 85
     private let buttonDisabledColor = Color(StyleProvider.color.onDisabled)
 
     var buttonForegroundColor: Color {
@@ -37,6 +37,6 @@ struct IconWithLabelButton: View {
         .animation(nil)
         .disabled(viewModel.isDisabled)
         .foregroundColor(viewModel.isDisabled ? buttonDisabledColor : buttonForegroundColor)
-        .frame(width: width, height: height, alignment: .center)
+        .frame(width: width, height: height, alignment: .top)
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Increase setupView buttonWithLabel text height to display up to 2 line of text, if longer will display 2 line with "..."
* Added horizontal padding for LobbyView text

| Before | After |
| ------ | ------|
| <img width="352" alt="image" src="https://user-images.githubusercontent.com/77021369/158689067-86010801-be90-4446-8035-caaeb60c1f30.png"> | <img width="353" alt="image" src="https://user-images.githubusercontent.com/77021369/158688789-8c6efddf-2923-47c9-8f44-792a1a0d25da.png"> |
| <img width="350" alt="image" src="https://user-images.githubusercontent.com/77021369/158689125-4a1e9038-a8f7-4e75-8e74-88c07d323076.png"> | <img width="354" alt="image" src="https://user-images.githubusercontent.com/77021369/158688838-e69bd2bb-6b35-41a2-96d8-04771fad359b.png"> |

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Check if long text (eg. German) the setupView button text will show up to 2 line of text
* Check LobbyView will display the text with proper padding to the side

## Other Information
<!-- Add any other helpful information that may be needed here. -->