### PR TITLE
[Feature] Error handling for participants view data

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import UIKit
 import AzureCommunicationCommon
 import AzureCommunicationUICalling
 
@@ -39,15 +38,9 @@ struct RemoteParticipantAvatarHelper {
             }
             let renderDisplayName = selectedAvatarName.isEmpty ? nameIdValue : "\(selectedAvatarName) \(nameIdValue)"
             let participantViewData = ParticipantViewData(avatar: avatarImage,
-                                          renderDisplayName: renderDisplayName)
-            let result = callComposite.setRemoteParticipantViewData(participantViewData,
-                                                                    for: identifier)
-            switch result {
-            case .success:
-                break
-            case .failure(let errorPart):
-                print("!!!!!! \(errorPart)")
-            }
+                                                          renderDisplayName: renderDisplayName)
+            callComposite.setRemoteParticipantViewData(participantViewData,
+                                                       for: identifier)
         }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
@@ -39,8 +39,8 @@ struct RemoteParticipantAvatarHelper {
             let renderDisplayName = selectedAvatarName.isEmpty ? nameIdValue : "\(selectedAvatarName) \(nameIdValue)"
             let participantViewData = ParticipantViewData(avatar: avatarImage,
                                                           renderDisplayName: renderDisplayName)
-            callComposite.setRemoteParticipantViewData(participantViewData,
-                                                       for: identifier)
+            callComposite.setRemoteParticipantViewData(for: identifier,
+                                                       participantViewData: participantViewData)
         }
     }
 }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import UIKit
-// import AzureCommunicationCommon
+import AzureCommunicationCommon
 import AzureCommunicationUICalling
 
 struct RemoteParticipantAvatarHelper {

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/RemoteParticipantAvatarHelper.swift
@@ -4,7 +4,8 @@
 //
 
 import Foundation
-import AzureCommunicationCommon
+import UIKit
+// import AzureCommunicationCommon
 import AzureCommunicationUICalling
 
 struct RemoteParticipantAvatarHelper {
@@ -39,7 +40,14 @@ struct RemoteParticipantAvatarHelper {
             let renderDisplayName = selectedAvatarName.isEmpty ? nameIdValue : "\(selectedAvatarName) \(nameIdValue)"
             let participantViewData = ParticipantViewData(avatar: avatarImage,
                                           renderDisplayName: renderDisplayName)
-            callComposite.setRemoteParticipantViewData(for: identifier, participantViewData: participantViewData)
+            let result = callComposite.setRemoteParticipantViewData(participantViewData,
+                                                                    for: identifier)
+            switch result {
+            case .success:
+                break
+            case .failure(let errorPart):
+                print("!!!!!! \(errorPart)")
+            }
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -230,8 +230,9 @@
 		FAC1FED027C98FC200D95845 /* BannerTextViewModelMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC1FEC927C98FC200D95845 /* BannerTextViewModelMocking.swift */; };
 		FAC3128F27F24A8B00A4F1D0 /* IconButtonViewModelMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC3128E27F24A8B00A4F1D0 /* IconButtonViewModelMocking.swift */; };
 		FAD845402819C129007DAFE1 /* RemoteParticipantsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD8453F2819C129007DAFE1 /* RemoteParticipantsManager.swift */; };
-		FAD845422819FC8E007DAFE1 /* CompositeRemoteParticipantsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD845412819FC8E007DAFE1 /* CompositeRemoteParticipantsManagerTests.swift */; };
+		FAD845422819FC8E007DAFE1 /* RemoteParticipantsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD845412819FC8E007DAFE1 /* RemoteParticipantsManagerTests.swift */; };
 		FAD845442819FFE6007DAFE1 /* CallingSDKEventsHandlerMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD845432819FFE6007DAFE1 /* CallingSDKEventsHandlerMocking.swift */; };
+		FAFA427D28380F7500053EA7 /* AvatarViewManagerMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFA427C28380F7500053EA7 /* AvatarViewManagerMocking.swift */; };
 		FB22A9D340197CA3DC74EEBB /* Pods_AzureCommunicationUICalling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C580DBF67D8B5AEF7A801F90 /* Pods_AzureCommunicationUICalling.framework */; };
 /* End PBXBuildFile section */
 
