### PR TITLE
[Refactor] AvatarManagerTest no longer load UIImage

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -15,9 +15,7 @@ class AvatarManagerTests: XCTestCase {
     }
 
     func test_avatarManager_when_setLocalAvatar_then_getLocalAvatar_returnsSameUIImage() {
-        guard let mockImage = UIImage(named: "Icon/ic_fluent_call_end_24_filled",
-                                      in: Bundle(for: CallComposite.self),
-                                      compatibleWith: nil) else {
+        guard let mockImage = UIImage.make(withColor: .red) else {
             XCTFail("UIImage does not exist")
             return
         }
@@ -34,5 +32,20 @@ class AvatarManagerTests: XCTestCase {
         return CompositeAvatarViewManager(store: mockStoreFactory.store,
                                           localSettings: mockLocalSettings)
 
+    }
+}
+
+extension UIImage {
+    static func make(withColor color: UIColor) -> UIImage? {
+        let rect = CGRect(x: 0, y: 0, width: 1, height: 1)
+        UIGraphicsBeginImageContext(rect.size)
+        guard let context = UIGraphicsGetCurrentContext() else {
+            return nil
+        }
+        context.setFillColor(color.cgColor)
+        context.fill(rect)
+        let img = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return img
     }
 }


### PR DESCRIPTION
## Purpose
AvatarManagerTest unit test no longer loads from assets. 
Instead as per suggestion, we now create a UIImage that is a 1x1 pixel with a UIColor 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
CI unit test failures will need to be validated 

## What to Check
Verify that the following are valid
CI unit test failures will need to be validated 
