### PR TITLE
[Refactor] Import UIKit inside FluentUI wrapper

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/AudioDevicesListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/AudioDevicesListViewController.swift
@@ -4,6 +4,7 @@
 //
 
 import FluentUI
+import UIKit
 
 class AudioDevicesListViewController: DrawerContainerViewController<AudioDevicesListCellViewModel> {
     private lazy var audioDevicesListTableView: UITableView? = {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAudioDevicesList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAudioDevicesList.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import FluentUI
+import UIKit
 
 struct CompositeAudioDevicesList: UIViewControllerRepresentable {
     @Binding var isPresented: Bool

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAudioDevicesListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAudioDevicesListCell.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import FluentUI
+import UIKit
 
 class CompositeAudioDevicesListCell: TableViewCell {
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAvatar.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeAvatar.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import FluentUI
+import UIKit
 
 struct CompositeAvatar: View {
     @Binding var displayName: String?

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeButton.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeButton.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import FluentUI
+import UIKit
 
 struct CompositeButton: UIViewRepresentable {
     let buttonStyle: FluentUI.ButtonStyle

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationList.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import FluentUI
+import UIKit
 
 struct CompositeLeaveCallConfirmationList: UIViewControllerRepresentable {
     @Binding var isPresented: Bool

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationListCell.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import FluentUI
+import UIKit
 
 class CompositeLeaveCallConfirmationListCell: TableViewCell {
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 import FluentUI
+import UIKit
 
 struct CompositeParticipantsList: UIViewControllerRepresentable {
     @Binding var isPresented: Bool

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import FluentUI
+import UIKit
 
 class CompositeParticipantsListCell: TableViewCell {
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -4,6 +4,7 @@
 //
 
 import FluentUI
+import UIKit
 
 class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelegate {
     weak var delegate: DrawerControllerDelegate?

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
@@ -4,6 +4,7 @@
 //
 
 import FluentUI
+import UIKit
 
 class LeaveCallConfirmationListViewController: DrawerContainerViewController<LeaveCallConfirmationViewModel> {
     private struct Constants {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
@@ -4,6 +4,7 @@
 //
 
 import FluentUI
+import UIKit
 
 class ParticipantsListViewController: DrawerContainerViewController<ParticipantsListCellViewModel> {
     private lazy var participantsListTableView: UITableView? = {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Style/ColorThemeProvider.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import FluentUI
+import UIKit
 
 class ColorThemeProvider {
     let colorSchemeOverride: UIUserInterfaceStyle

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Style/IconProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Style/IconProvider.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
+import UIKit
 import FluentUI
 import SwiftUI
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
*The FluentUI wrappers class used to rely on FluentUI module to import UIKit. Right now directly import the UIKit inside those classes

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

