### PR TITLE
[Feature] Added basic XCUITests for leave call

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B0D8DC627F3B1B800F0C47A /* AzureCommunicationUIDemoAppCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0D8DC527F3B1B800F0C47A /* AzureCommunicationUIDemoAppCallTests.swift */; };
 		1F18191727B39F36006AF3B3 /* XCUITestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18191627B39F36006AF3B3 /* XCUITestBase.swift */; };
 		1F18191A27B45050006AF3B3 /* XCUIElementExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F18191927B45050006AF3B3 /* XCUIElementExtension.swift */; };
 		1F8881BD27909E08001427F0 /* AzureCommunicationUIDemoAppLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8881BC27909E08001427F0 /* AzureCommunicationUIDemoAppLaunchTests.swift */; };
@@ -58,6 +59,7 @@
 
 /* Begin PBXFileReference section */
 		0883E4B2C59B676B35210362 /* Pods-AzureCommunicationUIDemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AzureCommunicationUIDemoApp.debug.xcconfig"; path = "Target Support Files/Pods-AzureCommunicationUIDemoApp/Pods-AzureCommunicationUIDemoApp.debug.xcconfig"; sourceTree = "<group>"; };
+		1B0D8DC527F3B1B800F0C47A /* AzureCommunicationUIDemoAppCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AzureCommunicationUIDemoAppCallTests.swift; sourceTree = "<group>"; };
 		1F18191627B39F36006AF3B3 /* XCUITestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUITestBase.swift; sourceTree = "<group>"; };
 		1F18191927B45050006AF3B3 /* XCUIElementExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCUIElementExtension.swift; sourceTree = "<group>"; };
 		1F8881BA27909E08001427F0 /* AzureCommunicationUIDemoAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AzureCommunicationUIDemoAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +127,7 @@
 			children = (
 				1F18191827B45050006AF3B3 /* Utilities */,
 				1F8881BC27909E08001427F0 /* AzureCommunicationUIDemoAppLaunchTests.swift */,
+				1B0D8DC527F3B1B800F0C47A /* AzureCommunicationUIDemoAppCallTests.swift */,
 				1F8881BE27909E08001427F0 /* AzureCommunicationUIDemoAppUITestsLaunchTests.swift */,
 				1FBA6B1B27B4F61A00FF3835 /* Info.plist */,
 			);
@@ -447,6 +450,7 @@
 				1F8881BF27909E08001427F0 /* AzureCommunicationUIDemoAppUITestsLaunchTests.swift in Sources */,
 				1F18191A27B45050006AF3B3 /* XCUIElementExtension.swift in Sources */,
 				1F18191727B39F36006AF3B3 /* XCUITestBase.swift in Sources */,
+				1B0D8DC627F3B1B800F0C47A /* AzureCommunicationUIDemoAppCallTests.swift in Sources */,
 				1F8881BD27909E08001427F0 /* AzureCommunicationUIDemoAppLaunchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppCallTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppCallTests.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+
+class AzureCommunicationUIDemoAppCallTests: XCUITestBase {
+
+    override func setUp() {
+        super.setUp()
+        app = XCUIApplication()
+        app?.launch()
+    }
+
+    // MARK: End call tests
+
+    func testCallCompositeEndCallGroupCallSwiftUI() {
+        guard app != nil else {
+            XCTFail("No App launch")
+            return
+        }
+
+        tapInterfaceFor(.swiftUI)
+        tapEnabledButton(buttonName: "Start Experience", shouldWait: true)
+        tapButton(buttonName: "Join call", shouldWait: true)
+        toggleLeaveCallOverlay(leaveCall: true)
+    }
+
+    func testCallCompositeEndCallTeamsCallSwiftUI() {
+        guard app != nil else {
+            XCTFail("No App launch")
+            return
+        }
+
+        tapInterfaceFor(.uiKit)
+        tapMeetingType(.teamsCall)
+        tapEnabledButton(buttonName: "Start Experience", shouldWait: true)
+        tapButton(buttonName: "Join call", shouldWait: true)
+        toggleLeaveCallOverlay(leaveCall: true)
+    }
+
+    func testCallCompositeEndCallGroupCallUIKit() {
+        guard app != nil else {
+            XCTFail("No App launch")
+            return
+        }
+
+        tapInterfaceFor(.swiftUI)
+        tapEnabledButton(buttonName: "Start Experience", shouldWait: true)
+        tapButton(buttonName: "Join call", shouldWait: true)
+        toggleLeaveCallOverlay(leaveCall: true)
+    }
+
+    func testCallCompositeEndCallTeamsCallUIKit() {
+        guard app != nil else {
+            XCTFail("No App launch")
+            return
+        }
+
+        tapInterfaceFor(.uiKit)
+        tapMeetingType(.teamsCall)
+        tapEnabledButton(buttonName: "Start Experience", shouldWait: true)
+        tapButton(buttonName: "Join call", shouldWait: true)
+        toggleLeaveCallOverlay(leaveCall: true)
+    }
+
+    // MARK: Private / helper functions
+
+    /// Toggles the leave call overlay  in the calling screen
+    private func toggleLeaveCallOverlay(leaveCall: Bool) {
+        guard let app = app else {
+            XCTFail("No App launch")
+            return
+        }
+        tapButton(buttonName: "AzureCommunicationUI.CallingView.ControlButton.HangUp", shouldWait: true)
+        tapButton(buttonName: "Cancel", shouldWait: true)
+        tapButton(buttonName: "AzureCommunicationUI.CallingView.ControlButton.HangUp", shouldWait: true)
+
+        if leaveCall {
+            tapButton(buttonName: "Leave call", shouldWait: true)
+            XCTAssertTrue(app.buttons["Start Experience"].waitForExistence(timeout: 3))
+        }
+    }
+}

--- a/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/Utilities/XCUITestBase.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/Utilities/XCUITestBase.swift
@@ -68,4 +68,16 @@ extension XCUITestBase {
     func tapMeetingType(_ meetingType: CompositeMeetingType) {
         app?.buttons[meetingType.name].tap()
     }
+
+    func takeScreenshot(name: String = "App Screenshot - \(Date().description)",
+                        lifetime: XCTAttachment.Lifetime  = .keepAlways) {
+        guard let app = app else {
+            return
+        }
+        let screenshot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = lifetime
+        add(attachment)
+    }
 }


### PR DESCRIPTION
## Purpose
Added basic XCUITests for leave call

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: XCUITests
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Run the AzureCommunicationUIDemoAppCallTests
```
```

## What to Check
Verify that the following are valid
* check if all the test cases pass.  

## Other Information
<!-- Add any other helpful information that may be needed here. -->