@@ -504,8 +505,9 @@
 		FAC1FEC927C98FC200D95845 /* BannerTextViewModelMocking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BannerTextViewModelMocking.swift; sourceTree = "<group>"; };
 		FAC3128E27F24A8B00A4F1D0 /* IconButtonViewModelMocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButtonViewModelMocking.swift; sourceTree = "<group>"; };
 		FAD8453F2819C129007DAFE1 /* RemoteParticipantsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteParticipantsManager.swift; sourceTree = "<group>"; };
-		FAD845412819FC8E007DAFE1 /* CompositeRemoteParticipantsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeRemoteParticipantsManagerTests.swift; sourceTree = "<group>"; };
+		FAD845412819FC8E007DAFE1 /* RemoteParticipantsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteParticipantsManagerTests.swift; sourceTree = "<group>"; };
 		FAD845432819FFE6007DAFE1 /* CallingSDKEventsHandlerMocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallingSDKEventsHandlerMocking.swift; sourceTree = "<group>"; };
+		FAFA427C28380F7500053EA7 /* AvatarViewManagerMocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AvatarViewManagerMocking.swift; path = Mocking/AvatarViewManagerMocking.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -743,7 +745,7 @@
 			children = (
 				1F4B0EF7269BD17600E87014 /* CompositeErrorManagerTests.swift */,
 				881D8F7527FCA8C4008EC897 /* AvatarManagerTests.swift */,
-				FAD845412819FC8E007DAFE1 /* CompositeRemoteParticipantsManagerTests.swift */,
+				FAD845412819FC8E007DAFE1 /* RemoteParticipantsManagerTests.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1134,6 +1136,7 @@
 				FA62233627DAD9AF008B5466 /* AccessibilityProviderMocking.swift */,
 				50B390D027D82D7E0010A2ED /* LocalizationProviderMocking.swift */,
 				FAD845432819FFE6007DAFE1 /* CallingSDKEventsHandlerMocking.swift */,
+				FAFA427C28380F7500053EA7 /* AvatarViewManagerMocking.swift */,
 			);
 			name = Mocking;
 			sourceTree = "<group>";
@@ -1484,7 +1487,7 @@
 				503E361C26CC2D0900158CB4 /* CompositeViewModelFactoryTests.swift in Sources */,
 				503300FC2706763800289BB5 /* BannerViewModelTests.swift in Sources */,
 				A869A63F26546A2E003CC4F2 /* VideoViewManagerMocking.swift in Sources */,
-				FAD845422819FC8E007DAFE1 /* CompositeRemoteParticipantsManagerTests.swift in Sources */,
+				FAD845422819FC8E007DAFE1 /* RemoteParticipantsManagerTests.swift in Sources */,
 				A830C306264C3B6400766E3D /* AppStateReducerTests.swift in Sources */,
 				88BC24C12832D29D00818446 /* AvatarManagerTests.swift in Sources */,
 				FAC1FECF27C98FC200D95845 /* InfoHeaderViewModelMocking.swift in Sources */,
@@ -1542,6 +1545,7 @@
 				5A314750E50CDF6A6F4577E5 /* GroupCallOptionsTests.swift in Sources */,
 				FAC3128F27F24A8B00A4F1D0 /* IconButtonViewModelMocking.swift in Sources */,
 				FAC1FECD27C98FC200D95845 /* ParticipantGridCellViewModelMocking.swift in Sources */,
+				FAFA427D28380F7500053EA7 /* AvatarViewManagerMocking.swift in Sources */,
 				5A31429C377C213B53F19163 /* DependencyContainerTests.swift in Sources */,
 				1F09A10426BA472A00BACED7 /* ParticipantInfoModelBuilder.swift in Sources */,
 				FAC1FECE27C98FC200D95845 /* ParticipantGridViewModelMocking.swift in Sources */,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
