### PR TITLE
[Refactor] Improve bridging RendererView into SwiftUI

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -12,15 +12,12 @@ struct ParticipantGridCellView: View {
     let getRemoteParticipantRendererView: (RemoteParticipantVideoViewId) -> ParticipantRendererViewInfo?
     let rendererViewManager: RendererViewManager?
     @State var displayedVideoStreamId: String?
-    @State var isVideoChanging: Bool = false
     let avatarSize: CGFloat = 56
 
     var body: some View {
         Group {
             GeometryReader { geometry in
-                if isVideoChanging {
-                    EmptyView()
-                } else if let rendererViewInfo = getRendererViewInfo() {
+                if let rendererViewInfo = getRendererViewInfo() {
                     let zoomable = viewModel.videoViewModel?.videoStreamType == .screenSharing
                     ParticipantGridCellVideoView(videoRendererViewInfo: rendererViewInfo,
                                                  rendererViewManager: rendererViewManager,
@@ -32,21 +29,6 @@ struct ParticipantGridCellView: View {
                     avatarView
                         .frame(width: geometry.size.width,
                                height: geometry.size.height)
-                }
-            }
-        }
-        .onReceive(viewModel.$videoViewModel) { model in
-            let cachedVideoStreamId = displayedVideoStreamId
-            if model?.videoStreamId != displayedVideoStreamId {
-                displayedVideoStreamId = model?.videoStreamId
-            }
-
-            if model?.videoStreamId != cachedVideoStreamId,
-               model?.videoStreamId != nil {
-                // workaround to force rendererView being recreated
-                isVideoChanging = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    isVideoChanging = false
                 }
             }
         }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -39,12 +39,11 @@ class VideoRendererUIView: UIView {
         for view in subviews {
             view.removeFromSuperview()
         }
+        // the frame should be updated manually
+        // as setting constrains may cause updateUIView(_ uiView: VideoRendererUIView, context: Context) call
+        rendererView.frame = self.frame
+        rendererView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(rendererView)
-        rendererView.translatesAutoresizingMaskIntoConstraints = false
-        rendererView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        rendererView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        rendererView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        rendererView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         self.rendererView = rendererView
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -10,11 +10,41 @@ import Combine
 struct VideoRendererView: UIViewRepresentable {
     let rendererView: UIView
 
-    func makeUIView(context: Context) -> UIView {
-        return rendererView
+    func makeUIView(context: Context) -> VideoRendererUIView {
+        return VideoRendererUIView(rendererView: rendererView)
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: VideoRendererUIView, context: Context) {
+        uiView.update(rendererView: rendererView)
+    }
+}
 
+class VideoRendererUIView: UIView {
+    private var rendererView: UIView?
+
+    init(rendererView: UIView) {
+        super.init(frame: .zero)
+        update(rendererView: rendererView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(rendererView: UIView) {
+        guard self.rendererView != rendererView
+        else { return }
+
+        rendererView.removeFromSuperview()
+        for view in subviews {
+            view.removeFromSuperview()
+        }
+        addSubview(rendererView)
+        rendererView.translatesAutoresizingMaskIntoConstraints = false
+        rendererView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        rendererView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        rendererView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        rendererView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        self.rendererView = rendererView
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -34,8 +34,8 @@ class VideoRendererUIView: UIView {
     func update(rendererView: UIView) {
         guard self.rendererView != rendererView
         else {
-            if self.rendererView?.frame != frame {
-                self.rendererView?.frame = frame
+            if self.rendererView?.frame != bounds {
+                self.rendererView?.frame = bounds
             }
             return
         }
@@ -46,7 +46,7 @@ class VideoRendererUIView: UIView {
         }
         // the frame should be updated manually
         // as setting constrains may cause updateUIView(_ uiView: VideoRendererUIView, context: Context) call
-        rendererView.frame = self.frame
+        rendererView.frame = bounds
         rendererView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(rendererView)
         self.rendererView = rendererView

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -33,7 +33,12 @@ class VideoRendererUIView: UIView {
 
     func update(rendererView: UIView) {
         guard self.rendererView != rendererView
-        else { return }
+        else {
+            if self.rendererView?.frame != frame {
+                self.rendererView?.frame = frame
+            }
+            return
+        }
 
         rendererView.removeFromSuperview()
         for view in subviews {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added VideoRendererUIView for correct bridging RendererView into SwiftUI
* Removed the workaround in ParticipantGridCellView

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Verify that the following are valid
* Participants grid and videos are rendered correctly on the Call screen
* Local video is displayed on the Setup and Calling screens