### PR TITLE
[Bug] Resolved the double tap to zoom issue in landscape mode on a device with an iOS home indicator and extended the screen share view to vertical edge of screen

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -10,7 +10,6 @@ import Combine
 struct ParticipantGridCellVideoView: View {
 
     private struct Constants {
-        static let homebarHeight: CGFloat = 22
         static let borderColor = Color(StyleProvider.color.primaryColor)
     }
 
@@ -23,21 +22,12 @@ struct ParticipantGridCellVideoView: View {
     @Environment(\.screenSizeClass) var screenSizeClass: ScreenSizeClassType
 
     var body: some View {
-        let lanscapeHasHomeBar = (screenSizeClass == .iphoneLandscapeScreenSize
-                                  && UIDevice.current.hasHomeBar)
         ZStack(alignment: .bottomLeading) {
             VStack(alignment: .center, spacing: 0) {
-                GeometryReader { geometry in
-                    if zoomable {
-                        // reduce height as work-around to resolve the double tap issue, when lanscapeHasHomeBar is true
-                        // To be improved in the next PR
-                        zoomableVideoRenderView
-                            .frame(width: geometry.size.width,
-                                   height: geometry.size.height - (lanscapeHasHomeBar ? Constants.homebarHeight : 0),
-                                   alignment: .center)
-                    } else {
-                        videoRenderView
-                    }
+                if zoomable {
+                    zoomableVideoRenderView
+                } else {
+                    videoRenderView
                 }
             }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ZoomableVideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ZoomableVideoRenderView.swift
@@ -41,6 +41,11 @@ struct ZoomableVideoRenderView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIScrollView {
+        // Creates a content view for scrollview, that holds on to the rendererView
+        let contentView = UIView()
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
         // Setup scrollview and renderview
         scrollView.delegate = context.coordinator
         scrollView.maximumZoomScale = initialMaxZoomScale
@@ -49,12 +54,15 @@ struct ZoomableVideoRenderView: UIViewRepresentable {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.decelerationRate = .fast
-        scrollView.zoomScale = initialMinZoomScale
+
         rendererView!.translatesAutoresizingMaskIntoConstraints = true
         rendererView!.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         rendererView!.frame = scrollView.bounds
-        scrollView.addSubview(rendererView!)
+
+        contentView.addSubview(rendererView!)
+        scrollView.addSubview(contentView)
         scrollView.contentSize = rendererView.bounds.size
+        scrollView.zoomScale = initialMinZoomScale
 
         // Double tap action
         let doubleTapGesture = UITapGestureRecognizer(target: context.coordinator,


### PR DESCRIPTION
## Purpose
In this PR, I resolved the double tap to zoom issue in landscape mode on a device with an iOS home indicator and extended the screen share view to vertical edge of screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## Test the code
* Join a call with a screenshare currently presented. 
* Try to perform double tap to zoom in landscape modes
* Follow  **What to Check** section

## What to Check
Verify that the following are valid
* Check if the height of the screen share view extended to the vertical edge of screen in landscape mode
* Check if the double tap to zoom animation works as expected (e.g. it zooms to the correct area based on the tap position with smooth zoom in animation). 
 

## Other Information
<!-- Add any other helpful information that may be needed here. -->