### PR TITLE
[Feature] Add hold and resume a call when there is audio interruption

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		1F47F78726E9E18E000AE4B7 /* DrawerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F47F78626E9E18E000AE4B7 /* DrawerContainerViewController.swift */; };
 		1F48B401274879F000B6E5F9 /* DiagnosticConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F48B400274879F000B6E5F9 /* DiagnosticConfig.swift */; };
 		1F48B40327496E2800B6E5F9 /* DiagnosticConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F48B40227496E2800B6E5F9 /* DiagnosticConfigTests.swift */; };
+		1F48CF1F283447F400A44D58 /* CallingSDKWrapperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F48CF1E283447F400A44D58 /* CallingSDKWrapperProtocol.swift */; };
 		1F4A24BC26D6F5E600C11083 /* CompositeViewModelFactoryMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A24BB26D6F5E600C11083 /* CompositeViewModelFactoryMocking.swift */; };
 		1F4B0EF8269BD17600E87014 /* CompositeErrorManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B0EF7269BD17600E87014 /* CompositeErrorManagerTests.swift */; };
 		1F4B0EFA269BD3D000E87014 /* CallCompositeMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B0EF9269BD3D000E87014 /* CallCompositeMocking.swift */; };
@@ -280,6 +281,7 @@
 		1F47F78626E9E18E000AE4B7 /* DrawerContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerContainerViewController.swift; sourceTree = "<group>"; };
 		1F48B400274879F000B6E5F9 /* DiagnosticConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticConfig.swift; sourceTree = "<group>"; };
 		1F48B40227496E2800B6E5F9 /* DiagnosticConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticConfigTests.swift; sourceTree = "<group>"; };
+		1F48CF1E283447F400A44D58 /* CallingSDKWrapperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingSDKWrapperProtocol.swift; sourceTree = "<group>"; };
 		1F4A24BB26D6F5E600C11083 /* CompositeViewModelFactoryMocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeViewModelFactoryMocking.swift; sourceTree = "<group>"; };
 		1F4B0EF7269BD17600E87014 /* CompositeErrorManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeErrorManagerTests.swift; sourceTree = "<group>"; };
 		1F4B0EF9269BD3D000E87014 /* CallCompositeMocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCompositeMocking.swift; sourceTree = "<group>"; };
@@ -824,6 +826,7 @@
 				1F13D37126AB3DDB00E31666 /* Extension */,
 				1F6470A82639DCFA0008B9E9 /* CallingService.swift */,
 				1FBCB6AB2649993500F57EEA /* CallingSDKWrapper.swift */,
+				1F48CF1E283447F400A44D58 /* CallingSDKWrapperProtocol.swift */,
 				1F4B0F0426A6469F00E87014 /* RemoteParticipantsEventsAdapter.swift */,
 				1FD299652728B72B0084B9ED /* CallingSDKEventsHandler.swift */,
 			);
@@ -1660,6 +1663,7 @@
 				988799912745EABE00AA3759 /* SourceViewSpace.swift in Sources */,
 				1FBCB6B12649EB1200F57EEA /* RemoteParticipantExtension.swift in Sources */,
 				88F6EE1C2735F8E8001AD3E9 /* ErrorState.swift in Sources */,
+				1F48CF1F283447F400A44D58 /* CallingSDKWrapperProtocol.swift in Sources */,
 				1F2BEDC026328F2700D98266 /* CallingState.swift in Sources */,
 				88F6EE1A2735F5CB001AD3E9 /* ErrorReducer.swift in Sources */,
 				A874EDC626616728003C7D92 /* AppLifeCycleState.swift in Sources */,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		1F2BEDC026328F2700D98266 /* CallingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2BEDBF26328F2700D98266 /* CallingState.swift */; };
 		1F2BEDCD26329E5600D98266 /* PermissionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2BEDCC26329E5600D98266 /* PermissionAction.swift */; };
 		1F2BEDD126329E7C00D98266 /* CallingAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2BEDD026329E7C00D98266 /* CallingAction.swift */; };
