### PR TITLE
[Refactor] Move determineErrorType to ACSCallEndReasonExtension

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/AzureCommunicationUI.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		1FCB056B2671D8BE00126A4E /* StyleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCB056A2671D8BE00126A4E /* StyleProvider.swift */; };
 		1FD299642723345B0084B9ED /* DefaultLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD299632723345B0084B9ED /* DefaultLogger.swift */; };
 		1FD299662728B72B0084B9ED /* CallingSDKEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD299652728B72B0084B9ED /* CallingSDKEventsHandler.swift */; };
+		1FDBF9F1281F8D2F00B92273 /* ACSCallEndReasonExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDBF9F0281F8D2E00B92273 /* ACSCallEndReasonExtension.swift */; };
 		1FE1BE7F26FE38C9000A8D18 /* CompositeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE1BE7E26FE38C9000A8D18 /* CompositeError.swift */; };
 		1FF252D627B6F29A006A113E /* JoiningCallActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF252D527B6F29A006A113E /* JoiningCallActivityView.swift */; };
 		1FFEA01426A68D0D00E90816 /* UIFontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFEA01326A68D0D00E90816 /* UIFontExtension.swift */; };
@@ -322,6 +323,7 @@
 		1FCB056A2671D8BE00126A4E /* StyleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleProvider.swift; sourceTree = "<group>"; };
 		1FD299632723345B0084B9ED /* DefaultLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultLogger.swift; sourceTree = "<group>"; };
 		1FD299652728B72B0084B9ED /* CallingSDKEventsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingSDKEventsHandler.swift; sourceTree = "<group>"; };
+		1FDBF9F0281F8D2E00B92273 /* ACSCallEndReasonExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACSCallEndReasonExtension.swift; sourceTree = "<group>"; };
 		1FE1BE7E26FE38C9000A8D18 /* CompositeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeError.swift; sourceTree = "<group>"; };
 		1FF252D527B6F29A006A113E /* JoiningCallActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoiningCallActivityView.swift; sourceTree = "<group>"; };
 		1FFEA01326A68D0D00E90816 /* UIFontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtension.swift; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 				1FBCB6B02649EB1200F57EEA /* RemoteParticipantExtension.swift */,
 				1F13D37226AB3F1200E31666 /* ACSCallingStateExtension.swift */,
 				5A31447C18BC49B691800C9D /* ACSCameraFacingExtension.swift */,
+				1FDBF9F0281F8D2E00B92273 /* ACSCallEndReasonExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1664,6 +1667,7 @@
 				985DF378269E07F400CFDA55 /* PrimaryButtonViewModel.swift in Sources */,
 				1FC30846266949E8007EC537 /* ColorExtension.swift in Sources */,
 				1F6470AC2639FE670008B9E9 /* CancelBag.swift in Sources */,
+				1FDBF9F1281F8D2F00B92273 /* ACSCallEndReasonExtension.swift in Sources */,
 				883D12DA2784F0B1005021E2 /* StringConstants.swift in Sources */,
 				1F4B0F0526A6469F00E87014 /* RemoteParticipantsEventsAdapter.swift in Sources */,
 				1F11D2B2263CA10000D33838 /* CommunicationIdentifierExtension.swift in Sources */,

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -150,8 +150,8 @@ extension CallingSDKEventsHandler: CallDelegate,
 
     func call(_ call: Call, didChangeState args: PropertyChangedEventArgs) {
         let currentStatus = call.state.toCallingStatus()
-        let errorCode = determineErrorType(previousStatus: self.previousCallingStatus,
-                                           callEndReason: call.callEndReason)
+        let isCallConnected = previousCallingStatus == .connected
+        let errorCode = call.callEndReason.toCompositeErrorCodeString(isCallConnected)
 
         let callInfoModel = CallInfoModel(status: currentStatus, errorCode: errorCode)
         callInfoSubject.send(callInfoModel)
@@ -174,28 +174,4 @@ extension CallingSDKEventsHandler: CallDelegate,
         isLocalUserMutedSubject.send(call.isMuted)
     }
 
