### PR TITLE
[Bugfix] Corrected view padding in Lobby overlay view 

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/LobbyOverlayView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/LobbyOverlayView.swift
@@ -24,7 +24,7 @@ struct LobbyOverlayView: View {
                     Text(viewModel.subtitle)
                         .font(Fonts.subhead.font)
                         .multilineTextAlignment(.center)
-                })
-            .padding(.horizontal, horizontalPaddingSize)
+                }.padding(.horizontal, horizontalPaddingSize)
+            )
     }
 }


### PR DESCRIPTION
## Purpose
Fixed a UI bug I found when joining a Teams meeting such that the greyish background colour in the Lobby Overlay view does not extend edge of the screen (horizontal).

Bug fixed in highlighted 
![bug](https://user-images.githubusercontent.com/90668345/158909044-f4f61556-f76e-4af6-a442-0cc3bf3aa41b.PNG)
area in the screenshot.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Join a Teams call, wait till the "Waiting for host to show"
* Follow **What to Check** section

## What to Check
Verify that the following are valid:
* In the Lobby Overlay view, check if the background overlay grey view does cover edge to edge (horizontal)
* In the Lobby Overlay view, check the texts in different local / language settings are having horizontal padding of 16 (addressed in the original PR: Azure/communication-ui-library-ios/pull/79)

## Other Information
<!-- Add any other helpful information that may be needed here. -->