### PR TITLE
[Feature] Reduced the width of the participation banner in iPad and iPhone layout in calling view.

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
@@ -143,8 +143,10 @@ struct CallingView: View {
     var topAlertAreaView: some View {
         GeometryReader { geometry in
             let geoWidth: CGFloat = geometry.size.width
-            let infoHeaderViewWidth = min(geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding,
-                                          Constants.infoHeaderViewMaxWidth)
+            let isIpad = getSizeClass() == .ipadScreenSize
+            let widthWIthHorizontalPadding = geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding
+            let infoHeaderViewWidth = isIpad ? min(widthWIthHorizontalPadding,
+                                                   Constants.infoHeaderViewMaxWidth) : widthWIthHorizontalPadding
             VStack {
                 bannerView
                 HStack {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
@@ -7,10 +7,16 @@ import SwiftUI
 import FluentUI
 
 struct CallingView: View {
+
+    struct Constants {
+        static let infoHeaderViewHorizontalPadding: CGFloat = 8.0
+        static let infoHeaderViewMaxWidth: CGFloat = 380.0
+        static let infoHeaderViewHeight: CGFloat = 46.0
+    }
+
     @ObservedObject var viewModel: CallingViewModel
     let avatarManager: AvatarViewManagerProtocol
     let viewManager: VideoViewManager
-
     let leaveCallConfirmationListSourceView = UIView()
 
     @Environment(\.horizontalSizeClass) var widthSizeClass: UserInterfaceSizeClass?
@@ -135,11 +141,20 @@ struct CallingView: View {
     }
 
     var topAlertAreaView: some View {
-        VStack {
-            bannerView
-            infoHeaderView
-                .padding(.horizontal, 8)
-            Spacer()
+        GeometryReader { geometry in
+            let geoWidth: CGFloat = geometry.size.width
+            let infoHeaderViewWidth = min(geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding,
+                                          Constants.infoHeaderViewMaxWidth)
+            VStack {
+                bannerView
+                HStack {
+                    infoHeaderView
+                        .frame(width: infoHeaderViewWidth, height: Constants.infoHeaderViewHeight, alignment: .leading)
+                        .padding(.horizontal, Constants.infoHeaderViewHorizontalPadding)
+                    Spacer()
+                }
+                Spacer()
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Reduced the width of the participation banner in iPad and iPhone layout in calling view.
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-05-05 at 16 55 38](https://user-images.githubusercontent.com/90668345/167045801-2d2c2053-a430-4e9d-bcdf-f3a2ae45f782.png)
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-05-05 at 16 55 36](https://user-images.githubusercontent.com/90668345/167045804-91ef41b7-be68-4421-80c7-4753c6a932cd.png)

RTL
![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-05-10 at 17 27 57](https://user-images.githubusercontent.com/90668345/167747921-d93663b2-de2c-43f8-9d7d-46aed0339631.png)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Try to join a call (teams and/or groups call with up to 2 remote participant)
* Turn the participation banner on. 
* Also try to turn video on, for local or remote participant, turn on / off meeting record / transcription.
* Follow **What to Check** section below

## What to Check
Verify that the following are valid
* Check if the width of the participant banner is **up to** 380.0, width is 46.0, in portrait and landscape
* Check the position of the participant banner left edge of the calling screen (leading and top padding 8.0)

## Other Information
<!-- Add any other helpful information that may be needed here. -->