+		1F3F0C65283E853800C66054 /* AudioSessionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3F0C64283E853800C66054 /* AudioSessionAction.swift */; };
+		1F3F0C67283E858600C66054 /* AudioSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3F0C66283E858600C66054 /* AudioSessionState.swift */; };
+		1F3F0C69283E860600C66054 /* AudioSessionReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3F0C68283E860600C66054 /* AudioSessionReducer.swift */; };
 		1F47F78726E9E18E000AE4B7 /* DrawerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F47F78626E9E18E000AE4B7 /* DrawerContainerViewController.swift */; };
 		1F48B401274879F000B6E5F9 /* DiagnosticConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F48B400274879F000B6E5F9 /* DiagnosticConfig.swift */; };
 		1F48B40327496E2800B6E5F9 /* DiagnosticConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F48B40227496E2800B6E5F9 /* DiagnosticConfigTests.swift */; };
@@ -278,6 +281,9 @@
 		1F2BEDBF26328F2700D98266 /* CallingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingState.swift; sourceTree = "<group>"; };
 		1F2BEDCC26329E5600D98266 /* PermissionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionAction.swift; sourceTree = "<group>"; };
 		1F2BEDD026329E7C00D98266 /* CallingAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingAction.swift; sourceTree = "<group>"; };
+		1F3F0C64283E853800C66054 /* AudioSessionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionAction.swift; sourceTree = "<group>"; };
+		1F3F0C66283E858600C66054 /* AudioSessionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioSessionState.swift; sourceTree = "<group>"; };
+		1F3F0C68283E860600C66054 /* AudioSessionReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionReducer.swift; sourceTree = "<group>"; };
 		1F47F78626E9E18E000AE4B7 /* DrawerContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerContainerViewController.swift; sourceTree = "<group>"; };
 		1F48B400274879F000B6E5F9 /* DiagnosticConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticConfig.swift; sourceTree = "<group>"; };
 		1F48B40227496E2800B6E5F9 /* DiagnosticConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticConfigTests.swift; sourceTree = "<group>"; };
@@ -702,6 +708,7 @@
 				1F13D36F26AB293700E31666 /* NavigationReducer.swift */,
 				88F6EE192735F5CB001AD3E9 /* ErrorReducer.swift */,
 				1F83813E26803ADF0096A454 /* CallingReducer.swift */,
+				1F3F0C68283E860600C66054 /* AudioSessionReducer.swift */,
 			);
 			path = Reducer;
 			sourceTree = "<group>";
