### PR TITLE
[Refactor] DispatchQueue.main unit test refactor for callingView and setupView

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Navigation/NavigationRouter.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Navigation/NavigationRouter.swift
@@ -25,7 +25,6 @@ class NavigationRouter: ObservableObject {
         self.logger = logger
 
         store.$state
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 self?.receive(state)
             }.store(in: &cancellables)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Navigation/NavigationRouter.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Navigation/NavigationRouter.swift
@@ -25,6 +25,7 @@ class NavigationRouter: ObservableObject {
         self.logger = logger
 
         store.$state
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 self?.receive(state)
             }.store(in: &cancellables)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -59,7 +59,6 @@ class CallingViewModel: ObservableObject {
             }, localUserState: store.state.localUserState)
 
         store.$state
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 self?.receive(state)
             }.store(in: &cancellables)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -73,7 +73,6 @@ class SetupViewModel: ObservableObject {
                                           localUserState: store.state.localUserState)
 
         store.$state
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 self?.receive(state)
             }.store(in: &cancellables)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
@@ -8,8 +8,8 @@ import FluentUI
 @testable import AzureCommunicationUICalling
 
 class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
+    let store: Store<AppState>
     private let logger: Logger
-    private let store: Store<AppState>
     private let accessibilityProvider: AccessibilityProviderProtocol
 
     var bannerTextViewModel: BannerTextViewModel?

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/BannerViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/BannerViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class BannerViewModelMocking: BannerViewModel {
-    private let updateState: ((CallingState) -> Void)?
+    var updateState: ((CallingState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          updateState: ((CallingState) -> Void)? = nil) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ControlBarViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ControlBarViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class ControlBarViewModelMocking: ControlBarViewModel {
-    private let updateState: ((LocalUserState, PermissionState) -> Void)?
+    var updateState: ((LocalUserState, PermissionState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/InfoHeaderViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/InfoHeaderViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class InfoHeaderViewModelMocking: InfoHeaderViewModel {
-    private let updateState: ((LocalUserState, RemoteParticipantsState, CallingState) -> Void)?
+    var updateState: ((LocalUserState, RemoteParticipantsState, CallingState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/LocalVideoViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/LocalVideoViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class LocalVideoViewModelMocking: LocalVideoViewModel {
-    private let updateState: ((LocalUserState) -> Void)?
+    var updateState: ((LocalUserState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ParticipantGridViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ParticipantGridViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class ParticipantGridViewModelMocking: ParticipantGridViewModel {
-    private let updateState: ((CallingState, RemoteParticipantsState) -> Void)?
+    var updateState: ((CallingState, RemoteParticipantsState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          localizationProvider: LocalizationProviderProtocol,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/PreviewAreaViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/PreviewAreaViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class PreviewAreaViewModelMocking: PreviewAreaViewModel {
-    private let updateState: ((LocalUserState, PermissionState) -> Void)?
+    var updateState: ((LocalUserState, PermissionState) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          dispatchAction: @escaping ActionDispatch,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/SetupControlBarViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/SetupControlBarViewModelMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUICalling
 
 class SetupControlBarViewModelMocking: SetupControlBarViewModel {
-    private let updateState: ((LocalUserState, PermissionState, CallingState) -> Void)?
+    var updateState: ((LocalUserState, PermissionState, CallingState) -> Void)?
     var updateIsJoinRequested: ((Bool) -> Void)?
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* remove `.receive(on: DispatchQueue.main)`
* DispatchQueue.main unit test refactor for callingView and setupView
* Refactor SUT to assign the mock viewModel object with closure for assertion to factory mocking before receive state

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* All unit test and UI test are passing, app remains functional

## Other Information
<!-- Add any other helpful information that may be needed here. -->