### PR TITLE
[Feature] Resolve issue where VoiceOver would sometimes read a word for an icon. Also added label for new join call button.

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -14,7 +14,7 @@ class SetupViewModel: ObservableObject {
 
     let previewAreaViewModel: PreviewAreaViewModel
     let title: String = "Setup"
-    
+
     var errorInfoViewModel: ErrorInfoViewModel
     var dismissButtonViewModel: IconButtonViewModel!
     var joinCallButtonViewModel: PrimaryButtonViewModel!

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -53,6 +53,7 @@ class SetupViewModel: ObservableObject {
                 }
                 self.joinCallButtonTapped()
         }
+        self.joinCallButtonViewModel.update(accessibilityLabel: "Join Call")
 
         self.dismissButtonViewModel = compositeViewModelFactory.makeIconButtonViewModel(
             iconName: .leftArrow,

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
@@ -28,6 +28,7 @@ struct IconWithLabelButton: View {
         Button(action: viewModel.action) {
             VStack(alignment: .center, spacing: verticalSpacing) {
                 Icon(name: viewModel.iconName, size: iconImageSize)
+                    .accessibility(hidden: true)
                 if let buttonLabel = viewModel.buttonLabel {
                     Text(buttonLabel)
                         .font(Fonts.button2.font)
@@ -40,5 +41,6 @@ struct IconWithLabelButton: View {
         .frame(width: width, height: height, alignment: .center)
         .accessibility(label: Text(viewModel.accessibilityLabel ?? ""))
         .accessibility(value: Text(viewModel.accessibilityValue ?? ""))
+        .accessibility(hint: Text(viewModel.accessibilityHint ?? ""))
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButtonViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButtonViewModel.swift
@@ -17,6 +17,7 @@ class IconWithLabelButtonViewModel: ObservableObject {
     @Published var buttonLabel: String
     @Published var accessibilityLabel: String?
     @Published var accessibilityValue: String?
+    @Published var accessibilityHint: String?
     @Published var isDisabled: Bool
     var action: (() -> Void)
 
@@ -50,6 +51,12 @@ class IconWithLabelButtonViewModel: ObservableObject {
     func update(accessibilityValue: String) {
         if self.accessibilityValue != accessibilityValue {
             self.accessibilityValue = accessibilityValue
+        }
+    }
+
+    func update(accessibilityHint: String) {
+        if self.accessibilityHint != accessibilityHint {
+            self.accessibilityHint = accessibilityHint
         }
     }
 


### PR DESCRIPTION
## Purpose
Resolve issue where VoiceOver would sometimes read a word for an icon. This was a super strange bug, I'm not entirely sure how it was even happening, but VoiceOver was somehow interpreting a word for some of the images used for the icons. In the case of the camera on button, it would read the word 'video' after the word 'button'. Using children ignore did not work either, so i had to hide the entire element.


Also added label for new join call button and an accessibility hint option for future use.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->