### PR TITLE
[Feature] Change how we set event handler

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
@@ -151,6 +151,7 @@ extension SwiftUIDemoView {
             : Theming(envConfigSubject: envConfigSubject),
             localization: localizationConfig)
         let callComposite = CallComposite(withOptions: callCompositeOptions)
+
         let didRemoteParticipantsJoin: ([CommunicationIdentifier]) -> Void = { [weak callComposite] identifiers in
             guard let composite = callComposite else {
                 return
@@ -158,7 +159,9 @@ extension SwiftUIDemoView {
 
             self.didRemoteParticipantsJoin(to: composite, identifiers: identifiers)
         }
-        callComposite.setTarget(didFail: didFail, didRemoteParticipantsJoin: didRemoteParticipantsJoin)
+        callComposite.setEventHandler(didFail: didFail)
+        callComposite.setEventHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
+
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
                                 nil:envConfigSubject.renderedDisplayName
         let persona = PersonaData(avatar: UIImage(named: envConfigSubject.avatarImageName),

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
@@ -159,8 +159,8 @@ extension SwiftUIDemoView {
 
             self.didRemoteParticipantsJoin(to: composite, identifiers: identifiers)
         }
-        callComposite.setEventHandler(didFail: didFail)
-        callComposite.setEventHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
+        callComposite.setDidFailHandler(didFail: didFail)
+        callComposite.setRemoteParticipantJoinHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
 
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
                                 nil:envConfigSubject.renderedDisplayName

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SwiftUIDemoView.swift
@@ -159,8 +159,8 @@ extension SwiftUIDemoView {
 
             self.didRemoteParticipantsJoin(to: composite, identifiers: identifiers)
         }
-        callComposite.setDidFailHandler(didFail: didFail)
-        callComposite.setRemoteParticipantJoinHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
+        callComposite.setDidFailHandler(with: didFail)
+        callComposite.setRemoteParticipantJoinHandler(with: didRemoteParticipantsJoin)
 
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
                                 nil:envConfigSubject.renderedDisplayName

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
@@ -172,8 +172,8 @@ class UIKitDemoViewController: UIViewController {
             return
         }
 
-        callComposite.setEventHandler(didFail: didFail)
-        callComposite.setEventHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
+        callComposite.setDidFailHandler(didFail: didFail)
+        callComposite.setRemoteParticipantJoinHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
         nil : envConfigSubject.renderedDisplayName
         let persona = PersonaData(avatar: UIImage(named: envConfigSubject.avatarImageName),

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
@@ -172,7 +172,8 @@ class UIKitDemoViewController: UIViewController {
             return
         }
 
-        callComposite.setTarget(didFail: didFail, didRemoteParticipantsJoin: didRemoteParticipantsJoin)
+        callComposite.setEventHandler(didFail: didFail)
+        callComposite.setEventHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
         nil : envConfigSubject.renderedDisplayName
         let persona = PersonaData(avatar: UIImage(named: envConfigSubject.avatarImageName),

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/UIKitDemoViewController.swift
@@ -172,8 +172,8 @@ class UIKitDemoViewController: UIViewController {
             return
         }
 
-        callComposite.setDidFailHandler(didFail: didFail)
-        callComposite.setRemoteParticipantJoinHandler(didRemoteParticipantJoin: didRemoteParticipantsJoin)
+        callComposite.setDidFailHandler(with: didFail)
+        callComposite.setRemoteParticipantJoinHandler(with: didRemoteParticipantsJoin)
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
         nil : envConfigSubject.renderedDisplayName
         let persona = PersonaData(avatar: UIImage(named: envConfigSubject.avatarImageName),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
@@ -34,13 +34,14 @@ public class CallComposite {
 
     /// Assign closures to execute when error event  occurs inside Call Composite.
     /// - Parameter didFailAction: The closure returning the error thrown from Call Composite.
-    public func setEventHandler(didFail didFailAction: CompositeErrorHandler?) {
+    public func setDidFailHandler(didFail didFailAction: CompositeErrorHandler?) {
         callCompositeEventsHandler.didFail = didFailAction
     }
 
     /// Assign closures to execute when participant has joined a call  inside Call Composite.
     /// - Parameter participantsJoinedAction: The closure returning identifiers for joined remote participants.
-    public func setEventHandler(didRemoteParticipantJoin participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
+    public func setRemoteParticipantJoinHandler(didRemoteParticipantJoin
+                                                participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
         callCompositeEventsHandler.didRemoteParticipantsJoin = participantsJoinedAction
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
@@ -34,14 +34,13 @@ public class CallComposite {
 
     /// Assign closures to execute when error event  occurs inside Call Composite.
     /// - Parameter didFailAction: The closure returning the error thrown from Call Composite.
-    public func setDidFailHandler(didFail didFailAction: CompositeErrorHandler?) {
+    public func setDidFailHandler(with didFailAction: CompositeErrorHandler?) {
         callCompositeEventsHandler.didFail = didFailAction
     }
 
     /// Assign closures to execute when participant has joined a call  inside Call Composite.
     /// - Parameter participantsJoinedAction: The closure returning identifiers for joined remote participants.
-    public func setRemoteParticipantJoinHandler(didRemoteParticipantJoin
-                                                participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
+    public func setRemoteParticipantJoinHandler(with participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
         callCompositeEventsHandler.didRemoteParticipantsJoin = participantsJoinedAction
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
@@ -32,12 +32,15 @@ public class CallComposite {
         localizationConfiguration = options?.localizationConfiguration
     }
 
-    /// Assign closures to execute when events occur inside Call Composite.
+    /// Assign closures to execute when error event  occurs inside Call Composite.
     /// - Parameter didFailAction: The closure returning the error thrown from Call Composite.
-    /// - Parameter participantsJoinedAction: The closure returning identifiers for joined remote participants.
-    public func setTarget(didFail didFailAction: CompositeErrorHandler?,
-                          didRemoteParticipantsJoin participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
+    public func setEventHandler(didFail didFailAction: CompositeErrorHandler?) {
         callCompositeEventsHandler.didFail = didFailAction
+    }
+
+    /// Assign closures to execute when participant has joined a call  inside Call Composite.
+    /// - Parameter participantsJoinedAction: The closure returning identifiers for joined remote participants.
+    public func setEventHandler(didRemoteParticipantJoin participantsJoinedAction: RemoteParticipantsJoinedHandler?) {
         callCompositeEventsHandler.didRemoteParticipantsJoin = participantsJoinedAction
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 ## 1.0.0-beta.3 (Upcoming)
+### Breaking Change
+- Updated CallComposite function `setTarget(didFail:)` has been renamed to `setDidFailHandler(didFail:)`
+
 ### New Features
 - Updated minimum iOS version to 14.0. [#103](https://github.com/Azure/communication-ui-library-ios/pull/103)
 - Updated leave call confirmation drawer. [#129](https://github.com/Azure/communication-ui-library-ios/pull/129)
@@ -10,7 +13,7 @@
 - Implemented additional primary color tint overrides to ThemeConfiguration
 - Implemented light/dark mode override to ThemeConfiguration
 - Implemented ability to drag the PiP around the display
-
+- Implemented new event handler to listen fo when a participant has joined the call `setRemoteParticipantJoinHandler(didRemoteParticipantJoin:)`
 
 ### Bugs Fixed
 - Fixed screen share not rendering in large screen device. [#128](https://github.com/Azure/communication-ui-library-ios/pull/128)


### PR DESCRIPTION
## Purpose
Second approach to having developers set event handlers. 
Have a new method per event handler so developers can only set but not get a reference to them .

What they will see in the IDE:
<img width="1059" alt="Screen Shot 2022-05-11 at 12 08 24 PM" src="https://user-images.githubusercontent.com/9044372/167933710-8d99fb82-310d-499d-9317-ba072b0b0f2b.png">

If developers choose to use trailing closure syntax:
<img width="703" alt="Screen Shot 2022-05-11 at 12 08 49 PM" src="https://user-images.githubusercontent.com/9044372/167933725-9ba02218-02a4-46cd-b6e9-e8a321f40340.png">

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
