### PR TITLE
[Feature] CallOnHold layerView error banner/controlBar update

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Assets.xcassets/Color/ACSPrimaryColor.colorset/Contents.json
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Assets.xcassets/Color/ACSPrimaryColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.831",
-          "green" : "0.471",
-          "red" : "0.000"
+          "blue" : "0xD3",
+          "green" : "0x78",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.941",
-          "green" : "0.525",
-          "red" : "0.000"
+          "blue" : "0xEF",
+          "green" : "0x85",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/Factories/CompositeViewModelFactory.swift
@@ -33,11 +33,12 @@ protocol CompositeViewModelFactoryProtocol {
                                            title: String,
                                            isSelected: Bool,
                                            onSelectedAction: @escaping (() -> Void)) -> AudioDevicesListCellViewModel
-    func makeErrorInfoViewModel() -> ErrorInfoViewModel
+    func makeErrorInfoViewModel(title: String,
+                                subtitle: String) -> ErrorInfoViewModel
 
     // MARK: CallingViewModels
     func makeLobbyOverlayViewModel() -> LobbyOverlayViewModel
-    func makeOnHoldOverlayViewModel(resume: @escaping (() -> Void)) -> OnHoldOverlayViewModel
+    func makeOnHoldOverlayViewModel(resumeAction: @escaping (() -> Void)) -> OnHoldOverlayViewModel
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),
                                  localUserState: LocalUserState) -> ControlBarViewModel
@@ -160,8 +161,11 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
                                       onSelected: onSelectedAction)
     }
 
-    func makeErrorInfoViewModel() -> ErrorInfoViewModel {
-        ErrorInfoViewModel(localizationProvider: localizationProvider)
+    func makeErrorInfoViewModel(title: String,
+                                subtitle: String) -> ErrorInfoViewModel {
+        ErrorInfoViewModel(localizationProvider: localizationProvider,
+                           title: title,
+                           subtitle: subtitle)
     }
 
     // MARK: CallingViewModels
@@ -169,12 +173,12 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
         LobbyOverlayViewModel(localizationProvider: localizationProvider,
                               accessibilityProvider: accessibilityProvider)
     }
