### PR TITLE
[Feature] Updated setup screen UX on iPad 

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupView.swift
@@ -11,9 +11,21 @@ struct SetupView: View {
     @ObservedObject var viewModel: SetupViewModel
     let localPersonaData: CommunicationUIPersonaData?
     let viewManager: VideoViewManager
+    @Environment(\.horizontalSizeClass) var widthSizeClass: UserInterfaceSizeClass?
+    @Environment(\.verticalSizeClass) var heightSizeClass: UserInterfaceSizeClass?
+    @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
 
     let layoutSpacing: CGFloat = 24
-    let horizontalPadding: CGFloat = 16
+    var horizontalPadding: CGFloat {
+        let isIpad = getSizeClass() == .ipadScreenSize
+        let isLandscape = orientation.isLandscape
+        return isIpad ? (isLandscape ? 360 : 200 ) : 0
+    }
+    var verticalPadding: CGFloat {
+        let isIpad = getSizeClass() == .ipadScreenSize
+        let isLandscape = orientation.isLandscape
+        return isIpad ? (isLandscape ? 180 : 280 ) : 0
+    }
     let startCallButtonHeight: CGFloat = 52
     let errorHorizontalPadding: CGFloat = 8
 
@@ -34,12 +46,21 @@ struct SetupView: View {
                         .padding(.bottom)
                 }
                 .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
             }
             errorInfoView
         }
         .onAppear {
             viewModel.setupAudioPermissions()
             viewModel.setupCall()
+        }
+        .onRotate { newOrientation in
+            if newOrientation != orientation
+                && newOrientation != .unknown
+                && newOrientation != .faceDown
+                && newOrientation != .faceUp {
+                orientation = newOrientation
+            }
         }
     }
 
@@ -65,6 +86,18 @@ struct SetupView: View {
                 )
                 .accessibilityElement(children: .contain)
                 .accessibilityAddTraits(.isModal)
+        }
+    }
+    
+    private func getSizeClass() -> ScreenSizeClassType {
+        switch (widthSizeClass, heightSizeClass) {
+        case (.compact, .regular):
+            return .iphonePortraitScreenSize
+        case (.compact, .compact),
+             (.regular, .compact):
+            return .iphoneLandscapeScreenSize
+        default:
+            return .ipadScreenSize
         }
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Updated the padding of the child views in setup view to match Figma UX. 
Note: this is an iPad only UX change
![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-05-17 at 17 46 43](https://user-images.githubusercontent.com/90668345/168958101-a1397f84-2462-4312-8b51-3a59e2a36b6b.png)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
* Install the app 
* go to setup screen
* see the UX in setup screen are as per Figma, 
* follow **What to Check**

## What to Check
Verify that the following are valid
* (iPad and iPhone) check if the paddings of the setup views are as per figma in portrait, and landscape. 
* iPhone layout should be uncanged

## Other Information
<!-- Add any other helpful information that may be needed here. -->