### PR TITLE
[Feature] Implement call denied behaviour to return to setup view

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallCompositeOptions/CommunicationUIErrorEvent.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallCompositeOptions/CommunicationUIErrorEvent.swift
@@ -18,6 +18,9 @@ public struct CallCompositeErrorCode {
 
     /// Error when a participant is evicted from the call by another participant
     static let callEvicted: String = "callEvicted"
+
+    /// Error when a participant is denied from entering the call
+    static let callDenied: String = "callDenied"
 }
 
 /// The error thrown after Call Composite launching.

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Localization/en.lproj/Localizable.strings
@@ -34,6 +34,10 @@
 "AzureCommunicationUICalling.LobbyView.Text.WaitingForHost"="Waiting for host"; // host (people not server) of a meeting
 "AzureCommunicationUICalling.LobbyView.Text.WaitingDetails"="Someone in the meeting will let you in soon";
 
+/* OnHoldView */
+"AzureCommunicationUICalling.OnHoldView.Text.OnHold"="You're on hold";
+"AzureCommunicationUICalling.OnHoldView.Button.Resume"="Resume";
+
 /* CallingView */
 "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"="Waiting for others to join";
 "AzureCommunicationUICalling.CallingView.InfoHeader.CallWith1Person"="Call with 1 person";
@@ -43,6 +47,7 @@
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.LocalParticipant"="%@ (me)"; // %@ is local participant name
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsMuted"="Muted";
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsUnmuted"="Unmuted";
+"AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold"="On hold";
 
 "AzureCommunicationUICalling.CallingView.SwitchCamera.Front"="Switch to back camera";
 "AzureCommunicationUICalling.CallingView.SwitchCamera.Back"="Switch to front camera";
@@ -89,3 +94,6 @@
 "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEnd"="You were removed from the call due to an error.";
 "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEvicted"="You were removed from the call.";
 "AzureCommunicationUICalling.SnackBar.Text.Error"="There was an error.";
