### PR TITLE
[Refactor] Improved accessibility and UITest for leave call drawer, also cleaned up unneeded UITests

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
@@ -73,6 +73,7 @@ extension LeaveCallConfirmationListViewController: UITableViewDataSource, UITabl
 
         cell.setup(viewModel: viewModel)
         cell.accessibilityValue = "\(indexPath.row + 1) of \(indexPath.count)"
+        cell.accessibilityIdentifier = viewModel.accessibilityIdentifier
         return cell
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
@@ -116,7 +116,7 @@ class ControlBarViewModel: ObservableObject {
         self.isAudioDeviceSelectionDisplayed = true
     }
 
-    func dismissConfirmLeaveOverlay() {
+    func dismissConfirmLeaveDrawerList() {
         self.isConfirmLeaveListDisplayed = false
     }
 
@@ -131,6 +131,7 @@ class ControlBarViewModel: ObservableObject {
     func getLeaveCallButtonViewModel() -> LeaveCallConfirmationViewModel {
         return LeaveCallConfirmationViewModel(icon: .endCallRegular,
                                               title: localizationProvider.getLocalizedString(.leaveCall),
+                                              accessibilityIdentifier: LocalizationKey.leaveCall.rawValue,
                                               action: { [weak self] in
             guard let self = self else {
                 return
@@ -143,12 +144,13 @@ class ControlBarViewModel: ObservableObject {
     func getCancelButtonViewModel() -> LeaveCallConfirmationViewModel {
         return LeaveCallConfirmationViewModel(icon: .dismiss,
                                               title: localizationProvider.getLocalizedString(.cancel),
+                                              accessibilityIdentifier: LocalizationKey.cancelAccssibilityLabel.rawValue,
                                               action: { [weak self] in
             guard let self = self else {
                 return
             }
             self.logger.debug("Cancel button tapped")
-            self.dismissConfirmLeaveOverlay()
+            self.dismissConfirmLeaveDrawerList()
         })
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -69,52 +69,13 @@ class CallingViewModel: ObservableObject {
         return compositeViewModelFactory.makeLobbyOverlayViewModel()
     }
 
-    // MARK: ConfirmLeaveOverlay
-    func getLeaveCallButtonViewModel() -> PrimaryButtonViewModel {
-        let leaveCallButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
-            buttonStyle: .primaryFilled,
-            buttonLabel: localizationProvider.getLocalizedString(.leaveCall),
-            iconName: nil,
-            isDisabled: false,
-            action: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                self.logger.debug("Leave call button tapped")
-                self.endCall()
-            })
-        leaveCallButtonViewModel.update(accessibilityLabel: localizationProvider.getLocalizedString(.leaveCall))
-        return leaveCallButtonViewModel
-    }
-
-    func getCancelButtonViewModel() -> PrimaryButtonViewModel {
-        let cancelButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
-            buttonStyle: .primaryOutline,
-            buttonLabel: localizationProvider.getLocalizedString(.cancel),
-            iconName: nil,
-            isDisabled: false,
-            action: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                self.logger.debug("Cancel button tapped")
-                self.dismissConfirmLeaveOverlay()
-            })
-        cancelButtonViewModel.update(accessibilityLabel: localizationProvider.getLocalizedString(.cancel))
-        return cancelButtonViewModel
-    }
-
-    func displayConfirmLeaveOverlay() {
-        self.isConfirmLeaveListDisplayed = true
-    }
-
-    func dismissConfirmLeaveOverlay() {
+    func dismissConfirmLeaveDrawerList() {
         self.isConfirmLeaveListDisplayed = false
     }
 
     func endCall() {
         store.dispatch(action: CallingAction.CallEndRequested())
-        dismissConfirmLeaveOverlay()
+        dismissConfirmLeaveDrawerList()
     }
 
     func receive(_ state: AppState) {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Drawer/LeaveCallConfirmationViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/ViewComponents/Drawer/LeaveCallConfirmationViewModel.swift
@@ -8,13 +8,16 @@ import Foundation
 class LeaveCallConfirmationViewModel {
     let icon: CompositeIcon
     let title: String
+    let accessibilityIdentifier: String
     let action: (() -> Void)
 
     init(icon: CompositeIcon,
          title: String,
+         accessibilityIdentifier: String,
          action: @escaping (() -> Void)) {
         self.icon = icon
         self.title = title
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.action = action
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppCallTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppCallTests.swift
@@ -47,7 +47,10 @@ class AzureCommunicationUIDemoAppCallTests: XCUITestBase {
         tapButton(accessibilityIdentifier: .hangupAccessibilityLabel, shouldWait: true)
 
         if leaveCall {
-            app.tables.cells.firstMatch.tap()
+            let cell = app.tables.cells[LocalizationKey.leaveCall.rawValue]
+            if cell.waitForExistence(timeout: 3) {
+                cell.tap()
+            }
             XCTAssertTrue(app.buttons[LocalizationKey.startExperienceAccessibilityLabel.rawValue]
                             .waitForExistence(timeout: 3))
         }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppLaunchTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoAppUITests/AzureCommunicationUIDemoAppLaunchTests.swift
@@ -10,11 +10,6 @@ class AzureCommunicationUIDemoAppLaunchTests: XCUITestBase {
     func testLaunch() {
         let app = XCUIApplication()
         app.launch()
-
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
-        add(attachment)
     }
 
     func testCallCompositeLaunch() {
@@ -60,15 +55,6 @@ class AzureCommunicationUIDemoAppLaunchTests: XCUITestBase {
         tapEnabledButton(accessibilityIdentifier: .startExperienceAccessibilityLabel, shouldWait: true)
         tapButton(accessibilityIdentifier: .joinCallAccessibilityLabel, shouldWait: true)
         tapButton(accessibilityIdentifier: .hangupAccessibilityLabel, shouldWait: true)
-    }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
     }
 }
 

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ControlBarViewModelTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Calling/ControlBarViewModelTests.swift
@@ -64,7 +64,7 @@ class ControlBarViewModelTests: XCTestCase {
     func test_controlBarViewModel_dismissConfirmLeaveOverlay_when_isConfirmLeaveListDisplayedTrue_shouldBecomeFalse() {
         let sut = makeSUT()
         sut.isConfirmLeaveListDisplayed = true
-        sut.dismissConfirmLeaveOverlay()
+        sut.dismissConfirmLeaveDrawerList()
 
         XCTAssertFalse(sut.isConfirmLeaveListDisplayed)
     }


### PR DESCRIPTION

## Purpose
Improved accessibility and UITest for leave call drawer, also cleaned up unneeded UITests


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Try to run the UITests
* Also try to check the accessibility id is added for "Leave" and "Cancel" button in leave call confirmation drawer (using Accessibility Inspector)

## What to Check
* Make sure the UITests runs correctly
* Also try to check the accessibility id is added for "Leave" and "Cancel" button in leave call confirmation drawer (using Accessibility Inspector)


## Other Information
<!-- Add any other helpful information that may be needed here. -->