### PR TITLE
[Feature] Optimized participant grid layout in calling view on iPad (portrait and landscape)

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/Factories/CompositeViewModelFactory.swift
@@ -42,7 +42,7 @@ protocol CompositeViewModelFactoryProtocol {
                                  localUserState: LocalUserState) -> ControlBarViewModel
     func makeInfoHeaderViewModel(localUserState: LocalUserState) -> InfoHeaderViewModel
     func makeParticipantCellViewModel(participantModel: ParticipantInfoModel) -> ParticipantGridCellViewModel
-    func makeParticipantGridsViewModel() -> ParticipantGridViewModel
+    func makeParticipantGridsViewModel(isIpadInterface: Bool) -> ParticipantGridViewModel
     func makeParticipantsListViewModel(localUserState: LocalUserState) -> ParticipantsListViewModel
     func makeBannerViewModel() -> BannerViewModel
     func makeBannerTextViewModel() -> BannerTextViewModel
@@ -95,7 +95,8 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
                                              logger: logger,
                                              store: store,
                                              localizationProvider: localizationProvider,
-                                             accessibilityProvider: accessibilityProvider)
+                                             accessibilityProvider: accessibilityProvider,
+                                             isIPadInterface: UIDevice.current.userInterfaceIdiom == .pad)
             self.setupViewModel = nil
             self.callingViewModel = viewModel
             return viewModel
@@ -190,10 +191,11 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
                                      accessibilityProvider: accessibilityProvider,
                                      participantModel: participantModel)
     }
