### PR TITLE
[Feature] Added logics to hide iOS home indicator when screenshare is presented during a call

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -35,6 +35,7 @@ struct ParticipantGridCellVideoView: View {
                             .frame(width: geometry.size.width,
                                    height: geometry.size.height - (lanscapeHasHomeBar ? Constants.homebarHeight : 0),
                                    alignment: .center)
+                            .prefersHomeIndicatorAutoHidden(UIDevice.current.hasHomeBar)
                     } else {
                         videoRenderView
                     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Utilities/PreferenceKey.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Utilities/PreferenceKey.swift
@@ -25,3 +25,14 @@ struct ProximitySensorPreferenceKey: PreferenceKey {
         value = nextValue()
     }
 }
+
+struct PrefersHomeIndicatorAutoHiddenPreferenceKey: PreferenceKey {
+
+    static var defaultValue: Bool {
+        return false
+    }
+
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = nextValue() || value
+    }
+}

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Utilities/ViewExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Utilities/ViewExtension.swift
@@ -23,4 +23,9 @@ extension View {
     func proximitySensorEnabled(_ proximityEnabled: Bool) -> some View {
         preference(key: ProximitySensorPreferenceKey.self, value: proximityEnabled)
     }
+
+    // Controls the application's preferred home indicator auto-hiding when this view is shown.
+    func prefersHomeIndicatorAutoHidden(_ value: Bool) -> some View {
+        preference(key: PrefersHomeIndicatorAutoHiddenPreferenceKey.self, value: value)
+    }
 }


### PR DESCRIPTION
## Purpose
Added logics to hide iOS home indicator when screenshare is presented during a call

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: UX improvement
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Launch the app, join a call (with remote participant), either group call or Teams call is ok
* Turn on screenshare (done by remote participant)
* Follow **What to check** section
* Turn off screenshare (done by remote participant)
* Follow **What to check** section

## What to Check
Verify that the following are valid
* Check if the iOS indicator are hidden when screen share is presented on the screen during a call, in portrait and landscape mode.
* Check if the iOS indicate are shown when switched to other screen such as Setup view, Participant / Audio Drawer, or exit overlay.

## Other Information
<!-- Add any other helpful information that may be needed here. -->