@@ -105,14 +105,14 @@ public class CallComposite {
     /// - Returns: The `Result` enum value with either a `Void` or an `Error`.
     @discardableResult
     public func setRemoteParticipantViewData(
-        _ participantViewData: ParticipantViewData,
-        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
+        for identifier: CommunicationIdentifier,
+        participantViewData: ParticipantViewData) -> Result<Void, CommunicationUIErrorEvent> {
         guard let avatarManager = avatarViewManager else {
             return .failure(CommunicationUIErrorEvent(code: CallCompositeErrorCode.remoteParticipantNotFound))
         }
 
-        return avatarManager.setRemoteParticipantViewData(participantViewData,
-                                                          for: identifier)
+        return avatarManager.setRemoteParticipantViewData(for: identifier,
+                                                          participantViewData: participantViewData)
     }
 
     private func setupManagers(dependencyContainer: DependencyContainer) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallComposite.swift
@@ -104,14 +104,15 @@ public class CallComposite {
     ///   This is data is not sent up to ACS.
     /// - Returns: The `Result` enum value with either a `Void` or an `Error`.
     @discardableResult
-    public func setRemoteParticipantViewData(for identifier: CommunicationIdentifier,
-                                             participantViewData: ParticipantViewData) -> Result<Void, Error> {
+    public func setRemoteParticipantViewData(
+        _ participantViewData: ParticipantViewData,
+        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
         guard let avatarManager = avatarViewManager else {
-            return .failure(CompositeError.callCompositeNotLaunched)
+            return .failure(CommunicationUIErrorEvent(code: CallCompositeErrorCode.remoteParticipantNotFound))
         }
 
-        return avatarManager.setRemoteParticipantViewData(for: identifier,
-                                                          participantViewData: participantViewData)
+        return avatarManager.setRemoteParticipantViewData(participantViewData,
+                                                          for: identifier)
     }
 
     private func setupManagers(dependencyContainer: DependencyContainer) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallCompositeOptions/CommunicationUIErrorEvent.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/CallCompositeOptions/CommunicationUIErrorEvent.swift
@@ -16,12 +16,16 @@ public struct CallCompositeErrorCode {
     /// Error when the input token is expired.
     public static let tokenExpired: String = "tokenExpired"
 
+    /// Error when the remote participant is not found in the call.
+    public static let remoteParticipantNotFound: String = "RemoteParticipantNotFound"
+
     /// Error when a participant is evicted from the call by another participant
     static let callEvicted: String = "callEvicted"
+
 }
 
 /// The error thrown after Call Composite launching.
-public struct CommunicationUIErrorEvent {
+public struct CommunicationUIErrorEvent: Error {
 
     /// The string representing the CallCompositeErrorCode.
     public let code: String

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
@@ -53,7 +53,7 @@ class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
     func setRemoteParticipantViewData(
         _ participantViewData: ParticipantViewData,
         for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
-            let participantsList = store.state.remoteParticipantsState.participantInfoList
+        let participantsList = store.state.remoteParticipantsState.participantInfoList
         guard let idStringValue = identifier.stringValue,
               participantsList.contains(where: { $0.userIdentifier == idStringValue })
         else {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
@@ -9,8 +9,8 @@ import Combine
 
 protocol AvatarViewManagerProtocol {
     func setRemoteParticipantViewData(
-        _ participantViewData: ParticipantViewData,
-        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent>
+        for identifier: CommunicationIdentifier,
+        participantViewData: ParticipantViewData) -> Result<Void, CommunicationUIErrorEvent>
 }
 
 class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
@@ -51,8 +51,8 @@ class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
     }
 
     func setRemoteParticipantViewData(
-        _ participantViewData: ParticipantViewData,
-        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
+        for identifier: CommunicationIdentifier,
+        participantViewData: ParticipantViewData) -> Result<Void, CommunicationUIErrorEvent> {
         let participantsList = store.state.remoteParticipantsState.participantInfoList
         guard let idStringValue = identifier.stringValue,
               participantsList.contains(where: { $0.userIdentifier == idStringValue })

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
@@ -8,8 +8,9 @@ import AzureCommunicationCommon
 import Combine
 
 protocol AvatarViewManagerProtocol {
-    func setRemoteParticipantViewData(for identifier: CommunicationIdentifier,
-                                      participantViewData: ParticipantViewData) -> Result<Void, Error>
+    func setRemoteParticipantViewData(
+        _ participantViewData: ParticipantViewData,
+        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent>
 }
 
 class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
@@ -49,10 +50,14 @@ class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
         }
     }
 
-    func setRemoteParticipantViewData(for identifier: CommunicationIdentifier,
-                                      participantViewData: ParticipantViewData) -> Result<Void, Error> {
-        guard let idStringValue = identifier.stringValue else {
-            return .failure(CompositeError.remoteParticipantNotFound)
+    func setRemoteParticipantViewData(
+        _ participantViewData: ParticipantViewData,
+        for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
+            let participantslist = store.state.remoteParticipantsState.participantInfoList
+        guard let idStringValue = identifier.stringValue,
+              participantslist.contains(where: { $0.userIdentifier == idStringValue })
+        else {
+            return .failure(CommunicationUIErrorEvent(code: CallCompositeErrorCode.remoteParticipantNotFound))
         }
 
         if avatarStorage.value(forKey: idStringValue) != nil {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Manager/AvatarViewManager.swift
@@ -53,9 +53,9 @@ class AvatarViewManager: AvatarViewManagerProtocol, ObservableObject {
     func setRemoteParticipantViewData(
         _ participantViewData: ParticipantViewData,
         for identifier: CommunicationIdentifier) -> Result<Void, CommunicationUIErrorEvent> {
-            let participantslist = store.state.remoteParticipantsState.participantInfoList
+            let participantsList = store.state.remoteParticipantsState.participantInfoList
         guard let idStringValue = identifier.stringValue,
-              participantslist.contains(where: { $0.userIdentifier == idStringValue })
+              participantsList.contains(where: { $0.userIdentifier == idStringValue })
         else {
             return .failure(CommunicationUIErrorEvent(code: CallCompositeErrorCode.remoteParticipantNotFound))
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/ErrorState.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/ErrorState.swift
@@ -15,8 +15,8 @@ class ErrorState: ReduxState, Equatable {
     let error: CommunicationUIErrorEvent?
     let errorCategory: ErrorCategory
 
-    public init(error: CommunicationUIErrorEvent? = nil,
-                errorCategory: ErrorCategory = .none) {
+    init(error: CommunicationUIErrorEvent? = nil,
+         errorCategory: ErrorCategory = .none) {
         self.error = error
         self.errorCategory = errorCategory
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/NavigationState.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/State/NavigationState.swift
@@ -15,7 +15,7 @@ class NavigationState: ReduxState, Equatable {
 
     let status: NavigationStatus
 
-    public init(status: NavigationStatus = .setup) {
+    init(status: NavigationStatus = .setup) {
         self.status = status
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Store.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Store.swift
@@ -8,7 +8,7 @@ import Foundation
 
 class Store<T: ReduxState>: ObservableObject {
 
-    @Published public var state: T
+    @Published var state: T
 
     private var dispatchFunction: ActionDispatch!
     private let reducer: Reducer

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Utilities/CompositeError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Utilities/CompositeError.swift
@@ -9,8 +9,6 @@ enum CompositeError: String, LocalizedError, Equatable {
 
     case invalidSDKWrapper = "InvalidSDKWrapper"
     case invalidLocalVideoStream = "InvalidLocalVideoStream"
-    case callCompositeNotLaunched = "CallCompositeNotLaunched"
-    case remoteParticipantNotFound = "RemoteParticipantNotFound"
 
     var localizedDescription: String { return NSLocalizedString(self.rawValue, comment: "") }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -46,8 +46,8 @@ class AvatarManagerTests: XCTestCase {
         mockStoreFactory.setState(AppState(remoteParticipantsState: remoteParticipantsState))
         let sut = makeSUT()
         let participantViewData = ParticipantViewData(avatar: mockImage)
-        let result = sut.setRemoteParticipantViewData(participantViewData,
-                                                      for: CommunicationUserIdentifier(participant.userIdentifier))
+        let result = sut.setRemoteParticipantViewData(for: CommunicationUserIdentifier(participant.userIdentifier),
+                                                      participantViewData: participantViewData)
         guard case .success = result else {
             XCTFail("Failed with result validation")
             return
@@ -63,8 +63,8 @@ class AvatarManagerTests: XCTestCase {
         let sut = makeSUT()
         let participantViewData = ParticipantViewData(avatar: mockImage)
         let id = UUID().uuidString
-        let result = sut.setRemoteParticipantViewData(participantViewData,
-                                                      for: CommunicationUserIdentifier(id))
+        let result = sut.setRemoteParticipantViewData(for: CommunicationUserIdentifier(id),
+                                                      participantViewData: participantViewData)
         guard case .failure(let error) = result else {
             XCTFail("Failed with result validation")
             return

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -34,16 +34,46 @@ class AvatarManagerTests: XCTestCase {
             XCTFail("UIImage does not exist")
             return
         }
+        let participant = ParticipantInfoModel(
+            displayName: "Participant 1",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier1",
+            recentSpeakingStamp: Date(),
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        let remoteParticipantsState = RemoteParticipantsState(participantInfoList: [participant],
+                                                              lastUpdateTimeStamp: Date())
+        mockStoreFactory.setState(AppState(remoteParticipantsState: remoteParticipantsState))
         let sut = makeSUT()
         let participantViewData = ParticipantViewData(avatar: mockImage)
-        let id = UUID().uuidString
-        let result = sut.setRemoteParticipantViewData(for: CommunicationUserIdentifier(id),
-                                                      participantViewData: participantViewData)
+        let result = sut.setRemoteParticipantViewData(participantViewData,
+                                                      for: CommunicationUserIdentifier(participant.userIdentifier))
         guard case .success = result else {
             XCTFail("Failed with result validation")
             return
         }
-        XCTAssertEqual(sut.avatarStorage.value(forKey: id)?.avatarImage!, mockImage)
+        XCTAssertEqual(sut.avatarStorage.value(forKey: participant.userIdentifier)?.avatarImage!, mockImage)
+    }
+
+    func test_avatarManager_setRemoteParticipantViewData_when_avatarDataSet__and_participantNotOnCall_then_participantNotFoundErrorReturned() {
+        guard let mockImage = UIImage(named: "Icon/ic_fluent_call_end_24_filled",
+                                      in: Bundle(for: CallComposite.self),
+                                      compatibleWith: nil) else {
+            XCTFail("UIImage does not exist")
+            return
+        }
+        let sut = makeSUT()
+        let participantViewData = ParticipantViewData(avatar: mockImage)
+        let id = UUID().uuidString
+        let result = sut.setRemoteParticipantViewData(participantViewData,
+                                                      for: CommunicationUserIdentifier(id))
+        guard case .failure(let error) = result else {
+            XCTFail("Failed with result validation")
+            return
+        }
+        XCTAssertEqual(error.code, CallCompositeErrorCode.remoteParticipantNotFound)
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -28,9 +28,7 @@ class AvatarManagerTests: XCTestCase {
     }
 
     func test_avatarManager_setRemoteParticipantViewData_when_personeDataSet_then_participantViewDataDataUpdated() {
-        guard let mockImage = UIImage(named: "Icon/ic_fluent_call_end_24_filled",
-                                      in: Bundle(for: CallComposite.self),
-                                      compatibleWith: nil) else {
+        guard let mockImage = UIImage.make(withColor: .red) else {
             XCTFail("UIImage does not exist")
             return
         }
@@ -58,9 +56,7 @@ class AvatarManagerTests: XCTestCase {
     }
 
     func test_avatarManager_setRemoteParticipantViewData_when_avatarDataSet__and_participantNotOnCall_then_participantNotFoundErrorReturned() {
-        guard let mockImage = UIImage(named: "Icon/ic_fluent_call_end_24_filled",
-                                      in: Bundle(for: CallComposite.self),
-                                      compatibleWith: nil) else {
+        guard let mockImage = UIImage.make(withColor: .red) else {
             XCTFail("UIImage does not exist")
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
@@ -4,10 +4,12 @@
 //
 
 import XCTest
+import AzureCommunicationCommon
 @testable import AzureCommunicationUICalling
 
-class CompositeRemoteParticipantsManagerTests: XCTestCase {
+class RemoteParticipantsManagerTests: XCTestCase {
     var sut: RemoteParticipantsManager!
+    var avatarViewManager: AvatarViewManagerMocking!
     var mockStoreFactory: StoreFactoryMocking!
     var callingSDKWrapper: CallingSDKWrapperMocking!
     var eventsHandler: CallCompositeEventsHandling!
@@ -16,28 +18,68 @@ class CompositeRemoteParticipantsManagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        sut = nil
         remoteParticipantsJoinedExpectation = XCTestExpectation(description: "DidRemoteParticipantsJoin event expectation")
         mockStoreFactory = StoreFactoryMocking()
         eventsHandler = CallCompositeEventsHandler()
         callingSDKWrapper = CallingSDKWrapperMocking()
-        eventsHandler.didRemoteParticipantsJoin = { [weak self] _ in
-            guard let self = self else {
-                return
-            }
-            // check getRemoteParticipantCallIds as there is no way to init RemoteParticipant for getRemoteParticipant func
-            XCTAssertEqual(self.callingSDKWrapper.getRemoteParticipantCallIds.sorted(),
-                           self.expectedIds.sorted())
-            self.remoteParticipantsJoinedExpectation.fulfill()
-        }
-        let avatarViewManager = AvatarViewManager(store: mockStoreFactory.store,
-                                                  localSettings: nil)
-        sut = RemoteParticipantsManager(store: mockStoreFactory.store,
-                                        callCompositeEventsHandler: eventsHandler,
-                                        callingSDKWrapper: callingSDKWrapper,
-                                        avatarViewManager: avatarViewManager)
+        avatarViewManager = AvatarViewManagerMocking(store: mockStoreFactory.store,
+                                                     localSettings: nil)
     }
 
-    func test_compositeRemoteParticipantsManager_receive_when_stateUpdated_then_didRemoteParticipantsJoinEventPosted() {
+    func test_remoteParticipantsManager_receive_when_stateUpdated_and_participantRemoved_then_avatarViewManagerUpdateStorageCalled() {
+        let storageUpdatedExpectation = XCTestExpectation(description: "AvatarViewManager storage update expectation")
+        makeSUT(isParticipantsJoinHandlerSet: false)
+        let participant1 = ParticipantInfoModel(
+            displayName: "Participant 1",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier1",
+            recentSpeakingStamp: Date(),
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        let participant2 = ParticipantInfoModel(
+            displayName: "Participant 2",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier2",
+            recentSpeakingStamp: Date(),
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        avatarViewManager.updateStorage = { ids in
+            XCTAssertEqual(ids, [participant2.userIdentifier])
+            storageUpdatedExpectation.fulfill()
+        }
+        let participants = [participant1, participant2]
+        let state = AppState(remoteParticipantsState: RemoteParticipantsState(participantInfoList: participants))
+        mockStoreFactory.setState(state)
+        let updatedState = AppState(remoteParticipantsState: RemoteParticipantsState(participantInfoList: [participant1]))
+        mockStoreFactory.setState(updatedState)
+        wait(for: [storageUpdatedExpectation], timeout: 1)
+    }
+
+    func test_remoteParticipantsManager_receive_when_stateUpdated_and_noHandlerSet_then_didRemoteParticipantsJoinEventNotPosted() {
+        makeSUT(isParticipantsJoinHandlerSet: false)
+        remoteParticipantsJoinedExpectation.isInverted = true
+        let participantInfoModel = ParticipantInfoModel(
+            displayName: "Participant 1",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier1",
+            recentSpeakingStamp: Date(),
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        expectedIds = [participantInfoModel.userIdentifier]
+        let state = AppState(remoteParticipantsState: RemoteParticipantsState(participantInfoList: [participantInfoModel]))
+        mockStoreFactory.setState(state)
+        wait(for: [remoteParticipantsJoinedExpectation], timeout: 1)
+    }
+
+    func test_remoteParticipantsManager_receive_when_stateUpdated_then_didRemoteParticipantsJoinEventPosted() {
+        makeSUT()
         let participantInfoModel = ParticipantInfoModel(
             displayName: "Participant 1",
             isSpeaking: false,
@@ -54,7 +96,8 @@ class CompositeRemoteParticipantsManagerTests: XCTestCase {
         wait(for: [remoteParticipantsJoinedExpectation], timeout: 1)
     }
 
-    func test_compositeRemoteParticipantsManager_receive_when_participantsLastUpdateTimeStampNotChanged_then_didRemoteParticipantsJoinEventNotPosted() {
+    func test_remoteParticipantsManager_receive_when_participantsLastUpdateTimeStampNotChanged_then_didRemoteParticipantsJoinEventNotPosted() {
+        makeSUT()
         let participantInfoModel = ParticipantInfoModel(
             displayName: "Participant 1",
             isSpeaking: false,
@@ -75,7 +118,8 @@ class CompositeRemoteParticipantsManagerTests: XCTestCase {
         wait(for: [remoteParticipantsJoinedExpectation], timeout: 1)
     }
 
-    func test_compositeRemoteParticipantsManager_receive_when_participantsIdsNotChanged_then_didRemoteParticipantsJoinEventIsNotPosted() {
+    func test_remoteParticipantsManager_receive_when_participantsIdsNotChanged_then_didRemoteParticipantsJoinEventIsNotPosted() {
+        makeSUT()
         let participantInfoModel = ParticipantInfoModel(
             displayName: "Participant 1",
             isSpeaking: false,
@@ -97,7 +141,8 @@ class CompositeRemoteParticipantsManagerTests: XCTestCase {
         wait(for: [remoteParticipantsJoinedExpectation], timeout: 1)
     }
 
-    func test_compositeRemoteParticipantsManager_receive_when_participantLeftCall_then_didRemoteParticipantsJoinEventIsNotPosted() {
+    func test_remoteParticipantsManager_receive_when_participantLeftCall_then_didRemoteParticipantsJoinEventIsNotPosted() {
+        makeSUT()
         var participantInfoModels: [ParticipantInfoModel] = []
         for i in 0...5 {
             participantInfoModels.append(ParticipantInfoModel(
@@ -121,5 +166,25 @@ class CompositeRemoteParticipantsManagerTests: XCTestCase {
         // final state setup
         mockStoreFactory.setState(newState)
         wait(for: [remoteParticipantsJoinedExpectation], timeout: 1)
+    }
+}
+
+extension RemoteParticipantsManagerTests {
+    func makeSUT(isParticipantsJoinHandlerSet: Bool = true) {
+        if isParticipantsJoinHandlerSet {
+            eventsHandler.didRemoteParticipantsJoin = { [weak self] _ in
+                guard let self = self else {
+                    return
+                }
+                // check getRemoteParticipantCallIds as there is no way to init RemoteParticipant for getRemoteParticipant func
+                XCTAssertEqual(self.callingSDKWrapper.getRemoteParticipantCallIds.sorted(),
+                               self.expectedIds.sorted())
+                self.remoteParticipantsJoinedExpectation.fulfill()
+            }
+        }
+        sut = RemoteParticipantsManager(store: mockStoreFactory.store,
+                                        callCompositeEventsHandler: eventsHandler,
+                                        callingSDKWrapper: callingSDKWrapper,
+                                        avatarViewManager: avatarViewManager)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/AvatarViewManagerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/AvatarViewManagerMocking.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+@testable import AzureCommunicationUICalling
+
+class AvatarViewManagerMocking: AvatarViewManager {
+    var updateStorage: (([String]) -> Void)?
+
+    override func updateStorage(with removedParticipantsIds: [String]) {
+        updateStorage?(removedParticipantsIds)
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added error handling for setting participant view data when the participant is not in a call
* Added unit tests
* Updated setRemoteParticipantViewData function signature

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Please turn on "Inject avatars" option in Settings
Call setRemoteParticipantViewData function for not existed user id
```