-    func makeParticipantGridsViewModel() -> ParticipantGridViewModel {
+    func makeParticipantGridsViewModel(isIpadInterface: Bool) -> ParticipantGridViewModel {
         ParticipantGridViewModel(compositeViewModelFactory: self,
                                  localizationProvider: localizationProvider,
-                                 accessibilityProvider: accessibilityProvider)
+                                 accessibilityProvider: accessibilityProvider,
+                                 isIPadInterface: isIpadInterface)
     }
 
     func makeParticipantsListViewModel(localUserState: LocalUserState) -> ParticipantsListViewModel {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -32,7 +32,8 @@ class CallingViewModel: ObservableObject {
          logger: Logger,
          store: Store<AppState>,
          localizationProvider: LocalizationProviderProtocol,
-         accessibilityProvider: AccessibilityProviderProtocol) {
+         accessibilityProvider: AccessibilityProviderProtocol,
+         isIPadInterface: Bool) {
         self.logger = logger
         self.compositeViewModelFactory = compositeViewModelFactory
         self.store = store
@@ -41,7 +42,8 @@ class CallingViewModel: ObservableObject {
         self.accessibilityProvider = accessibilityProvider
         let actionDispatch: ActionDispatch = store.dispatch
         localVideoViewModel = compositeViewModelFactory.makeLocalVideoViewModel(dispatchAction: actionDispatch)
-        participantGridsViewModel = compositeViewModelFactory.makeParticipantGridsViewModel()
+        participantGridsViewModel = compositeViewModelFactory.makeParticipantGridsViewModel(isIpadInterface:
+                                                                                                isIPadInterface)
         bannerViewModel = compositeViewModelFactory.makeBannerViewModel()
 
         infoHeaderViewModel = compositeViewModelFactory

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
@@ -25,7 +25,8 @@ struct ParticipantGridLayoutView: View {
     func  getChunkedCellViewModelArray() -> [[ParticipantGridCellViewModel]] {
         let cellCount = cellViewModels.count
         let vGridLayout = screenSize == .iphonePortraitScreenSize
-        let screenBasedRowSize = (screenSize == .ipadScreenSize && (cellCount != 4)) ? 3 : 2
+        let screenBasedRowSize = cellCount == 2 ?
+                                                1 : (screenSize == .ipadScreenSize && (cellCount != 4)) ? 3 : 2
         return cellViewModels.chunkedAndReversed(into: screenBasedRowSize,
                                                  vGridLayout: vGridLayout)
     }

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
@@ -23,9 +23,11 @@ struct ParticipantGridLayoutView: View {
     }
 
     func  getChunkedCellViewModelArray() -> [[ParticipantGridCellViewModel]] {
-        let screenBasedRowSize = screenSize == .ipadScreenSize ? 3 : 2
-        let rowSize = cellViewModels.count == 2 ? 1 : screenBasedRowSize
-        return cellViewModels.chunkedAndReversed(into: rowSize)
+        let cellCount = cellViewModels.count
+        let vGridLayout = screenSize == .iphonePortraitScreenSize
+        let screenBasedRowSize = (screenSize == .ipadScreenSize && (cellCount != 4)) ? 3 : 2
+        return cellViewModels.chunkedAndReversed(into: screenBasedRowSize,
+                                                 vGridLayout: vGridLayout)
     }
 
     var hGridLayout: some View {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridLayoutView.swift
@@ -23,7 +23,8 @@ struct ParticipantGridLayoutView: View {
     }
 
     func  getChunkedCellViewModelArray() -> [[ParticipantGridCellViewModel]] {
-        let rowSize = cellViewModels.count == 2 ? 1 : 2
+        let screenBasedRowSize = screenSize == .ipadScreenSize ? 3 : 2
+        let rowSize = cellViewModels.count == 2 ? 1 : screenBasedRowSize
         return cellViewModels.chunkedAndReversed(into: rowSize)
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
@@ -12,7 +12,7 @@ class ParticipantGridViewModel: ObservableObject {
     private let accessibilityProvider: AccessibilityProviderProtocol
     private let isIpadInterface: Bool
     private var maximumParticipantsDisplayed: Int {
-        return isIpadInterface ? 9 : 6
+        return isIpadInterface ? 12 : 6
     }
 
     private var lastUpdateTimeStamp = Date()

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
@@ -10,8 +10,10 @@ class ParticipantGridViewModel: ObservableObject {
     private let compositeViewModelFactory: CompositeViewModelFactoryProtocol
     private let localizationProvider: LocalizationProviderProtocol
     private let accessibilityProvider: AccessibilityProviderProtocol
-
-    private let maximumParticipantsDisplayed: Int = 6
+    private let isIpadInterface: Bool
+    private var maximumParticipantsDisplayed: Int {
+        return isIpadInterface ? 9 : 6
+    }
 
     private var lastUpdateTimeStamp = Date()
     private(set) var participantsCellViewModelArr: [ParticipantGridCellViewModel] = []
@@ -21,10 +23,12 @@ class ParticipantGridViewModel: ObservableObject {
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          localizationProvider: LocalizationProviderProtocol,
-         accessibilityProvider: AccessibilityProviderProtocol) {
+         accessibilityProvider: AccessibilityProviderProtocol,
+         isIPadInterface: Bool) {
         self.compositeViewModelFactory = compositeViewModelFactory
         self.localizationProvider = localizationProvider
         self.accessibilityProvider = accessibilityProvider
+        self.isIpadInterface = isIPadInterface
     }
 
     func update(callingState: CallingState,

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
@@ -20,7 +20,6 @@ extension Array {
                     let startingIdx = index - (index % size)
                     if startingIdx < index - 1 || self.count < size {
                         chunkedArray.append(Array(self[startingIdx...]))
-                    } else {
                     }
                 }
             }

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
@@ -14,7 +14,11 @@ extension Array {
             if index % size == 0, index != 0 {
                 chunkedArray.append(Array(self[(index - size)..<index]))
             } else if index == self.count {
-                chunkedArray.append(Array(self[index - 1..<index]))
+                let startingIdx = index - (index % size)
+                if startingIdx < index - 1 {
+                    chunkedArray.append(Array(self[startingIdx...]))
+                } else {
+                }
             }
         }
 

--- a/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Utilities/ArrayExtension.swift
@@ -4,7 +4,7 @@
 //
 
 extension Array {
-    func chunkedAndReversed(into size: Int) -> [[Element]] {
+    func chunkedAndReversed(into size: Int, vGridLayout: Bool = true) -> [[Element]] {
         var chunkedArray = [[Element]]()
         guard self.count > 0 else {
             return chunkedArray
@@ -14,10 +14,14 @@ extension Array {
             if index % size == 0, index != 0 {
                 chunkedArray.append(Array(self[(index - size)..<index]))
             } else if index == self.count {
-                let startingIdx = index - (index % size)
-                if startingIdx < index - 1 {
-                    chunkedArray.append(Array(self[startingIdx...]))
+                if vGridLayout {
+                    chunkedArray.append(Array(self[index - 1..<index]))
                 } else {
+                    let startingIdx = index - (index % size)
+                    if startingIdx < index - 1 || self.count < size {
+                        chunkedArray.append(Array(self[startingIdx...]))
+                    } else {
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
Optimized participant grid layout in calling view on iPad (portrait and landscape)
* Applied 3x3 grid on iPad, with exception of having `4`  remote participants (2x2 grid shown).

Portrait:

Landscape:


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test


```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Join a call, with up to 10 participants, 
* See how the grid changes as per the remote participants changes, in two orientations (portrait, landscape)
* follow **What to check section**

## What to Check
Verify that the following are valid
* on iPad checks the grid changes as per the remote participants changes described in Figma UX (link added in the ticket work item 2842671), in two orientations (portrait, landscape)
* also check the grid in iPhone in two orientations (portrait, landscape).

## Other Information
<!-- Add any other helpful information that may be needed here. -->