+"AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallTitle"="Unable to resume call";
+"AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallSubTitle"="Your mic is in use by another app";
+"AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied"="You were denied access to the call.";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/CompositeErrorManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/CompositeErrorManager.swift
@@ -49,6 +49,7 @@ class CompositeErrorManager: ErrorManagerProtocol {
         self.error = error
         guard let eventsHandler = eventsHandler,
               error.code != CallCompositeErrorCode.callEvicted,
+              error.code != CallCompositeErrorCode.callDenied,
               let didFail = eventsHandler.didFail else {
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
@@ -47,6 +47,8 @@ class ErrorInfoViewModel: ObservableObject {
             message = localizationProvider.getLocalizedString(.snackBarErrorCallEnd)
         case CallCompositeErrorCode.callEvicted:
             message = localizationProvider.getLocalizedString(.snackBarErrorCallEvicted)
+        case CallCompositeErrorCode.callDenied:
+            message = localizationProvider.getLocalizedString(.snackBarErrorCallDenied)
         default:
             message = localizationProvider.getLocalizedString(.snackBarError)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSCallEndReasonExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSCallEndReasonExtension.swift
@@ -17,6 +17,8 @@ extension CallEndReason {
             if (callEndErrorSubCode == 5300 || callEndErrorSubCode == 5000),
                wasCallConnected {
                 compositeErrorCodeString = CallCompositeErrorCode.callEvicted
+            } else if callEndErrorSubCode == 5854 {
+                compositeErrorCodeString = CallCompositeErrorCode.callDenied
             }
         case 401:
             compositeErrorCodeString = CallCompositeErrorCode.tokenExpired

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Utilities/LocalizationKey.swift
@@ -37,6 +37,10 @@ enum LocalizationKey: String {
     case waitingForHost = "AzureCommunicationUICalling.LobbyView.Text.WaitingForHost"
     case waitingDetails = "AzureCommunicationUICalling.LobbyView.Text.WaitingDetails"
 
+    /* OnHoldView */
+    case onHoldMessage = "AzureCommunicationUICalling.OnHoldView.Text.OnHold"
+    case resume = "AzureCommunicationUICalling.OnHoldView.Button.Resume"
+
     /* CallingView */
     case callWith0Person = "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"
     case callWith1Person = "AzureCommunicationUICalling.CallingView.InfoHeader.CallWith1Person"
@@ -49,6 +53,7 @@ enum LocalizationKey: String {
             "AzureCommunicationUICalling.CallingView.ParticipantDrawer.LocalParticipant"
     case muted = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsMuted"
     case unmuted = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsUnmuted"
+    case onHold = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold"
 
     case frontCamera = "AzureCommunicationUICalling.CallingView.SwitchCamera.Front"
     case backCamera = "AzureCommunicationUICalling.CallingView.SwitchCamera.Back"
@@ -107,4 +112,8 @@ enum LocalizationKey: String {
     case snackBarErrorCallEnd = "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEnd"
     case snackBarErrorCallEvicted = "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEvicted"
     case snackBarError = "AzureCommunicationUICalling.SnackBar.Text.Error"
+    case snackBarErrorOnHoldTitle = "AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallTitle"
+    case snackBarErrorOnHoldSubtitle = "AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallSubTitle"
+    case snackBarErrorCallDenied =
+            "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied"
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -40,7 +40,7 @@ class ErrorInfoViewModelTests: XCTestCase {
         XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEnd")
     }
 
-    func test_errorInfoViewModel_update_when_errorStateCallEvictionSet_then_snackBarErrorJoinCallMessageDisplayed() {
+    func test_errorInfoViewModel_update_when_errorStateCallEvictionSet_then_snackBarErrorCallEvictedMessageDisplayed() {
         let sut = makeSUT()
         let event = CommunicationUIErrorEvent(code: CallCompositeErrorCode.callEvicted)
         let state = ErrorState(error: event, errorCategory: .callState)
@@ -48,6 +48,16 @@ class ErrorInfoViewModelTests: XCTestCase {
         sut.update(errorState: state)
         XCTAssertEqual(sut.isDisplayed, true)
         XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEvicted")
+    }
+
+    func test_errorInfoViewModel_update_when_errorStateCallDeniedSet_then_snackBarErrorCallDeniedMessageDisplayed() {
+        let sut = makeSUT()
+        let event = CommunicationUIErrorEvent(code: CallCompositeErrorCode.callDenied)
+        let state = ErrorState(error: event, errorCategory: .callState)
+
+        sut.update(errorState: state)
+        XCTAssertEqual(sut.isDisplayed, true)
+        XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied")
     }
 
     func test_errorInfoViewModel_update_when_errorTypeIsEmpty_then_isDisplayEqualFalse() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/CallingReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/CallingReducerTests.swift
@@ -153,6 +153,25 @@ class CallingReducerTests: XCTestCase {
         }
         XCTAssertEqual(resultState, expectedState)
     }
+
+    func test_callingReducer_reduce_when_callDeniedErrorAndCallReset_then_CallingStateReset() {
+        let expectedState = CallingState(status: .none,
+                                         isRecordingActive: false,
+                                         isTranscriptionActive: false)
+        let state = CallingState(status: .disconnected,
+                                 isRecordingActive: false,
+                                 isTranscriptionActive: false)
+        let action = ErrorAction.StatusErrorAndCallReset(error: CommunicationUIErrorEvent(code: "callDenied",
+                                                                          error: nil))
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        guard let resultState = resultState as? CallingState else {
+            XCTFail("Failed with state validation")
+            return
+        }
+        XCTAssertEqual(resultState, expectedState)
+    }
 }
 
 extension CallingReducerTests {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/ErrorReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/ErrorReducerTests.swift
@@ -83,6 +83,26 @@ class ErrorReducerTests: XCTestCase {
         XCTAssertEqual(errorState.errorCategory, .callState)
     }
 
+    func test_handleErrorReducer_reduce_when_statusErrorCallDeniedAndCallReset_then_returnErrorState_categoryCallState() {
+        let state = ErrorState(error: CommunicationUIErrorEvent(code: CallCompositeErrorCode.callDenied,
+                                                 error: nil),
+                               errorCategory: .callState)
+        let errorEvent = CommunicationUIErrorEvent(code: CallCompositeErrorCode.callDenied, error: nil)
+
+        let action = ErrorAction.StatusErrorAndCallReset(error: errorEvent)
+        let sut = getSUT()
+
+        let resultState = sut.reduce(state, action)
+        XCTAssertTrue(resultState is ErrorState)
+        guard let errorState = resultState as? ErrorState else {
+            XCTFail("Failed with state validation")
+            return
+        }
+
+        XCTAssertEqual(errorState.error?.code, errorEvent.code)
+        XCTAssertEqual(errorState.errorCategory, .callState)
+    }
+
     func test_handleErrorReducer_reduce_when_callStartRequested_then_cleanup() {
         let error = CommunicationUIErrorEvent(code: "", error: nil)
         let state = ErrorState(error: error,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Implement call denied behaviour to return to setup view


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* When being denied from a Teams call will return to setupView similar to call eviction behaviour

## Other Information
<!-- Add any other helpful information that may be needed here. -->
* Added localization keys for snackbar for TD translation service