@@ -709,6 +716,7 @@
 		1F2BEDBE26328EFA00D98266 /* State */ = {
 			isa = PBXGroup;
 			children = (
+				1F3F0C66283E858600C66054 /* AudioSessionState.swift */,
 				1F2BED75262F944500D98266 /* ReduxState.swift */,
 				1F2BED982631FA6C00D98266 /* PermissionState.swift */,
 				1F2BEDBF26328F2700D98266 /* CallingState.swift */,
@@ -729,6 +737,7 @@
 				1F2BEDCC26329E5600D98266 /* PermissionAction.swift */,
 				1F2BEDD026329E7C00D98266 /* CallingAction.swift */,
 				A874EDC726616792003C7D92 /* LifecycleAction.swift */,
+				1F3F0C64283E853800C66054 /* AudioSessionAction.swift */,
 				1F94DAE326740BCB00691D1E /* LocalUserAction.swift */,
 			);
 			path = Action;
@@ -1547,6 +1556,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50B390D827D976930010A2ED /* JoiningCallActivityViewModel.swift in Sources */,
+				1F3F0C67283E858600C66054 /* AudioSessionState.swift in Sources */,
 				1FBCB6B6264BA8A200F57EEA /* ParticipantGridCellViewModel.swift in Sources */,
 				1F03D3CE2638A6AE0055C456 /* CallingView.swift in Sources */,
 				1FF252D627B6F29A006A113E /* JoiningCallActivityView.swift in Sources */,
@@ -1624,6 +1634,7 @@
 				1F94DAF52677D48400691D1E /* CommunicationUIErrorEvent.swift in Sources */,
 				1F94DAE626740D4400691D1E /* AppState.swift in Sources */,
 				8815B6E227DA707B0065A184 /* LobbyOverlayViewModel.swift in Sources */,
+				1F3F0C69283E860600C66054 /* AudioSessionReducer.swift in Sources */,
 				50137D0626A7479C00AB843E /* EnvironmentValuesExtension.swift in Sources */,
 				1FD299642723345B0084B9ED /* DefaultLogger.swift in Sources */,
 				1F2BEDA92632530D00D98266 /* Action.swift in Sources */,
@@ -1667,6 +1678,7 @@
 				1F2BEDC026328F2700D98266 /* CallingState.swift in Sources */,
 				88F6EE1A2735F5CB001AD3E9 /* ErrorReducer.swift in Sources */,
 				A874EDC626616728003C7D92 /* AppLifeCycleState.swift in Sources */,
+				1F3F0C65283E853800C66054 /* AudioSessionAction.swift in Sources */,
 				A865AF0927B7116B008347B4 /* IconAndLabelConversion.swift in Sources */,
 				1F13D36C26A8B83300E31666 /* RemoteParticipantsState.swift in Sources */,
 				1FFEA01426A68D0D00E90816 /* FontExtension.swift in Sources */,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/DI/DependancyContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/DI/DependancyContainer.swift
@@ -64,6 +64,7 @@ final class DependencyContainer {
         let appStateReducer = AppStateReducer(permissionReducer: PermissionReducer(),
                                               localUserReducer: LocalUserReducer(),
                                               lifeCycleReducer: LifeCycleReducer(),
+                                              audioSessionReducer: AudioSessionReducer(),
                                               callingReducer: CallingReducer(),
                                               navigationReducer: NavigationReducer(),
                                               errorReducer: ErrorReducer())

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
@@ -55,7 +55,6 @@ class AudioSessionManager: AudioSessionManagerProtocol {
     }
 
     private func setupAudioSession() {
-
         activateAudioSessionCategory()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(handleRouteChange),
@@ -74,13 +73,16 @@ class AudioSessionManager: AudioSessionManagerProtocol {
               let interruptionType = AVAudioSession.InterruptionType(rawValue: typeValue)else {
             return
         }
+
         switch interruptionType {
         case .began:
-            <#code#>
+            store.dispatch(action: LifecycleAction.AudioInterruptionBegan())
         case .ended:
-            <#code#>
+            store.dispatch(action: LifecycleAction.AudioInterruptionEnded())
+        default:
+            break
         }
-        resumeAudioSession()
+
     }
 
     @objc func handleRouteChange(notification: Notification) {
@@ -103,33 +105,6 @@ class AudioSessionManager: AudioSessionManagerProtocol {
             try audioSession.setActive(true)
         } catch let error {
             logger.error("Failed to set audio session category:\(error.localizedDescription)")
-        }
-    }
-
-    private func resumeAudioSession() {
-        var audioDeviceType: AudioDeviceType
-        switch localUserAudioDeviceState {
-        case .receiverSelected,
-                .receiverRequested:
-            audioDeviceType = .receiver
-        case .speakerSelected,
-                .speakerRequested:
-            audioDeviceType = .speaker
-        case .headphonesSelected,
-                .headphonesRequested:
-            audioDeviceType = .headphones
-        case .bluetoothSelected,
-                .bluetoothRequested:
-            audioDeviceType = .bluetooth
-        default:
-            audioDeviceType = .receiver
-        }
-
-        activateAudioSessionCategory()
-
-        // Add a delay of setting audioDeviceType, to override the default port from setAudioSessionCategory.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.switchAudioDevice(to: audioDeviceType)
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
@@ -71,9 +71,14 @@ class AudioSessionManager: AudioSessionManagerProtocol {
     @objc func handleInterruption(notification: Notification) {
         guard let userInfo = notification.userInfo,
               let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-              let interruptionType = AVAudioSession.InterruptionType(rawValue: typeValue),
-              interruptionType == AVAudioSession.InterruptionType.ended else {
+              let interruptionType = AVAudioSession.InterruptionType(rawValue: typeValue)else {
             return
+        }
+        switch interruptionType {
+        case .began:
+            <#code#>
+        case .ended:
+            <#code#>
         }
         resumeAudioSession()
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
@@ -179,10 +179,10 @@ class AudioSessionManager: AudioSessionManagerProtocol {
 
     private func startAudioSessionDetector() {
         audioSessionDetector?.invalidate()
-        audioSessionDetector = Timer.scheduledTimer(timeInterval: 1,
-                                                    target: self,
-                                                    selector: #selector(detectAudioSessionEngage),
-                                                    userInfo: nil,
-                                                    repeats: true)
+        audioSessionDetector = Timer.scheduledTimer(withTimeInterval: 1,
+                                                    repeats: true,
+                                                    block: { [weak self] _ in
+            self?.detectAudioSessionEngage()
+        })
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
@@ -79,12 +79,9 @@ class AudioSessionManager: AudioSessionManagerProtocol {
 
         switch interruptionType {
         case .began:
-            print("-------------interrupted begin")
-
             startAudioSessionDetector()
             store.dispatch(action: AudioInterrupted())
         case .ended:
-            print("-------------interrupted end, send AudioInterruptEnded,  audioSessionState:\(audioSessionState)")
             store.dispatch(action: AudioInterruptEnded())
             audioSessionDetector?.invalidate()
         default:
@@ -168,26 +165,19 @@ class AudioSessionManager: AudioSessionManagerProtocol {
     }
 
     @objc private func detectAudioSessionEngage() {
-        print("----------detectAudioSessionEngage ")
-
         guard AVAudioSession.sharedInstance().isOtherAudioPlaying == false else {
             return
         }
 
         guard audioSessionState == .interrupted else {
-            print("----------detectAudioSessionEngage active")
-
             audioSessionDetector?.invalidate()
             return
         }
-        print("----------send action audioEngaged")
-
         store.dispatch(action: AudioEngaged())
         audioSessionDetector?.invalidate()
     }
 
     private func startAudioSessionDetector() {
-        print("----------startAudioSessionDetector")
         audioSessionDetector?.invalidate()
         audioSessionDetector = Timer.scheduledTimer(timeInterval: 1,
                                                     target: self,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AudioSessionManager.swift
@@ -73,7 +73,7 @@ class AudioSessionManager: AudioSessionManagerProtocol {
     @objc func handleInterruption(notification: Notification) {
         guard let userInfo = notification.userInfo,
               let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-              let interruptionType = AVAudioSession.InterruptionType(rawValue: typeValue)else {
+              let interruptionType = AVAudioSession.InterruptionType(rawValue: typeValue) else {
             return
         }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/AudioSessionAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/AudioSessionAction.swift
@@ -5,7 +5,6 @@
 
 import Foundation
 
-struct LifecycleAction {
-    struct ForegroundEntered: Action {}
-    struct BackgroundEntered: Action {}
-}
+struct AudioInterrupted: Action {}
+struct AudioInterruptEnded: Action {}
+struct AudioEngaged: Action {}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/CallingAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/CallingAction.swift
@@ -25,6 +25,9 @@ struct CallingAction {
     struct TranscriptionStateUpdated: Action {
         let isTranscriptionActive: Bool
     }
+
+    struct ResumeRequested: Action {}
+    struct HoldRequested: Action {}
 }
 
 struct ParticipantListUpdated: Action {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/LifecycleAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Action/LifecycleAction.swift
@@ -9,5 +9,7 @@ struct LifecycleAction {
     struct ForegroundEntered: Action {}
     struct BackgroundEntered: Action {}
 
+    struct AudioInterruptionBegan: Action {}
+    struct AudioInterruptionEnded: Action {}
     // Additional action completed
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
@@ -35,12 +35,17 @@ struct CallingMiddleware: Middleware {
                     actionHandler.requestMicrophoneMute(state: getState(), dispatch: dispatch)
                 case _ as LocalUserAction.MicrophoneOnTriggered:
                     actionHandler.requestMicrophoneUnmute(state: getState(), dispatch: dispatch)
+                case _ as PermissionAction.CameraPermissionGranted:
+                    actionHandler.onCameraPermissionIsSet(state: getState(), dispatch: dispatch)
                 case _ as LifecycleAction.BackgroundEntered:
                     actionHandler.enterBackground(state: getState(), dispatch: dispatch)
                 case _ as LifecycleAction.ForegroundEntered:
                     actionHandler.enterForeground(state: getState(), dispatch: dispatch)
-                case _ as PermissionAction.CameraPermissionGranted:
-                    actionHandler.onCameraPermissionIsSet(state: getState(), dispatch: dispatch)
+                case _ as LifecycleAction.AudioInterruptionBegan:
+                    actionHandler.holdCall(state: getState(), dispatch: dispatch)
+                case _ as LifecycleAction.AudioInterruptionEnded:
+                    actionHandler.resumeCall(state: getState(), dispatch: dispatch)
+
                 default:
                     break
                 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
@@ -23,6 +23,10 @@ struct CallingMiddleware: Middleware {
                     actionHandler.startCall(state: getState(), dispatch: dispatch)
                 case _ as CallingAction.CallEndRequested:
                     actionHandler.endCall(state: getState(), dispatch: dispatch)
+                case _ as CallingAction.HoldRequested:
+                    actionHandler.holdCall(state: getState(), dispatch: dispatch)
+                case _ as CallingAction.ResumeRequested:
+                    actionHandler.resumeCall(state: getState(), dispatch: dispatch)
                 case _ as LocalUserAction.CameraPreviewOnTriggered:
                     actionHandler.requestCameraPreviewOn(state: getState(), dispatch: dispatch)
                 case _ as LocalUserAction.CameraOnTriggered:
@@ -41,11 +45,10 @@ struct CallingMiddleware: Middleware {
                     actionHandler.enterBackground(state: getState(), dispatch: dispatch)
                 case _ as LifecycleAction.ForegroundEntered:
                     actionHandler.enterForeground(state: getState(), dispatch: dispatch)
-                case _ as LifecycleAction.AudioInterruptionBegan:
-                    actionHandler.holdCall(state: getState(), dispatch: dispatch)
-                case _ as LifecycleAction.AudioInterruptionEnded:
-                    actionHandler.resumeCall(state: getState(), dispatch: dispatch)
-
+                case _ as AudioInterrupted:
+                    actionHandler.audioSessionInterrupted(state: getState(), dispatch: dispatch)
+                case _ as AudioInterruptEnded:
+                    actionHandler.audioSessionInterruptEnded(state: getState(), dispatch: dispatch)
                 default:
                     break
                 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -10,6 +10,8 @@ protocol CallingMiddlewareHandling {
     func setupCall(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func startCall(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func endCall(state: ReduxState?, dispatch: @escaping ActionDispatch)
+    func holdCall(state: ReduxState?, dispatch: @escaping ActionDispatch)
+    func resumeCall(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func enterBackground(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func enterForeground(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func requestCameraPreviewOn(state: ReduxState?, dispatch: @escaping ActionDispatch)
@@ -95,14 +97,14 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
             .store(in: cancelBag)
     }
 
-    func beginAudioSessionInterruption(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+    func holdCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         guard let state = state as? AppState,
            state.callingState.status == .connected else {
             return
         }
 
         callingService.holdCall()
-            .sink(receiveCompletion: { [weak self] _ in
+            .sink(receiveCompletion: { _ in
 
             }, receiveValue: { _ in
                 self.subscription(dispatch: dispatch)
@@ -110,14 +112,14 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
 
     }
 
-    func endAudioSessionInterruption(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+    func resumeCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         guard let state = state as? AppState,
            state.callingState.status == .localHold else {
             return
         }
 
         callingService.resumeCall()
-            .sink(receiveCompletion: { [weak self] _ in
+            .sink(receiveCompletion: { _ in
 
             }, receiveValue: { _ in
                 self.subscription(dispatch: dispatch)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AppStateReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AppStateReducer.swift
@@ -9,6 +9,7 @@ struct AppStateReducer: Reducer {
     let permissionReducer: Reducer
     let localUserReducer: Reducer
     let lifeCycleReducer: Reducer
+    let audioSessionReducer: Reducer
     let callingReducer: Reducer
     let navigationReducer: Reducer
     let errorReducer: Reducer
@@ -16,12 +17,14 @@ struct AppStateReducer: Reducer {
     init(permissionReducer: Reducer,
          localUserReducer: Reducer,
          lifeCycleReducer: Reducer,
+         audioSessionReducer: Reducer,
          callingReducer: Reducer,
          navigationReducer: Reducer,
          errorReducer: Reducer) {
         self.permissionReducer = permissionReducer
         self.localUserReducer = localUserReducer
         self.lifeCycleReducer = lifeCycleReducer
+        self.audioSessionReducer = audioSessionReducer
         self.callingReducer = callingReducer
         self.navigationReducer = navigationReducer
         self.errorReducer = errorReducer
@@ -39,6 +42,7 @@ struct AppStateReducer: Reducer {
         var remoteParticipantState = state.remoteParticipantsState
         var navigationState = state.navigationState
         var errorState = state.errorState
+        var audioSessionState = state.audioSessionState
 
         if let newPermissionState = permissionReducer.reduce(state.permissionState, action) as? PermissionState {
             permissionState = newPermissionState
@@ -64,6 +68,10 @@ struct AppStateReducer: Reducer {
             errorState = newErrorState
         }
 
+        if let newAudioState = audioSessionReducer.reduce(state.audioSessionState, action) as? AudioSessionState {
+            audioSessionState = newAudioState
+        }
+
         switch action {
         case let action as ParticipantListUpdated:
             remoteParticipantState = RemoteParticipantsState(participantInfoList: action.participantsInfoList)
@@ -76,6 +84,7 @@ struct AppStateReducer: Reducer {
                         permissionState: permissionState,
                         localUserState: localUserState,
                         lifeCycleState: lifeCycleState,
+                        audioSessionState: audioSessionState,
                         navigationState: navigationState,
                         remoteParticipantsState: remoteParticipantState,
                         errorState: errorState)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AudioSessionReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AudioSessionReducer.swift
@@ -14,11 +14,8 @@ struct AudioSessionReducer: Reducer {
         switch action {
         case _ as AudioEngaged,
             _ as AudioInterruptEnded:
-            print("--------audioSessionStatus engaged")
             audioSessionStatus = .active
         case _ as AudioInterrupted:
-            print("--------audioSessionStatus AudioInterrupted")
-
             audioSessionStatus = .interrupted
         default:
             return audioSessionState

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AudioSessionReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/AudioSessionReducer.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+struct AudioSessionReducer: Reducer {
+    func reduce(_ state: ReduxState, _ action: Action) -> ReduxState {
+        guard let audioSessionState = state as? AudioSessionState else {
+            return state
+        }
+        var audioSessionStatus = audioSessionState.status
+        switch action {
+        case _ as AudioEngaged,
+            _ as AudioInterruptEnded:
+            print("--------audioSessionStatus engaged")
+            audioSessionStatus = .active
+        case _ as AudioInterrupted:
+            print("--------audioSessionStatus AudioInterrupted")
+
+            audioSessionStatus = .interrupted
+        default:
+            return audioSessionState
+        }
+        return AudioSessionState(status: audioSessionStatus)
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/AppState.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/AppState.swift
@@ -10,6 +10,7 @@ class AppState: ReduxState {
     let permissionState: PermissionState
     let localUserState: LocalUserState
     let lifeCycleState: LifeCycleState
+    let audioSessionState: AudioSessionState
     let remoteParticipantsState: RemoteParticipantsState
     let navigationState: NavigationState
     let errorState: ErrorState
@@ -18,6 +19,7 @@ class AppState: ReduxState {
          permissionState: PermissionState = .init(),
          localUserState: LocalUserState = .init(),
          lifeCycleState: LifeCycleState = .init(),
+         audioSessionState: AudioSessionState = .init(),
          navigationState: NavigationState = .init(),
          remoteParticipantsState: RemoteParticipantsState = .init(),
          errorState: ErrorState = .init()) {
@@ -25,6 +27,7 @@ class AppState: ReduxState {
         self.permissionState = permissionState
         self.localUserState = localUserState
         self.lifeCycleState = lifeCycleState
+        self.audioSessionState = audioSessionState
         self.navigationState = navigationState
         self.remoteParticipantsState = remoteParticipantsState
         self.errorState = errorState

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/AudioSessionState.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/AudioSessionState.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+enum AudioSessionStatus {
+    case active
+    case interrupted
+}
+
+class AudioSessionState: ReduxState {
+
+    let status: AudioSessionStatus
+
+    init(status: AudioSessionStatus = .active) {
+        self.status = status
+    }
+
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKWrapper.swift
@@ -7,27 +7,6 @@ import Foundation
 import Combine
 import AzureCommunicationCalling
 
-enum CameraDevice {
-    case front
-    case back
-}
-
-protocol CallingSDKWrapperProtocol {
-    func getRemoteParticipant(_ identifier: String) -> RemoteParticipant?
-    func startPreviewVideoStream() -> AnyPublisher<String, Error>
-    func getLocalVideoStream(_ identifier: String) -> LocalVideoStream?
-    func setupCall() -> AnyPublisher<Void, Error>
-    func startCall(isCameraPreferred: Bool, isAudioPreferred: Bool) -> AnyPublisher<Void, Error>
-    func endCall() -> AnyPublisher<Void, Error>
-    func startCallLocalVideoStream() -> AnyPublisher<String, Error>
-    func stopLocalVideoStream() -> AnyPublisher<Void, Error>
-    func switchCamera() -> AnyPublisher<CameraDevice, Error>
-    func muteLocalMic() -> AnyPublisher<Void, Error>
-    func unmuteLocalMic() -> AnyPublisher<Void, Error>
-
-    var callingEventsHandler: CallingSDKEventsHandling { get }
-}
-
 class CallingSDKWrapper: NSObject, CallingSDKWrapperProtocol {
     let callingEventsHandler: CallingSDKEventsHandling
 
@@ -234,6 +213,33 @@ class CallingSDKWrapper: NSObject, CallingSDKWrapperProtocol {
             }
         }.eraseToAnyPublisher()
     }
+
+    func holdCall() -> AnyPublisher<Void, Error> {
+        Future { promise in
+            self.call?.hold { [weak self] (error) in
+                if error != nil {
+                    self?.logger.error( "ERROR: It was not possible to hold call. \(error!)")
+                    return promise(.failure(error!))
+                }
+                self?.logger.debug("Hold Call successful")
+                promise(.success(()))
+            }
+        }.eraseToAnyPublisher()
+    }
+
+    func resumeCall() -> AnyPublisher<Void, Error> {
+        Future { promise in
+            self.call?.resume { [weak self] (error) in
+                if error != nil {
+                    self?.logger.error( "ERROR: It was not possible to resume call. \(error!)")
+                    return promise(.failure(error!))
+                }
+                self?.logger.debug("Resume Call successful")
+                promise(.success(()))
+            }
+        }.eraseToAnyPublisher()
+    }
+
 }
 
 extension CallingSDKWrapper {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKWrapperProtocol.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKWrapperProtocol.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import Combine
+import AzureCommunicationCalling
+
+enum CameraDevice {
+    case front
+    case back
+}
+
+protocol CallingSDKWrapperProtocol {
+    func getRemoteParticipant(_ identifier: String) -> RemoteParticipant?
+    func startPreviewVideoStream() -> AnyPublisher<String, Error>
+    func getLocalVideoStream(_ identifier: String) -> LocalVideoStream?
+    func setupCall() -> AnyPublisher<Void, Error>
+    func startCall(isCameraPreferred: Bool, isAudioPreferred: Bool) -> AnyPublisher<Void, Error>
+    func endCall() -> AnyPublisher<Void, Error>
+    func startCallLocalVideoStream() -> AnyPublisher<String, Error>
+    func stopLocalVideoStream() -> AnyPublisher<Void, Error>
+    func switchCamera() -> AnyPublisher<CameraDevice, Error>
+    func muteLocalMic() -> AnyPublisher<Void, Error>
+    func unmuteLocalMic() -> AnyPublisher<Void, Error>
+    func holdCall() -> AnyPublisher<Void, Error>
+    func resumeCall() -> AnyPublisher<Void, Error>
+
+    var callingEventsHandler: CallingSDKEventsHandling { get }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingService.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingService.swift
@@ -25,6 +25,9 @@ protocol CallingServiceProtocol {
 
     func muteLocalMic() -> AnyPublisher<Void, Error>
     func unmuteLocalMic() -> AnyPublisher<Void, Error>
+
+    func holdCall() -> AnyPublisher<Void, Error>
+    func resumeCall() -> AnyPublisher<Void, Error>
 }
 
 class CallingService: NSObject, CallingServiceProtocol {
@@ -86,5 +89,13 @@ class CallingService: NSObject, CallingServiceProtocol {
 
     func unmuteLocalMic() -> AnyPublisher<Void, Error> {
         return callingSDKWrapper.unmuteLocalMic()
+    }
+
+    func holdCall() -> AnyPublisher<Void, Error> {
+        return callingSDKWrapper.holdCall()
+    }
+
+    func resumeCall() -> AnyPublisher<Void, Error> {
+        return callingSDKWrapper.resumeCall()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
@@ -82,4 +82,12 @@ class CallingMiddlewareHandlerMocking: CallingMiddlewareHandling {
     func resumeCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         requestResumeCalled = true
     }
+
+    func audioSessionInterrupted(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+
+    }
+
+    func audioSessionInterruptEnded(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+
+    }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
@@ -20,6 +20,8 @@ class CallingMiddlewareHandlerMocking: CallingMiddlewareHandling {
     var requestCameraSwitchCalled: Bool = false
     var requestMicMuteCalled: Bool = false
     var requestMicUnmuteCalled: Bool = false
+    var requestHoldCalled: Bool = false
+    var requestResumeCalled: Bool = false
 
     func setupCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         setupCallWasCalled = true
@@ -71,5 +73,13 @@ class CallingMiddlewareHandlerMocking: CallingMiddlewareHandling {
 
     func requestMicrophoneUnmute(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         requestMicUnmuteCalled = true
+    }
+
+    func holdCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+        requestHoldCalled = true
+    }
+
+    func resumeCall(state: ReduxState?, dispatch: @escaping ActionDispatch) {
+        requestResumeCalled = true
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/CallingSDKWrapperMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/CallingSDKWrapperMocking.swift
@@ -34,6 +34,8 @@ class CallingSDKWrapperMocking: CallingSDKWrapperProtocol {
     var endCallCallCount: Int = 0
     var switchCameraCallCount: Int = 0
 
+    var holdCallCalled: Bool = false
+    var resumeCallCalled: Bool = false
     var muteLocalMicCalled: Bool = false
     var unmuteLocalMicCalled: Bool = false
     var startPreviewVideoStreamCalled: Bool = false
@@ -91,6 +93,28 @@ class CallingSDKWrapperMocking: CallingSDKWrapperProtocol {
         return AnyPublisher<Void, Error>.init(Result<Void, Error>.Publisher(()))
     }
 
+    func holdCall() -> AnyPublisher<Void, Error> {
+        holdCallCalled = true
+
+        return Future<Void, Error> { promise in
+            if let error = self.error {
+                return promise(.failure(error))
+            }
+            return promise(.success(()))
+        }.eraseToAnyPublisher()
+    }
+
+    func resumeCall() -> AnyPublisher<Void, Error> {
+        resumeCallCalled = true
+
+        return Future<Void, Error> { promise in
+            if let error = self.error {
+                return promise(.failure(error))
+            }
+            return promise(.success(()))
+        }.eraseToAnyPublisher()
+    }
+
     func startCallWasCalled() -> Bool {
         return startCallCallCount > 0
     }
@@ -124,4 +148,5 @@ class CallingSDKWrapperMocking: CallingSDKWrapperProtocol {
     func switchCameraWasCalled() -> Bool {
         return switchCameraCallCount > 0
     }
+
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/CallingServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/CallingServiceMocking.swift
@@ -14,6 +14,9 @@ class CallingServiceMocking: CallingServiceProtocol {
     var setupCallCalled: Bool = false
     var startCallCalled: Bool = false
     var endCallCalled: Bool = false
+    var holdCallCalled: Bool = false
+    var resumeCallCalled: Bool = false
+
     var localCameraStream: String = "MockCameraStream"
 
     var startLocalVideoStreamCalled: Bool = false
@@ -119,6 +122,28 @@ class CallingServiceMocking: CallingServiceProtocol {
                 return promise(.failure(error))
             }
             return promise(.success((self.localCameraStream)))
+        }.eraseToAnyPublisher()
+    }
+
+    func holdCall() -> AnyPublisher<Void, Error> {
+        holdCallCalled = true
+
+        return Future<Void, Error> { promise in
+            if let error = self.error {
+                return promise(.failure(error))
+            }
+            return promise(.success(()))
+        }.eraseToAnyPublisher()
+    }
+
+    func resumeCall() -> AnyPublisher<Void, Error> {
+        resumeCallCalled = true
+
+        return Future<Void, Error> { promise in
+            if let error = self.error {
+                return promise(.failure(error))
+            }
+            return promise(.success(()))
         }.eraseToAnyPublisher()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/AppStateReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/AppStateReducerTests.swift
@@ -205,12 +205,14 @@ extension AppStateReducerTests {
     func getSUT(permissionReducer: Reducer = ReducerMocking(),
                 localUserReducer: Reducer = ReducerMocking(),
                 lifeCycleReducer: Reducer = ReducerMocking(),
+                audioSessionReducer: Reducer = ReducerMocking(),
                 callingReducer: Reducer = ReducerMocking(),
                 navigationReducer: Reducer = ReducerMocking(),
                 errorReducer: Reducer = ReducerMocking()) -> AppStateReducer {
         return AppStateReducer(permissionReducer: permissionReducer,
                                localUserReducer: localUserReducer,
                                lifeCycleReducer: lifeCycleReducer,
+                               audioSessionReducer: audioSessionReducer,
                                callingReducer: callingReducer,
                                navigationReducer: navigationReducer,
                                errorReducer: errorReducer)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add holding call and resuming call with CallingSDK Api. The call state would be changed through `CallingSDKEventHandler`
* Hold the call when there is an audio session interruption, like alarm, incoming/outgoing call
* Automatically resume the call when the interruption is ended
* Remove the `resumeAudioSession` in audioSessionManager since `resumeCall` could work without it
New added state/action/logic
![image](https://user-images.githubusercontent.com/75647512/170351641-9fad0948-5845-4749-b795-a7a5d8eb235f.png)



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get into a call
* Trigger an alarm/incoming/outgoing Facetime, PSTN call , etc
* End the alarm/incoming/outgoing Facetime, PSTN call 
* It's possible that the call is still on hold
* But if the call is resumed, make sure you can hear and speak again in the group call