### PR TITLE
[Feature] Reposition and reduced the width of the participation banner in iPad layout in calling view.

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
@@ -143,8 +143,10 @@ struct CallingView: View {
     var topAlertAreaView: some View {
         GeometryReader { geometry in
             let geoWidth: CGFloat = geometry.size.width
-            let infoHeaderViewWidth = min(geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding,
-                                          Constants.infoHeaderViewMaxWidth)
+            let isIpad = getSizeClass() == .ipadScreenSize
+            let widthWIthHorizontalPadding = geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding
+            let infoHeaderViewWidth = isIpad ? min(widthWIthHorizontalPadding,
+                                                   Constants.infoHeaderViewMaxWidth) : widthWIthHorizontalPadding
             VStack {
                 bannerView
                 HStack {

--- a/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUI/Presentation/SwiftUI/Calling/CallingView.swift
@@ -7,10 +7,16 @@ import SwiftUI
 import FluentUI
 
 struct CallingView: View {
+
+    struct Constants {
+        static let infoHeaderViewHorizontalPadding: CGFloat = 8.0
+        static let infoHeaderViewMaxWidth: CGFloat = 380.0
+        static let infoHeaderViewHeight: CGFloat = 46.0
+    }
+
     @ObservedObject var viewModel: CallingViewModel
     let avatarManager: AvatarViewManagerProtocol
     let viewManager: VideoViewManager
-
     let leaveCallConfirmationListSourceView = UIView()
 
     @Environment(\.horizontalSizeClass) var widthSizeClass: UserInterfaceSizeClass?
@@ -135,11 +141,20 @@ struct CallingView: View {
     }
 
     var topAlertAreaView: some View {
-        VStack {
-            bannerView
-            infoHeaderView
-                .padding(.horizontal, 8)
-            Spacer()
+        GeometryReader { geometry in
+            let geoWidth: CGFloat = geometry.size.width
+            let infoHeaderViewWidth = min(geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding,
+                                          Constants.infoHeaderViewMaxWidth)
+            VStack {
+                bannerView
+                HStack {
+                    infoHeaderView
+                        .frame(width: infoHeaderViewWidth, height: Constants.infoHeaderViewHeight, alignment: .leading)
+                        .padding(.horizontal, Constants.infoHeaderViewHorizontalPadding)
+                    Spacer()
+                }
+                Spacer()
+            }
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
@@ -150,6 +150,11 @@ struct CallingView: View {
             VStack {
                 bannerView
                 HStack {
+                    if isIpad {
+                        Spacer()
+                    } else {
+                        EmptyView()
+                    }
                     infoHeaderView
                         .frame(width: infoHeaderViewWidth, height: Constants.infoHeaderViewHeight, alignment: .leading)
                         .padding(.horizontal, Constants.infoHeaderViewHorizontalPadding)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
@@ -144,9 +144,9 @@ struct CallingView: View {
         GeometryReader { geometry in
             let geoWidth: CGFloat = geometry.size.width
             let isIpad = getSizeClass() == .ipadScreenSize
-            let widthWIthHorizontalPadding = geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding
-            let infoHeaderViewWidth = isIpad ? min(widthWIthHorizontalPadding,
-                                                   Constants.infoHeaderViewMaxWidth) : widthWIthHorizontalPadding
+            let widthWithoutHorizontalPadding = geoWidth - 2 * Constants.infoHeaderViewHorizontalPadding
+            let infoHeaderViewWidth = isIpad ? min(widthWithoutHorizontalPadding,
+                                                   Constants.infoHeaderViewMaxWidth) : widthWithoutHorizontalPadding
             VStack {
                 bannerView
                 HStack {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Centered the participant banner and reduced the width of the participation banner in iPad layout in calling view. (iPhone layout unchanged)

Screenshot
![Simulator Screen Shot - iPad mini (6th generation) - 2022-05-17 at 13 39 17](https://user-images.githubusercontent.com/90668345/168906054-ff1ca367-f658-4fdf-a6f7-2e39c2444462.png)
![Simulator Screen Shot - iPad mini (6th generation) - 2022-05-17 at 13 39 13](https://user-images.githubusercontent.com/90668345/168906058-02676fb7-672b-4783-9a2e-c95e26b31108.png)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
* Try to join a call (teams and/or groups call with up to 2 remote participant)
* Turn the participation banner on. 
* Also try to turn video on, for local or remote participant, turn on / off meeting record / transcription.
* Follow **What to Check** section below

## What to Check
Verify that the following are valid
* On iPad, check if the width of the participant banner is centred with fixed width 380.0, height is 46.0, in portrait and landscape
* Check the banner UX is unchanged in iPhone layout

## Other Information
<!-- Add any other helpful information that may be needed here. -->