-    private func determineErrorType(previousStatus: CallingStatus, callEndReason: CallEndReason) -> String {
-        let callEndReasonCode = callEndReason.code
-        let callEndReasonSubCode = callEndReason.subcode
-
-        if callEndReasonCode == 0 {
-            if (callEndReasonSubCode == 5300 || callEndReasonSubCode == 5000),
-                previousStatus == .connected {
-                return CallCompositeErrorCode.callEvicted
-            }
-        } else if callEndReasonCode > 0 {
-            if callEndReasonCode == 401 {
-                return CallCompositeErrorCode.tokenExpired
-            } else if callEndReasonCode == 487 {
-                // having "" will leave the composite
-                return ""
-            } else {
-                return previousStatus == .connected
-                ? CallCompositeErrorCode.callEnd
-                : CallCompositeErrorCode.callJoin
-            }
-        }
-
-        return ""
-    }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/CallingSDKEventsHandler.swift
@@ -150,8 +150,8 @@ extension CallingSDKEventsHandler: CallDelegate,
 
     func call(_ call: Call, didChangeState args: PropertyChangedEventArgs) {
         let currentStatus = call.state.toCallingStatus()
-        let isCallConnected = previousCallingStatus == .connected
-        let errorCode = call.callEndReason.toCompositeErrorCodeString(isCallConnected)
+        let wasCallConnected = previousCallingStatus == .connected
+        let errorCode = call.callEndReason.toCompositeErrorCodeString(wasCallConnected)
 
         let callInfoModel = CallInfoModel(status: currentStatus, errorCode: errorCode)
         callInfoSubject.send(callInfoModel)

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/Extension/ACSCallEndReasonExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/Extension/ACSCallEndReasonExtension.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AzureCommunicationCalling
+
+extension CallEndReason {
+    func toCompositeErrorCodeString(_ isCallConnected: Bool) -> String {
+        let callEndErrorCode = self.code
+        let callEndErrorSubCode = self.subcode
+
+        var compositeErrorCodeString = ""
+        switch callEndErrorCode {
+        case 0 :
+            if (callEndErrorSubCode == 5300 || callEndErrorSubCode == 5000),
+               isCallConnected {
+                compositeErrorCodeString = CallCompositeErrorCode.callEvicted
+            }
+        case 401:
+            compositeErrorCodeString = CallCompositeErrorCode.tokenExpired
+        case 487:
+            // Call cancelled by user as a happy path
+            break
+        default:
+            // For all other errorCodes:
+            // https://docs.microsoft.com/en-us/azure/communication-services/concepts/troubleshooting-info
+            compositeErrorCodeString = isCallConnected ? CallCompositeErrorCode.callEnd
+            : CallCompositeErrorCode.callJoin
+        }
+
+        return compositeErrorCodeString
+    }
+}

--- a/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/Extension/ACSCallEndReasonExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Service/Calling/Extension/ACSCallEndReasonExtension.swift
@@ -7,7 +7,7 @@ import Foundation
 import AzureCommunicationCalling
 
 extension CallEndReason {
-    func toCompositeErrorCodeString(_ isCallConnected: Bool) -> String {
+    func toCompositeErrorCodeString(_ wasCallConnected: Bool) -> String {
         let callEndErrorCode = self.code
         let callEndErrorSubCode = self.subcode
 
@@ -15,7 +15,7 @@ extension CallEndReason {
         switch callEndErrorCode {
         case 0 :
             if (callEndErrorSubCode == 5300 || callEndErrorSubCode == 5000),
-               isCallConnected {
+               wasCallConnected {
                 compositeErrorCodeString = CallCompositeErrorCode.callEvicted
             }
         case 401:
@@ -26,7 +26,7 @@ extension CallEndReason {
         default:
             // For all other errorCodes:
             // https://docs.microsoft.com/en-us/azure/communication-services/concepts/troubleshooting-info
-            compositeErrorCodeString = isCallConnected ? CallCompositeErrorCode.callEnd
+            compositeErrorCodeString = wasCallConnected ? CallCompositeErrorCode.callEnd
             : CallCompositeErrorCode.callJoin
         }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add extension of CallEndReason, to convert it into `CallCompositeErrorCode` String
* `Question`, I am thinking, why not make `CallCompositeErrorCode` as a protocol/subclass of String, therefore, we could limit the CommunicationUIErrorEvent only having the string code defined inside our library. Otherwise, it would be any string. 
* For example, for the function, `toCompositeErrorCodeString()->String`, it could return any string, and I couldn't make it return `CallCompositeErrorCode`, because `CallCompositeErrorCode` is a struct,  which may not friendly for Community contributor. cc @JoshuaLai
 
```
public struct CommunicationUIErrorEvent {
    public let code: String -> CallCompositeErrorCode
    public var error: Error?
}
``` 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