-    func makeOnHoldOverlayViewModel(resume: @escaping (() -> Void)) -> OnHoldOverlayViewModel {
+    func makeOnHoldOverlayViewModel(resumeAction: @escaping (() -> Void)) -> OnHoldOverlayViewModel {
         OnHoldOverlayViewModel(localizationProvider: localizationProvider,
                                compositeViewModelFactory: self,
                                logger: logger,
                                accessibilityProvider: accessibilityProvider,
-                               resume: resume)
+                               resumeAction: resumeAction)
     }
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
@@ -72,7 +72,6 @@ struct CallingView: View {
                         .accessibilityElement(children: .contain)
                         .accessibilitySortPriority(1)
                         .accessibilityHidden(viewModel.lobbyOverlayViewModel.isDisplayed)
-                    errorInfoView
                 }
                 .onAppear {
                     self.pipPosition = getInitialPipPosition(containerBounds: geometry.frame(in: .local))
@@ -154,20 +153,6 @@ struct CallingView: View {
                        avatarViewManager: avatarManager)
                 .padding(.horizontal, 8)
             Spacer()
-        }
-    }
-
-    var errorInfoView: some View {
-        VStack {
-            Spacer()
-            ErrorInfoView(viewModel: viewModel.errorInfoViewModel)
-//                .padding(EdgeInsets(top: 0,
-//                                    leading: errorHorizontalPadding,
-//                                    bottom: startCallButtonHeight + layoutSpacing,
-//                                    trailing: errorHorizontalPadding)
-//                )
-                .accessibilityElement(children: .contain)
-                .accessibilityAddTraits(.isModal)
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
@@ -129,7 +129,7 @@ class ControlBarViewModel: ObservableObject {
         audioState.operation == .pending || callingStatus == .localHold
     }
 
-    func isAudioDeviceDisable() -> Bool {
+    func isAudioDeviceDisabled() -> Bool {
         callingStatus == .localHold
     }
 
@@ -192,7 +192,7 @@ class ControlBarViewModel: ObservableObject {
                                      ? localizationProvider.getLocalizedString(.micOnAccessibilityLabel)
                                      : localizationProvider.getLocalizedString(.micOffAccessibilityLabel))
         micButtonViewModel.update(isDisabled: isMicDisabled())
-        audioDeviceButtonViewModel.update(isDisabled: isAudioDeviceDisable())
+        audioDeviceButtonViewModel.update(isDisabled: isAudioDeviceDisabled())
         let audioDeviceState = localUserState.audioState.device
         audioDeviceButtonViewModel.update(
             iconName: audioDeviceState.icon

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
@@ -21,6 +21,7 @@ class ControlBarViewModel: ObservableObject {
     var micButtonViewModel: IconButtonViewModel!
     var audioDeviceButtonViewModel: IconButtonViewModel!
     var hangUpButtonViewModel: IconButtonViewModel!
+    var callingStatus: CallingStatus = .none
     var cameraState = LocalUserState.CameraState(operation: .off,
                                                  device: .front,
                                                  transmission: .local)
@@ -121,11 +122,15 @@ class ControlBarViewModel: ObservableObject {
     }
 
     func isCameraDisabled() -> Bool {
-        cameraPermission == .denied || cameraState.operation == .pending
+        cameraPermission == .denied || cameraState.operation == .pending || callingStatus == .localHold
     }
 
     func isMicDisabled() -> Bool {
-        audioState.operation == .pending
+        audioState.operation == .pending || callingStatus == .localHold
+    }
+
+    func isAudioDeviceDisable() -> Bool {
+        callingStatus == .localHold
     }
 
     func getLeaveCallButtonViewModel() -> LeaveCallConfirmationViewModel {
@@ -166,7 +171,10 @@ class ControlBarViewModel: ObservableObject {
                                                   listItemViewModel: leaveCallConfirmationVm)
     }
 
-    func update(localUserState: LocalUserState, permissionState: PermissionState) {
+    func update(localUserState: LocalUserState,
+                permissionState: PermissionState,
+                callingState: CallingState) {
+        callingStatus = callingState.status
         if cameraPermission != permissionState.cameraPermission {
             cameraPermission = permissionState.cameraPermission
         }
@@ -184,6 +192,7 @@ class ControlBarViewModel: ObservableObject {
                                      ? localizationProvider.getLocalizedString(.micOnAccessibilityLabel)
                                      : localizationProvider.getLocalizedString(.micOffAccessibilityLabel))
         micButtonViewModel.update(isDisabled: isMicDisabled())
+        audioDeviceButtonViewModel.update(isDisabled: isAudioDeviceDisable())
         let audioDeviceState = localUserState.audioState.device
         audioDeviceButtonViewModel.update(
             iconName: audioDeviceState.icon

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
@@ -72,6 +72,8 @@ class InfoHeaderViewModel: ObservableObject {
     func update(localUserState: LocalUserState,
                 remoteParticipantsState: RemoteParticipantsState,
                 callingState: CallingState) {
+        isHoldingCall(callingState: callingState)
+
         callingStatus = callingState.status
         let newDisplayInfoHeaderValue = callingStatus != .inLobby
         if isVoiceOverEnabled && newDisplayInfoHeaderValue != shouldDisplayInfoHeader {
@@ -83,6 +85,20 @@ class InfoHeaderViewModel: ObservableObject {
         }
         participantsListViewModel.update(localUserState: localUserState,
                                          remoteParticipantsState: remoteParticipantsState)
+    }
+
+    private func isHoldingCall(callingState: CallingState) {
+        guard callingState.status == .localHold,
+              callingStatus != callingState.status else {
+
+            return
+        }
+        if isInfoHeaderDisplayed {
+            isInfoHeaderDisplayed = false
+        }
+        if isParticipantsListDisplayed {
+            isParticipantsListDisplayed = false
+        }
     }
 
     private func updateInfoLabel() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayView.swift
@@ -17,7 +17,9 @@ struct OverlayView: View {
     var body: some View {
         Color(StyleProvider.color.overlay)
             .overlay(
+                ZStack(alignment: .bottom) {
                 VStack(spacing: layoutSpacing) {
+                    Spacer()
                     Icon(name: .clock, size: iconImageSize)
                         .accessibility(hidden: true)
                     Text(viewModel.title)
@@ -30,6 +32,15 @@ struct OverlayView: View {
                     if let actionButtonViewModel = viewModel.actionButtonViewModel {
                         PrimaryButton(viewModel: actionButtonViewModel)
                             .fixedSize()
+                    }
+                    Spacer()
+                }
+                    if let errorInfoViewModel = viewModel.errorInfoViewModel {
+                        VStack {
+                            Spacer()
+                            ErrorInfoView(viewModel: errorInfoViewModel)
+                                .padding([.bottom])
+                        }
                     }
                 }.padding(.horizontal, horizontalPaddingSize)
                     .accessibilityElement(children: .combine)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayView.swift
@@ -9,8 +9,6 @@ import Combine
 
 struct OverlayView: View {
     let viewModel: OverlayViewModelProtocol
-
-    private let layoutSpacing: CGFloat = 24
     private let iconImageSize: CGFloat = 24
     private let horizontalPaddingSize: CGFloat = 16
 
@@ -18,20 +16,25 @@ struct OverlayView: View {
         Color(StyleProvider.color.overlay)
             .overlay(
                 ZStack(alignment: .bottom) {
-                VStack(spacing: layoutSpacing) {
+                VStack(spacing: 0) {
                     Spacer()
                     Icon(name: .clock, size: iconImageSize)
                         .accessibility(hidden: true)
+                        .padding(.bottom, 14)
+
                     Text(viewModel.title)
                         .font(Fonts.title2.font)
                     if let subtitle = viewModel.subtitle {
                         Text(subtitle)
                             .font(Fonts.subhead.font)
                             .multilineTextAlignment(.center)
+                            .padding(.top, 5)
+
                     }
                     if let actionButtonViewModel = viewModel.actionButtonViewModel {
                         PrimaryButton(viewModel: actionButtonViewModel)
                             .fixedSize()
+                            .padding(.top, 32)
                     }
                     Spacer()
                 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/LobbyOverlayViewModel.swift
@@ -23,8 +23,6 @@ class LobbyOverlayViewModel: OverlayViewModelProtocol {
         return localizationProvider.getLocalizedString(.waitingDetails)
     }
 
-    var actionButtonViewModel: PrimaryButtonViewModel?
-
     @Published var isDisplayed: Bool = false
 
     func update(callingStatus: CallingStatus) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
@@ -62,5 +62,9 @@ class OnHoldOverlayViewModel: OverlayViewModelProtocol, ObservableObject {
             isDisplayed = shouldDisplay
             accessibilityProvider.moveFocusToFirstElement()
         }
+
+        if !isDisplayed {
+            self.errorInfoViewModel?.dismiss()
+        }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
@@ -7,7 +7,7 @@ import Foundation
 
 class OnHoldOverlayViewModel: OverlayViewModelProtocol, ObservableObject {
     private let localizationProvider: LocalizationProviderProtocol
-    private let compositeViewModelFactory: CompositeViewModelFactory
+    private let compositeViewModelFactory: CompositeViewModelFactoryProtocol
     private let logger: Logger
     private let accessibilityProvider: AccessibilityProviderProtocol
     private var audioSessionStatus: AudioSessionStatus = .interrupted
@@ -24,7 +24,7 @@ class OnHoldOverlayViewModel: OverlayViewModelProtocol, ObservableObject {
     @Published var isDisplayed: Bool = false
 
     init(localizationProvider: LocalizationProviderProtocol,
-         compositeViewModelFactory: CompositeViewModelFactory,
+         compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,
          accessibilityProvider: AccessibilityProviderProtocol,
          resumeAction: @escaping (() -> Void)) {
@@ -40,7 +40,8 @@ class OnHoldOverlayViewModel: OverlayViewModelProtocol, ObservableObject {
         self.actionButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
             buttonStyle: .primaryFilled,
             buttonLabel: localizationProvider.getLocalizedString(.resume),
-            iconName: nil) { [weak self] in
+            iconName: nil,
+            isDisabled: false) { [weak self] in
                 guard let self = self else {
                     return
                 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OverlayViewModelProtocol.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OverlayViewModelProtocol.swift
@@ -9,5 +9,12 @@ protocol OverlayViewModelProtocol {
     var title: String { get }
     var subtitle: String? { get }
     var actionButtonViewModel: PrimaryButtonViewModel? { get }
+    var errorInfoViewModel: ErrorInfoViewModel? { get }
     var isDisplayed: Bool { get }
+}
+
+extension OverlayViewModelProtocol {
+    var subtitle: String? { return nil }
+    var actionButtonViewModel: PrimaryButtonViewModel? { return nil }
+    var errorInfoViewModel: ErrorInfoViewModel? { return nil }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -104,7 +104,8 @@ class CallingViewModel: ObservableObject {
         }
 
         controlBarViewModel.update(localUserState: state.localUserState,
-                                   permissionState: state.permissionState)
+                                   permissionState: state.permissionState,
+                                   callingState: state.callingState)
         infoHeaderViewModel.update(localUserState: state.localUserState,
                                    remoteParticipantsState: state.remoteParticipantsState,
                                    callingState: state.callingState)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -24,9 +24,8 @@ class CallingViewModel: ObservableObject {
     let localVideoViewModel: LocalVideoViewModel
     let participantGridsViewModel: ParticipantGridViewModel
     let bannerViewModel: BannerViewModel
-    let errorInfoViewModel: ErrorInfoViewModel
     let lobbyOverlayViewModel: LobbyOverlayViewModel
-    let onHoldOverlayViewModel: OnHoldOverlayViewModel
+    var onHoldOverlayViewModel: OnHoldOverlayViewModel!
     let isRightToLeft: Bool
 
     var controlBarViewModel: ControlBarViewModel!
@@ -54,14 +53,7 @@ class CallingViewModel: ObservableObject {
         localVideoViewModel = compositeViewModelFactory.makeLocalVideoViewModel(dispatchAction: dispatchAction)
         participantGridsViewModel = compositeViewModelFactory.makeParticipantGridsViewModel()
         bannerViewModel = compositeViewModelFactory.makeBannerViewModel()
-        errorInfoViewModel = compositeViewModelFactory.makeErrorInfoViewModel()
         lobbyOverlayViewModel = compositeViewModelFactory.makeLobbyOverlayViewModel()
-        onHoldOverlayViewModel = compositeViewModelFactory.makeOnHoldOverlayViewModel(resume: { [weak self] in
-            guard let self = self else {
-                return
-            }
-            self.resumeOnHold()
-        })
 
         infoHeaderViewModel = compositeViewModelFactory
             .makeInfoHeaderViewModel(localUserState: store.state.localUserState)
@@ -72,6 +64,13 @@ class CallingViewModel: ObservableObject {
                 }
                 self.endCall()
             }, localUserState: store.state.localUserState)
+
+        onHoldOverlayViewModel = compositeViewModelFactory.makeOnHoldOverlayViewModel(resumeAction: { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.resumeOnHold()
+        })
 
         store.$state
             .receive(on: DispatchQueue.main)
@@ -92,12 +91,7 @@ class CallingViewModel: ObservableObject {
     }
 
     func resumeOnHold() {
-        if store.state.audioSessionState.status == .active {
-            let action = CallingAction.ResumeRequested()
-            store.dispatch(action: action)
-        } else {
-            errorInfoViewModel.show()
-        }
+        store.dispatch(action: CallingAction.ResumeRequested())
     }
 
     func receive(_ state: AppState) {
@@ -119,7 +113,8 @@ class CallingViewModel: ObservableObject {
                                          remoteParticipantsState: state.remoteParticipantsState)
         bannerViewModel.update(callingState: state.callingState)
         lobbyOverlayViewModel.update(callingStatus: state.callingState.status)
-        onHoldOverlayViewModel.update(callingStatus: state.callingState.status)
+        onHoldOverlayViewModel.update(callingStatus: state.callingState.status,
+                                      audioSessionStatus: state.audioSessionState.status)
 
         let newIsCallConnected = state.callingState.status == .connected
         let hasRemoteParticipants = state.remoteParticipantsState.participantInfoList.count > 0

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -41,7 +41,8 @@ class SetupViewModel: ObservableObject {
 
         joiningCallActivityViewModel = compositeViewModelFactory.makeJoiningCallActivityViewModel()
 
-        errorInfoViewModel = compositeViewModelFactory.makeErrorInfoViewModel()
+        errorInfoViewModel = compositeViewModelFactory.makeErrorInfoViewModel(title: "",
+                                                                              subtitle: "")
 
         joinCallButtonViewModel = compositeViewModelFactory.makePrimaryButtonViewModel(
             buttonStyle: .primaryFilled,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoView.swift
@@ -9,16 +9,24 @@ import FluentUI
 struct ErrorInfoView: View {
     @ObservedObject var viewModel: ErrorInfoViewModel
 
-    private let cornerRadius: CGFloat = 4
+    private let cornerRadius: CGFloat = 12
 
     var body: some View {
         if viewModel.isDisplayed {
             HStack {
-                Text(viewModel.message)
-                    .padding([.top, .leading, .bottom])
-                    .font(Fonts.footnote.font)
-                    .foregroundColor(Color(StyleProvider.color.onWarning))
-                    .accessibilitySortPriority(1)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(viewModel.title)
+                        .font(Fonts.button1.font)
+                        .foregroundColor(Color(StyleProvider.color.onWarning))
+                        .accessibilitySortPriority(1)
+
+                    if !viewModel.subtitle.isEmpty {
+                        Text(viewModel.subtitle)
+                            .font(Fonts.subhead.font)
+                            .foregroundColor(Color(StyleProvider.color.onWarning))
+                            .accessibilitySortPriority(2)
+                    }
+                }.padding([.top, .leading, .bottom])
                 Spacer()
                 Button(action: viewModel.dismiss) {
                     Text(viewModel.dismissContent)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
@@ -8,13 +8,18 @@ import Combine
 
 class ErrorInfoViewModel: ObservableObject {
     @Published private(set) var isDisplayed: Bool = false
-    @Published private(set) var message: String = ""
+    @Published private(set) var title: String
+    @Published private(set) var subtitle: String
 
     private let localizationProvider: LocalizationProviderProtocol
     private var previousErrorType: String = ""
 
-    init(localizationProvider: LocalizationProviderProtocol) {
+    init(localizationProvider: LocalizationProviderProtocol,
+         title: String = "",
+         subtitle: String = "") {
         self.localizationProvider = localizationProvider
+        self.title = title
+        self.subtitle = subtitle
     }
 
     var dismissContent: String {
@@ -50,15 +55,15 @@ class ErrorInfoViewModel: ObservableObject {
         isDisplayed = true
         switch errorState.error?.code {
         case CallCompositeErrorCode.callJoin:
-            message = localizationProvider.getLocalizedString(.snackBarErrorJoinCall)
+            title = localizationProvider.getLocalizedString(.snackBarErrorJoinCall)
         case CallCompositeErrorCode.callEnd:
-            message = localizationProvider.getLocalizedString(.snackBarErrorCallEnd)
+            title = localizationProvider.getLocalizedString(.snackBarErrorCallEnd)
         case CallCompositeErrorCode.callEvicted:
-            message = localizationProvider.getLocalizedString(.snackBarErrorCallEvicted)
+            title = localizationProvider.getLocalizedString(.snackBarErrorCallEvicted)
         case CallCompositeErrorCode.callDenied:
-            message = localizationProvider.getLocalizedString(.snackBarErrorCallDenied)
+            title = localizationProvider.getLocalizedString(.snackBarErrorCallDenied)
         default:
-            message = localizationProvider.getLocalizedString(.snackBarError)
+            title = localizationProvider.getLocalizedString(.snackBarError)
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
@@ -8,6 +8,7 @@ import FluentUI
 @testable import AzureCommunicationUICalling
 
 class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
+
     private let logger: Logger
     private let store: Store<AppState>
     private let accessibilityProvider: AccessibilityProviderProtocol
@@ -108,8 +109,11 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
                                                                       localizationProvider: LocalizationProviderMocking())
     }
 
-    func makeErrorInfoViewModel() -> ErrorInfoViewModel {
-        return errorInfoViewModel ?? ErrorInfoViewModel(localizationProvider: LocalizationProviderMocking())
+    func makeErrorInfoViewModel(title: String,
+                                subtitle: String) -> ErrorInfoViewModel {
+        return errorInfoViewModel ?? ErrorInfoViewModel(localizationProvider: LocalizationProviderMocking(),
+                                                        title: title,
+                                                        subtitle: title)
     }
 
     func makeAudioDevicesListCellViewModel(icon: CompositeIcon,
@@ -124,8 +128,9 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     // MARK: CallingViewModels
     func makeLobbyOverlayViewModel() -> LobbyOverlayViewModel {
-        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: LocalizationProviderMocking())
+        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: LocalizationProviderMocking(), accessibilityProvider: AccessibilityProviderMocking())
     }
+
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),
                                  localUserState: LocalUserState) -> ControlBarViewModel {
@@ -200,5 +205,13 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     func makeJoiningCallActivityViewModel() -> JoiningCallActivityViewModel {
         JoiningCallActivityViewModel(localizationProvider: LocalizationProviderMocking())
+    }
+
+    func makeOnHoldOverlayViewModel(resumeAction: @escaping (() -> Void)) -> OnHoldOverlayViewModel {
+        return OnHoldOverlayViewModel(localizationProvider: LocalizationProviderMocking(),
+                                      compositeViewModelFactory: self,
+                                      logger: LoggerMocking(),
+                                      accessibilityProvider: AccessibilityProviderMocking(),
+                                      resumeAction: {})
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
@@ -128,7 +128,8 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     // MARK: CallingViewModels
     func makeLobbyOverlayViewModel() -> LobbyOverlayViewModel {
-        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: LocalizationProviderMocking(), accessibilityProvider: AccessibilityProviderMocking())
+        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: LocalizationProviderMocking(),
+                                                              accessibilityProvider: accessibilityProvider)
     }
 
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ControlBarViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ControlBarViewModelMocking.swift
@@ -25,7 +25,9 @@ class ControlBarViewModelMocking: ControlBarViewModel {
                    localUserState: localUserState)
     }
 
-    override func update(localUserState: LocalUserState, permissionState: PermissionState) {
+    override func update(localUserState: LocalUserState,
+                         permissionState: PermissionState,
+                         callingState: CallingState) {
         updateState?(localUserState, permissionState)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
@@ -173,7 +173,9 @@ class CallingViewModelTests: XCTestCase {
 extension CallingViewModelTests {
     func makeSUT(storeFactory: StoreFactoryMocking = StoreFactoryMocking(),
                  accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProvider()) -> CallingViewModel {
-        let factoryMocking = CompositeViewModelFactoryMocking(logger: logger, store: storeFactory.store)
+        let factoryMocking = CompositeViewModelFactoryMocking(logger: logger,
+                                                              store: storeFactory.store,
+                                                              accessibilityProvider: accessibilityProvider)
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
@@ -41,23 +41,23 @@ class CallingViewModelTests: XCTestCase {
         let sut = makeSUT()
         let appState = AppState(callingState: CallingState(status: .inLobby))
         sut.receive(appState)
-        XCTAssert(sut.isLobbyOverlayDisplayed)
+        XCTAssert(sut.lobbyOverlayViewModel.isDisplayed)
     }
 
     func test_callingViewModel_update_when_callStatusIsConnected_then_isLobbyOverlayDisplayed_shouldBecomeFalse() {
         let sut = makeSUT()
         let appState = AppState(callingState: CallingState(status: .connected))
         sut.receive(appState)
-        XCTAssertFalse(sut.isLobbyOverlayDisplayed)
+        XCTAssertFalse(sut.lobbyOverlayViewModel.isDisplayed)
     }
 
     func test_callingViewModel_update_when_lifeCycleStateIsBackground_callStatusIsInLobby_then_isLobbyOverlayDisplayed_shouldKeepSame() {
         let sut = makeSUT()
-        let originalState = sut.isLobbyOverlayDisplayed
+        let originalState = sut.lobbyOverlayViewModel.isDisplayed
         let appState = AppState(callingState: CallingState(status: .inLobby),
                                 lifeCycleState: LifeCycleState(currentStatus: .background))
         sut.receive(appState)
-        XCTAssertEqual(sut.isLobbyOverlayDisplayed, originalState)
+        XCTAssertEqual(sut.lobbyOverlayViewModel.isDisplayed, originalState)
     }
 
     func test_callingViewModel_update_when_callStatusIsConnected_remoteParticipantNotEmpty_then_isParticipantGridDisplayed_shouldBecomeTrue() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ControlBarViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ControlBarViewModelTests.swift
@@ -126,7 +126,9 @@ class ControlBarViewModelTests: XCTestCase {
         let localUserState = LocalUserState(audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .off)
         XCTAssertEqual(sut.micButtonViewModel.iconName, .micOff)
         wait(for: [expectation], timeout: 1)
@@ -147,7 +149,9 @@ class ControlBarViewModelTests: XCTestCase {
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
 
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .pending)
         XCTAssertEqual(sut.isMicDisabled(), true)
         wait(for: [expectation], timeout: 1)
@@ -172,7 +176,9 @@ class ControlBarViewModelTests: XCTestCase {
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
 
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .pending)
         XCTAssertEqual(sut.isMicDisabled(), true)
         wait(for: [expectation], timeout: 1)
@@ -198,7 +204,9 @@ class ControlBarViewModelTests: XCTestCase {
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
 
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .on)
         XCTAssertEqual(sut.isMicDisabled(), false)
         wait(for: [expectation], timeout: 1)
@@ -223,7 +231,9 @@ class ControlBarViewModelTests: XCTestCase {
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
 
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .off)
         XCTAssertEqual(sut.isMicDisabled(), false)
         wait(for: [expectation], timeout: 1)
@@ -243,7 +253,9 @@ class ControlBarViewModelTests: XCTestCase {
         let localUserState = LocalUserState(audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .on)
         XCTAssertEqual(sut.isMicDisabled(), false)
         XCTAssertEqual(sut.micButtonViewModel.iconName, .micOn)
@@ -268,7 +280,9 @@ class ControlBarViewModelTests: XCTestCase {
         let localUserState = LocalUserState(audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .on)
         XCTAssertEqual(sut.isMicDisabled(), false)
         XCTAssertEqual(sut.micButtonViewModel.iconName, .micOn)
@@ -292,7 +306,9 @@ class ControlBarViewModelTests: XCTestCase {
         let localUserState = LocalUserState(audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted,
                                               cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.audioState.operation, .off)
         XCTAssertEqual(sut.isMicDisabled(), false)
         XCTAssertEqual(sut.micButtonViewModel.iconName, .micOff)
@@ -360,7 +376,9 @@ class ControlBarViewModelTests: XCTestCase {
                                                    device: .receiverSelected)
         let localUserState = LocalUserState(cameraState: cameraState, audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted, cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.cameraState.operation, .off)
         XCTAssertEqual(sut.cameraButtonViewModel.iconName, .videoOff)
         wait(for: [expectation], timeout: 1)
@@ -387,7 +405,9 @@ class ControlBarViewModelTests: XCTestCase {
                                                    device: .receiverSelected)
         let localUserState = LocalUserState(cameraState: cameraState, audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted, cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.cameraState.operation, .on)
         XCTAssertEqual(sut.cameraButtonViewModel.iconName, .videoOn)
         wait(for: [expectation], timeout: 1)
@@ -415,7 +435,9 @@ class ControlBarViewModelTests: XCTestCase {
                                                    device: .receiverSelected)
         let localUserState = LocalUserState(cameraState: cameraState, audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted, cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.cameraState.operation, .on)
         XCTAssertEqual(sut.cameraButtonViewModel.iconName, .videoOn)
         wait(for: [expectation], timeout: 1)
@@ -442,7 +464,9 @@ class ControlBarViewModelTests: XCTestCase {
                                                    device: .receiverSelected)
         let localUserState = LocalUserState(cameraState: cameraState, audioState: audioState)
         let permissionState = PermissionState(audioPermission: .granted, cameraPermission: .granted)
-        sut.update(localUserState: localUserState, permissionState: permissionState)
+        sut.update(localUserState: localUserState,
+                   permissionState: permissionState,
+                   callingState: CallingState())
         XCTAssertEqual(sut.cameraState.operation, .off)
         XCTAssertEqual(sut.cameraButtonViewModel.iconName, .videoOff)
         wait(for: [expectation], timeout: 1)
@@ -468,7 +492,9 @@ class ControlBarViewModelTests: XCTestCase {
                                                      device: .front,
                                                      transmission: .local)
         let localUserState = LocalUserState(cameraState: cameraState)
-        sut.update(localUserState: localUserState, permissionState: PermissionState())
+        sut.update(localUserState: localUserState,
+                   permissionState: PermissionState(),
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1)
     }
 
@@ -488,7 +514,9 @@ class ControlBarViewModelTests: XCTestCase {
         }
         let sut = makeSUT()
         let permissionState = PermissionState(cameraPermission: .granted)
-        sut.update(localUserState: LocalUserState(), permissionState: permissionState)
+        sut.update(localUserState: LocalUserState(),
+                   permissionState: permissionState,
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1)
     }
 
@@ -510,7 +538,9 @@ class ControlBarViewModelTests: XCTestCase {
         let audioState = LocalUserState.AudioState(operation: .on,
                                                    device: .speakerSelected)
         let localUserState = LocalUserState(audioState: audioState)
-        sut.update(localUserState: localUserState, permissionState: PermissionState())
+        sut.update(localUserState: localUserState,
+                   permissionState: PermissionState(),
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1)
     }
 
@@ -530,7 +560,9 @@ class ControlBarViewModelTests: XCTestCase {
         }
         let sut = makeSUT()
         let permissionState = PermissionState(audioPermission: .granted)
-        sut.update(localUserState: LocalUserState(), permissionState: permissionState)
+        sut.update(localUserState: LocalUserState(),
+                   permissionState: permissionState,
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1)
     }
 
@@ -552,7 +584,9 @@ class ControlBarViewModelTests: XCTestCase {
         let audioState = LocalUserState.AudioState(operation: .on,
                                                    device: .bluetoothSelected)
         let localUserState = LocalUserState(audioState: audioState)
-        sut.update(localUserState: localUserState, permissionState: PermissionState())
+        sut.update(localUserState: localUserState,
+                   permissionState: PermissionState(),
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1)
     }
 
@@ -570,7 +604,9 @@ class ControlBarViewModelTests: XCTestCase {
         }
         factoryMocking.audioDevicesListViewModel = audioDevicesListViewModel
         let sut = makeSUT()
-        sut.update(localUserState: localUserState, permissionState: PermissionState())
+        sut.update(localUserState: localUserState,
+                   permissionState: PermissionState(),
+                   callingState: CallingState())
         wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/LobbyOverlayViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/LobbyOverlayViewModelTests.swift
@@ -35,10 +35,11 @@ class LobbyOverlayViewModelTests: XCTestCase {
 extension LobbyOverlayViewModelTests {
     func makeSUT() -> LobbyOverlayViewModel {
         return LobbyOverlayViewModel(localizationProvider:
-                                        LocalizationProvider(logger: LoggerMocking()))
+                                        LocalizationProvider(logger: LoggerMocking()),
+                                     accessibilityProvider: AccessibilityProviderMocking())
     }
 
     func makeSUTLocalizationMocking() -> LobbyOverlayViewModel {
-        return LobbyOverlayViewModel(localizationProvider: localizationProvider)
+        return LobbyOverlayViewModel(localizationProvider: localizationProvider, accessibilityProvider: AccessibilityProviderMocking())
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -27,7 +27,7 @@ class ErrorInfoViewModelTests: XCTestCase {
 
         sut.update(errorState: state)
         XCTAssertEqual(sut.isDisplayed, true)
-        XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallJoin")
+        XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallJoin")
     }
 
     func test_errorInfoViewModel_update_when_errorStateCallEnd_then_snackBarErrorCallEndMessage() {
@@ -37,7 +37,7 @@ class ErrorInfoViewModelTests: XCTestCase {
 
         sut.update(errorState: state)
         XCTAssertEqual(sut.isDisplayed, true)
-        XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEnd")
+        XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEnd")
     }
 
     func test_errorInfoViewModel_update_when_errorStateCallEvictionSet_then_snackBarErrorCallEvictedMessageDisplayed() {
@@ -47,7 +47,7 @@ class ErrorInfoViewModelTests: XCTestCase {
 
         sut.update(errorState: state)
         XCTAssertEqual(sut.isDisplayed, true)
-        XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEvicted")
+        XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallEvicted")
     }
 
     func test_errorInfoViewModel_update_when_errorStateCallDeniedSet_then_snackBarErrorCallDeniedMessageDisplayed() {
@@ -57,7 +57,7 @@ class ErrorInfoViewModelTests: XCTestCase {
 
         sut.update(errorState: state)
         XCTAssertEqual(sut.isDisplayed, true)
-        XCTAssertEqual(sut.message, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied")
+        XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied")
     }
 
     func test_errorInfoViewModel_update_when_errorTypeIsEmpty_then_isDisplayEqualFalse() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Display error Banner inside onHoldOverlayView when error show up
* Disable control bar when call is on hold
![MicrosoftTeams-image (35)](https://user-images.githubusercontent.com/75647512/170770212-74992dec-ac2f-4aa6-a89e-86f0830c49d0.png)

![MicrosoftTeams-image (34)](https://user-images.githubusercontent.com/75647512/170770227-3cf8fc98-10e6-4a6a-b5da-4a25b9962821.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
