### PR TITLE
[Bugfix] Re-added code to hide screenshare indicator when screen share is presented.

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -26,6 +26,7 @@ struct ParticipantGridCellVideoView: View {
             VStack(alignment: .center, spacing: 0) {
                 if zoomable {
                     zoomableVideoRenderView
+                        .prefersHomeIndicatorAutoHidden(UIDevice.current.hasHomeBar)
                 } else {
                     videoRenderView
                 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -12,12 +12,15 @@ struct ParticipantGridCellView: View {
     let getRemoteParticipantRendererView: (RemoteParticipantVideoViewId) -> ParticipantRendererViewInfo?
     let rendererViewManager: RendererViewManager?
     @State var displayedVideoStreamId: String?
+    @State var isVideoChanging: Bool = false
     let avatarSize: CGFloat = 56
 
     var body: some View {
         Group {
             GeometryReader { geometry in
-                if let rendererViewInfo = getRendererViewInfo() {
+                if isVideoChanging {
+                    EmptyView()
+                } else if let rendererViewInfo = getRendererViewInfo() {
                     let zoomable = viewModel.videoViewModel?.videoStreamType == .screenSharing
                     ParticipantGridCellVideoView(videoRendererViewInfo: rendererViewInfo,
                                                  rendererViewManager: rendererViewManager,
@@ -33,6 +36,21 @@ struct ParticipantGridCellView: View {
             }
             .accessibilityElement(children: .combine)
             .accessibility(label: Text(viewModel.accessibilityLabel))
+        }
+        .onReceive(viewModel.$videoViewModel) { model in
+            let cachedVideoStreamId = displayedVideoStreamId
+            if model?.videoStreamId != displayedVideoStreamId {
+                displayedVideoStreamId = model?.videoStreamId
+            }
+
+            if model?.videoStreamId != cachedVideoStreamId,
+               model?.videoStreamId != nil {
+                // workaround to force rendererView being recreated
+                isVideoChanging = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    isVideoChanging = false
+                }
+            }
         }
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -10,45 +10,10 @@ import Combine
 struct VideoRendererView: UIViewRepresentable {
     let rendererView: UIView
 
-    func makeUIView(context: Context) -> VideoRendererUIView {
-        return VideoRendererUIView(rendererView: rendererView)
+    func makeUIView(context: Context) -> UIView {
+        return rendererView
     }
 
-    func updateUIView(_ uiView: VideoRendererUIView, context: Context) {
-        uiView.update(rendererView: rendererView)
-    }
-}
-
-class VideoRendererUIView: UIView {
-    private var rendererView: UIView?
-
-    init(rendererView: UIView) {
-        super.init(frame: .zero)
-        update(rendererView: rendererView)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func update(rendererView: UIView) {
-        guard self.rendererView != rendererView
-        else {
-            if self.rendererView?.frame != bounds {
-                self.rendererView?.frame = bounds
-            }
-            return
-        }
-
-        rendererView.removeFromSuperview()
-        for view in subviews {
-            view.removeFromSuperview()
-        }
-        // the frame should be updated manually
-        // as setting constrains may cause updateUIView(_ uiView: VideoRendererUIView, context: Context) call
-        rendererView.frame = bounds
-        rendererView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        addSubview(rendererView)
-        self.rendererView = rendererView
+    func updateUIView(_ uiView: UIView, context: Context) {
     }
 }


### PR DESCRIPTION
## Purpose
In this PR I re-added the deleted line of code that hides the iOS home indicator when screen share is presented.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Join a call, (teams / group) with remote participant
* ask the remote participant to turn on screen share
* see if the iOS home indicator is hidden when screenshare is presented on the screen


## What to Check
Verify that the following are valid
* check if the iOS home indicator is hidden when screenshare is presented on the screen
* check if the iOS home indicator is not hidden in other screens


## Other Information
<!-- Add any other helpful information that may be needed here. -->