### PR TITLE
[Refactor] Change LanguageCode string enum to CommunicationUISupportedLocale with Locale static variables

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/LocalizationConfiguration.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/LocalizationConfiguration.swift
@@ -74,7 +74,7 @@ public struct LocalizationConfiguration {
     /// Creates an instance of `LocalizationConfiguration` with related parameters. Allow
     /// overriding strings of localization keys with Localizable.strings file or other localizable filename.
     /// - Parameter locale: Locale struct representing the language identifier (ie. en, fr, fr-FR,
-    /// zh-Hant, zh-Hans, ...), with or without region. If Locale.languageCode is nil, will default to `en`.
+    /// zh-Hant, zh-Hans, ...), with or without region. If Locale identifier is not valid, will default to `en`.
     /// - Parameter localizableFilename: Filename of the `.strings` file to override predefined
     ///  Call Composite's localization key or to provide translation for an custom language.
     ///  The keys of the string should match with the keys from AzureCommunicationUI

--- a/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/LocalizationConfiguration.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/CallCompositeOptions/LocalizationConfiguration.swift
@@ -5,89 +5,71 @@
 import Foundation
 import SwiftUI
 
+/// CommunicationUISupportedLocale representing the supported locales.
+public struct CommunicationUISupportedLocale {
+    /// Chinese, Simplified
+    public static let zh = Locale(identifier: "zh")
+    /// Chinese, Simplified
+    public static let zhHans = Locale(identifier: "zh-Hans")
+    /// Chinese, Simplified (China mainland)
+    public static let zhHansCN = Locale(identifier: "zh-Hans-CN")
+    /// Chinese, Traditional
+    public static let zhHant = Locale(identifier: "zh-Hant")
+    /// Chinese, Traditional (Taiwan)
+    public static let zhHantTW = Locale(identifier: "zh-Hant-TW")
+    /// Dutch
+    public static let nl = Locale(identifier: "nl")
+    /// Dutch (Netherlands)
+    public static let nlNL = Locale(identifier: "nl-NL")
+    /// English
+    public static let en = Locale(identifier: "en")
+    /// English (United Kingdom)
+    public static let enGB = Locale(identifier: "en-GB")
+    /// English (United States)
+    public static let enUS = Locale(identifier: "en-US")
+    /// French
+    public static let fr = Locale(identifier: "fr")
+    /// French (France)
+    public static let frFR = Locale(identifier: "fr-FR")
+    /// German
+    public static let de = Locale(identifier: "de")
+    /// German (Germany)
+    public static let deDE = Locale(identifier: "de-DE")
+    /// Italian
+    public static let it = Locale(identifier: "it")
+    /// Italian (Italy)
+    public static let itIT = Locale(identifier: "it-IT")
+    /// Japanese
+    public static let ja = Locale(identifier: "ja")
+    /// Japanese (Japan)
+    public static let jaJP = Locale(identifier: "ja-JP")
+    /// Korean
+    public static let ko = Locale(identifier: "ko")
+    /// Korean (South Korea)
+    public static let koKR = Locale(identifier: "ko-KR")
+    /// Portuguese
+    public static let pt = Locale(identifier: "pt")
+    /// Portuguese (Brazil)
+    public static let ptBR = Locale(identifier: "pt-BR")
+    /// Russian
+    public static let ru = Locale(identifier: "ru")
+    /// Russian (Russia)
+    public static let ruRU = Locale(identifier: "ru-RU")
+    /// Spanish
+    public static let es = Locale(identifier: "es")
+    /// Spanish (Spain)
+    public static let esES = Locale(identifier: "es-ES")
+    /// Turkish
+    public static let tr = Locale(identifier: "tr")
+    /// Turkish (Turkey)
+    public static let trTR = Locale(identifier: "tr-TR")
+}
+
 /// A configuration to allow customizing localization.
 public struct LocalizationConfiguration {
-    /// LanguageCode enum representing the locale code.
-    public enum LanguageCode: String {
-        /// Chinese, Simplified
-        case zh = "zh"
-        /// Chinese, Simplified
-        case zhHans = "zh-Hans"
-        /// Chinese, Simplified (China mainland)
-        case zhHansCN = "zh-Hans-CN"
-        /// Chinese, Traditional
-        case zhHant = "zh-Hant"
-        /// Chinese, Traditional (Taiwan)
-        case zhHantTW = "zh-Hant-TW"
-        /// Dutch
-        case nl = "nl"
-        /// Dutch (Netherlands)
-        case nlNL = "nl-NL"
-        /// English
-        case en = "en"
-        /// English (United Kingdom)
-        case enGB = "en-GB"
-        /// English (United States)
-        case enUS = "en-US"
-        /// French
-        case fr = "fr"
-        /// French (France)
-        case frFR = "fr-FR"
-        /// German
-        case de = "de"
-        /// German (Germany)
-        case deDE = "de-DE"
-        /// Italian
-        case it = "it"
-        /// Italian (Italy)
-        case itIT = "it-IT"
-        /// Japanese
-        case ja = "ja"
-        /// Japanese (Japan)
-        case jaJP = "ja-JP"
-        /// Korean
-        case ko = "ko"
-        /// Korean (South Korea)
-        case koKR = "ko-KR"
-        /// Portuguese
-        case pt = "pt"
-        /// Portuguese (Brazil)
-        case ptBR = "pt-BR"
-        /// Russian
-        case ru = "ru"
-        /// Russian (Russia)
-        case ruRU = "ru-RU"
-        /// Spanish
-        case es = "es"
-        /// Spanish (Spain)
-        case esES = "es-ES"
-        /// Turkish
-        case tr = "tr"
-        /// Turkish (Turkey)
-        case trTR = "tr-TR"
-    }
-
     let languageCode: String
     let localizableFilename: String
     let layoutDirection: LayoutDirection
-
-    /// Creates an instance of `LocalizationConfiguration` with related parameters. Allow
-    /// overriding strings of localization keys with Localizable.strings file or other localizable filename.
-    /// - Parameter languageCode: String representing the language code with or without region
-    /// (ie. en, fr, fr-FR, zh-Hant, zh-Hans, ...)  separated by dash `-`.
-    /// - Parameter localizableFilename: Filename of the `.strings` file to override predefined
-    ///  Call Composite's localization key or to provide translation for an custom language.
-    ///  The keys of the string should match with the keys from AzureCommunicationUI
-    ///  localization keys. Default value is `"Localizable"`.
-    /// - Parameter layoutDirection: LayoutDirection for mirroring layout for right-to-left.
-    ///  Default value is `false`.
-    public init(languageCode: String,
-                localizableFilename: String = "Localizable",
-                layoutDirection: LayoutDirection = .leftToRight) {
-        self.languageCode = languageCode
-        self.localizableFilename = localizableFilename
-        self.layoutDirection = layoutDirection
-    }
 
     /// Creates an instance of `LocalizationConfiguration` with related parameters. Allow
     /// overriding strings of localization keys with Localizable.strings file or other localizable filename.
@@ -108,9 +90,10 @@ public struct LocalizationConfiguration {
     }
 
     /// Get supported languages the AzureCommunicationUICalling has predefined translations.
-    /// - Returns: Get supported languages the AzureCommunicationUICalling
+    /// - Returns: Get supported Locales the AzureCommunicationUICalling
     ///  has predefined translations.
-    public static var supportedLanguages: [String] {
+    public static var supportedLocales: [Locale] {
         return Bundle(for: CallComposite.self).localizations.sorted()
+            .map { Locale(identifier: $0) }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/Style/LocalizationProvider.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/Style/LocalizationProvider.swift
@@ -48,7 +48,7 @@ class LocalizationProvider: LocalizationProviderProtocol {
 
     func apply(localeConfig: LocalizationConfiguration) {
         if !supportedLocales.contains(localeConfig.languageCode) {
-            let warningMessage = "Language not supported by default for " +
+            let warningMessage = "Locale not supported by default for " +
             "`\(localeConfig.languageCode)`, if string for AzureCommunicationUI " +
             "localization keys not provided in custom Localizable.strings " +
             "or customString, strings will default to `en`"

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/EnvConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/EnvConfig.swift
@@ -36,7 +36,7 @@ class EnvConfigSubject: ObservableObject {
 
     @Published var selectedAcsTokenType: ACSTokenType = .token
     @Published var selectedMeetingType: MeetingType = .groupCall
-    @Published var languageCode: String = LocalizationConfiguration.LanguageCode.en.rawValue
+    @Published var locale: Locale = CommunicationUISupportedLocale.en
     @Published var localeIdentifier: String = ""
     @Published var isRightToLeft: Bool = false
     @Published var useCustomColors: Bool = false

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SettingsView.swift
@@ -41,7 +41,7 @@ struct SettingsView: View {
 
     var localizationSettings: some View {
         Section(header: Text("Localilzation")) {
-            LocalePicker(selection: $envConfigSubject.languageCode)
+            LocalePicker(selection: $envConfigSubject.locale)
             Toggle("Is Right-to-Left", isOn: $envConfigSubject.isRightToLeft)
             TextField(
                 "Locale identifier (eg. zh-Hant, fr-CA)",
@@ -85,16 +85,16 @@ struct SettingsView: View {
 }
 
 struct LocalePicker: View {
-    @Binding var selection: String
-    let supportedLanguage: [String] = ["auto"] + LocalizationConfiguration.supportedLanguages.sorted()
+    @Binding var selection: Locale
+    let supportedLanguage: [Locale] = [Locale(identifier: "")] + LocalizationConfiguration.supportedLocales
 
     var body: some View {
             Picker("Language", selection: $selection) {
                 ForEach(supportedLanguage, id: \.self) {
-                    if $0 == "auto" {
+                    if $0.identifier == "" {
                         Text("Detect locale (en, zh-Hant, fr, fr-CA)")
                     } else {
-                        Text($0)
+                        Text($0.identifier)
                     }
                 }
             }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
@@ -135,11 +135,11 @@ extension SwiftUIDemoView {
 
         var localizationConfig: LocalizationConfiguration?
         let layoutDirection: LayoutDirection = envConfigSubject.isRightToLeft ? .rightToLeft : .leftToRight
-        if envConfigSubject.localeIdentifier != "" {
+        if !envConfigSubject.localeIdentifier.isEmpty {
             let locale = Locale(identifier: envConfigSubject.localeIdentifier)
             localizationConfig = LocalizationConfiguration(locale: locale,
                                                            layoutDirection: layoutDirection)
-        } else if envConfigSubject.locale.identifier != "" {
+        } else if !envConfigSubject.locale.identifier.isEmpty {
             localizationConfig = LocalizationConfiguration(
                 locale: envConfigSubject.locale,
                 layoutDirection: layoutDirection)

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
@@ -139,9 +139,9 @@ extension SwiftUIDemoView {
             let locale = Locale(identifier: envConfigSubject.localeIdentifier)
             localizationConfig = LocalizationConfiguration(locale: locale,
                                                            layoutDirection: layoutDirection)
-        } else if envConfigSubject.languageCode != "auto" {
+        } else if envConfigSubject.locale.identifier != "" {
             localizationConfig = LocalizationConfiguration(
-                languageCode: envConfigSubject.languageCode,
+                locale: envConfigSubject.locale,
                 layoutDirection: layoutDirection)
         }
 

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
@@ -135,11 +135,11 @@ class UIKitDemoViewController: UIViewController {
     func startExperience(with link: String) {
         var localizationConfig: LocalizationConfiguration?
         let layoutDirection: LayoutDirection = envConfigSubject.isRightToLeft ? .rightToLeft : .leftToRight
-        if envConfigSubject.localeIdentifier != "" {
+        if !envConfigSubject.localeIdentifier.isEmpty {
             let locale = Locale(identifier: envConfigSubject.localeIdentifier)
             localizationConfig = LocalizationConfiguration(locale: locale,
                                                            layoutDirection: layoutDirection)
-        } else if envConfigSubject.locale.identifier != "" {
+        } else if !envConfigSubject.locale.identifier.isEmpty {
             localizationConfig = LocalizationConfiguration(
                 locale: envConfigSubject.locale,
                 layoutDirection: layoutDirection)

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
@@ -139,9 +139,9 @@ class UIKitDemoViewController: UIViewController {
             let locale = Locale(identifier: envConfigSubject.localeIdentifier)
             localizationConfig = LocalizationConfiguration(locale: locale,
                                                            layoutDirection: layoutDirection)
-        } else if envConfigSubject.languageCode != "auto" {
+        } else if envConfigSubject.locale.identifier != "" {
             localizationConfig = LocalizationConfiguration(
-                languageCode: envConfigSubject.languageCode,
+                locale: envConfigSubject.locale,
                 layoutDirection: layoutDirection)
         }
 

--- a/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Provider/LocalizationProviderTests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUITests/Presentation/Provider/LocalizationProviderTests.swift
@@ -18,9 +18,9 @@ class LocalizationProviderTests: XCTestCase {
 
     func test_localizationProvider_applyRTL_when_layoutDirectionRightToLeft_then_shouldRTLReturnTrue() {
         let sut = makeSUT()
-        let languageCode: LocalizationConfiguration.LanguageCode = .en
+        let locale: Locale = CommunicationUISupportedLocale.en
         let layoutDirection: LayoutDirection = .rightToLeft
-        let localeConfig = LocalizationConfiguration(languageCode: languageCode.rawValue,
+        let localeConfig = LocalizationConfiguration(locale: locale,
                                                      layoutDirection: layoutDirection)
         sut.apply(localeConfig: localeConfig)
         XCTAssertTrue(sut.isRightToLeft)
@@ -28,9 +28,9 @@ class LocalizationProviderTests: XCTestCase {
 
     func test_localizationProvider_applyRTL_when_layoutDirectionLeftToRight_then_shouldRTLReturnFalse() {
         let sut = makeSUT()
-        let languageCode: LocalizationConfiguration.LanguageCode = .en
+        let locale: Locale = CommunicationUISupportedLocale.en
         let layoutDirection: LayoutDirection = .leftToRight
-        let localeConfig = LocalizationConfiguration(languageCode: languageCode.rawValue,
+        let localeConfig = LocalizationConfiguration(locale: locale,
                                                      layoutDirection: layoutDirection)
         sut.apply(localeConfig: localeConfig)
         XCTAssertFalse(sut.isRightToLeft)
@@ -51,8 +51,8 @@ class LocalizationProviderTests: XCTestCase {
         let joinCallEn = "Join call"
         XCTAssertEqual(sut.getLocalizedString(key), joinCallEn)
 
-        let languageCode: LocalizationConfiguration.LanguageCode = .fr
-        let localeConfig = LocalizationConfiguration(languageCode: languageCode.rawValue)
+        let locale: Locale = CommunicationUISupportedLocale.fr
+        let localeConfig = LocalizationConfiguration(locale: locale)
         sut.apply(localeConfig: localeConfig)
 
         XCTAssertNotEqual(sut.getLocalizedString(key), joinCallEn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Updated leave call confirmation drawer. [#129](https://github.com/Azure/communication-ui-library-ios/pull/129)
 - Implemented new local participant avatar parameter into launch method. [#131](https://github.com/Azure/communication-ui-library-ios/pull/131)
 - Implemented automatic system language detection for localization. [#126](https://github.com/Azure/communication-ui-library-ios/pull/126)
-- Change `LanguageCode` to `CommunicationUISupportedLocale` to supoort both `ll` (language code) and `ll-CC` (language code with country code) format using swift `Locale` struct. [#158](https://github.com/Azure/communication-ui-library-ios/pull/133)
+- Change `LanguageCode` to `CommunicationUISupportedLocale` to support both `ll` (language code) and `ll-CC` (language code with country code) format using swift `Locale` struct. [#158](https://github.com/Azure/communication-ui-library-ios/pull/133)
 - Change initializer  `LocalizationConfiguration` to accept Locale struct. [#158](https://github.com/Azure/communication-ui-library-ios/pull/133)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Updated leave call confirmation drawer. [#129](https://github.com/Azure/communication-ui-library-ios/pull/129)
 - Implemented new local participant avatar parameter into launch method. [#131](https://github.com/Azure/communication-ui-library-ios/pull/131)
 - Implemented automatic system language detection for localization. [#126](https://github.com/Azure/communication-ui-library-ios/pull/126)
-- Updated localization language code to supoort both `ll` (language code) and `ll-CC` (language code with country code) format. [#133](https://github.com/Azure/communication-ui-library-ios/pull/133)
-- Implemented additional initializer for `LocalizationConfiguration` to accept Locale struct. [#133](https://github.com/Azure/communication-ui-library-ios/pull/133)
+- Change `LanguageCode` to `CommunicationUISupportedLocale` to supoort both `ll` (language code) and `ll-CC` (language code with country code) format using swift `Locale` struct. [#158](https://github.com/Azure/communication-ui-library-ios/pull/133)
+- Change initializer  `LocalizationConfiguration` to accept Locale struct. [#158](https://github.com/Azure/communication-ui-library-ios/pull/133)
 
 
 ### Bugs Fixed


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Change LanguageCode String enum to CommunicationUISupportedLocale with Locale static variables
* Removed LocalizationConfiguration languageCode initializer
* Refactor `supportedLanguage` to `supportedLocales` returning `[Locale]`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ x ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Localization of composite still works
* Automatic system language detection still works
* All unit test and UI test still passing

## Other Information
<!-- Add any other helpful information that may be needed here. -->