### PR TITLE
[Feature] Add onHold state for remote participant with UI/UX update

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		1F94DAF52677D48400691D1E /* CommunicationUIErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F94DAF42677D48400691D1E /* CommunicationUIErrorEvent.swift */; };
 		1FA23F9E265DA21400B4A080 /* VideoStreamInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA23F9D265DA21400B4A080 /* VideoStreamInfoModel.swift */; };
 		1FA24BAD2666F0CC00B4A080 /* ColorThemeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA24BAC2666F0CC00B4A080 /* ColorThemeProvider.swift */; };
+		1FB0A1C128412A5100D57B0F /* ACSParticipantStateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB0A1C028412A5000D57B0F /* ACSParticipantStateExtension.swift */; };
 		1FBCB666264519DA00F57EEA /* VideoViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBCB665264519DA00F57EEA /* VideoViewManager.swift */; };
 		1FBCB69F2645285100F57EEA /* AzureCommunicationUICalling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8659FC52602A22000C807DE /* AzureCommunicationUICalling.framework */; platformFilter = ios; };
 		1FBCB6AA2645AC2F00F57EEA /* VideoRenderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBCB6A92645AC2F00F57EEA /* VideoRenderView.swift */; };
@@ -319,6 +320,7 @@
 		1F94DAF42677D48400691D1E /* CommunicationUIErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationUIErrorEvent.swift; sourceTree = "<group>"; };
 		1FA23F9D265DA21400B4A080 /* VideoStreamInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoStreamInfoModel.swift; sourceTree = "<group>"; };
 		1FA24BAC2666F0CC00B4A080 /* ColorThemeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorThemeProvider.swift; sourceTree = "<group>"; };
+		1FB0A1C028412A5000D57B0F /* ACSParticipantStateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACSParticipantStateExtension.swift; sourceTree = "<group>"; };
 		1FBCB665264519DA00F57EEA /* VideoViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoViewManager.swift; sourceTree = "<group>"; };
 		1FBCB682264522F200F57EEA /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		1FBCB69A2645285100F57EEA /* AzureCommunicationUICallingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AzureCommunicationUICallingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -657,6 +659,7 @@
 				1F87A7BA263A7EE900F49C7E /* CommunicationIdentifierExtension.swift */,
 				1FBCB6B02649EB1200F57EEA /* RemoteParticipantExtension.swift */,
 				1F13D37226AB3F1200E31666 /* ACSCallingStateExtension.swift */,
+				1FB0A1C028412A5000D57B0F /* ACSParticipantStateExtension.swift */,
 				5A31447C18BC49B691800C9D /* ACSCameraFacingExtension.swift */,
 				1FDBF9F0281F8D2E00B92273 /* ACSCallEndReasonExtension.swift */,
 			);
@@ -1677,6 +1680,7 @@
 				98546EBA26DEF24D0069B246 /* AudioDeviceType.swift in Sources */,
 				A8810CDD263CC75200C88545 /* ContainerView.swift in Sources */,
 				A8100387269F9DA70015C26E /* TeamsMeetingOptions.swift in Sources */,
+				1FB0A1C128412A5100D57B0F /* ACSParticipantStateExtension.swift in Sources */,
 				981ACABC2685459400CD6A40 /* IconProvider.swift in Sources */,
 				1F2BEDCD26329E5600D98266 /* PermissionAction.swift in Sources */,
 				98B186A127C85F9800B837E6 /* AudioDevicesListViewModel.swift in Sources */,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Model/ParticipantInfoModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Model/ParticipantInfoModel.swift
@@ -5,6 +5,17 @@
 
 import Foundation
 
+enum ParticipantStatus: Int {
+    case idle
+    case earlyMedia
+    case connecting
+    case connected
+    case hold
+    case inLobby
+    case disconnected
+    case ringing
+}
+
 struct ParticipantInfoModel: Hashable, Equatable {
     let displayName: String
     let isSpeaking: Bool
@@ -12,6 +23,7 @@ struct ParticipantInfoModel: Hashable, Equatable {
 
     let isRemoteUser: Bool
     let userIdentifier: String
+    let status: ParticipantStatus
 
     let recentSpeakingStamp: Date
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -23,17 +23,6 @@ class CompositeParticipantsListCell: TableViewCell {
         avatar.state.image = participantViewData?.avatarImage
         let avatarView = avatar.view
 
-        var micImage: UIImage?
-        var micImageView: UIImageView?
-        if viewModel.isMuted {
-            micImage = StyleProvider.icon.getUIImage(for: .micOffRegular)?
-                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
-        } else {
-            micImage = StyleProvider.icon.getUIImage(for: .micOnRegular)?
-                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
-        }
-        micImageView = UIImageView(image: micImage)
-
         selectionStyle = .none
         backgroundColor = UIDevice.current.userInterfaceIdiom == .pad
             ? StyleProvider.color.popoverColor
@@ -46,10 +35,34 @@ class CompositeParticipantsListCell: TableViewCell {
                                 UIColor.compositeColor(CompositeColor.mute)
                                :
                                 UIColor.compositeColor(CompositeColor.onSurface))
-
+        let customAccessoryView = getCustomAccessoryView(isHold: viewModel.isHold,
+                                                         onHoldString: viewModel.getOnHoldString(),
+                                                         isMuted: viewModel.isMuted)
         setup(title: viewModel.getCellDisplayName(with: participantViewData),
               customView: avatarView,
-              customAccessoryView: micImageView)
+              customAccessoryView: customAccessoryView)
         self.titleNumberOfLines = 2
+    }
+
+    func getCustomAccessoryView(isHold: Bool,
+                                onHoldString: String,
+                                isMuted: Bool) -> UIView {
+        guard !isHold else {
+            let label = Label(style: .body, colorStyle: .secondary)
+            label.text = onHoldString
+            label.textColor = StyleProvider.color.mute
+            label.sizeToFit()
+            label.numberOfLines = 0
+            return label
+        }
+        var micImage: UIImage?
+        if isMuted {
+            micImage = StyleProvider.icon.getUIImage(for: .micOffRegular)?
+                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
+        } else {
+            micImage = StyleProvider.icon.getUIImage(for: .micOnRegular)?
+                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
+        }
+        return UIImageView(image: micImage)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -8,6 +8,7 @@ import Foundation
 class ParticipantsListCellViewModel {
     let participantId: String?
     let isMuted: Bool
+    let isHold: Bool
     let isLocalParticipant: Bool
     let localizationProvider: LocalizationProviderProtocol
     private let displayName: String
@@ -19,6 +20,7 @@ class ParticipantsListCellViewModel {
         self.displayName = localUserState.displayName ?? ""
         self.isMuted = localUserState.audioState.operation != .on
         self.isLocalParticipant = true
+        self.isHold = false
     }
 
     init(participantInfoModel: ParticipantInfoModel,
@@ -27,6 +29,7 @@ class ParticipantsListCellViewModel {
         self.localizationProvider = localizationProvider
         self.displayName = participantInfoModel.displayName
         self.isMuted = participantInfoModel.isMuted
+        self.isHold = participantInfoModel.status == .hold
         self.isLocalParticipant = false
     }
 
@@ -67,5 +70,9 @@ class ParticipantsListCellViewModel {
             name = displayName
         }
         return name
+    }
+
+    func getOnHoldString() -> String {
+        localizationProvider.getLocalizedString(.onHold)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -104,6 +104,7 @@ struct ParticipantGridCellView: View {
                             avatarImage: $avatarImage,
                             isSpeaking: viewModel.isSpeaking && !viewModel.isMuted)
             .frame(width: avatarSize, height: avatarSize)
+            .opacity(viewModel.isHold ? 0.6 : 1)
             Spacer().frame(height: 10)
             ParticipantTitleView(displayName: $viewModel.displayName,
                                  isMuted: $viewModel.isMuted,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -107,8 +107,9 @@ struct ParticipantGridCellView: View {
             Spacer().frame(height: 10)
             ParticipantTitleView(displayName: $viewModel.displayName,
                                  isMuted: $viewModel.isMuted,
-                                 titleFont: Fonts.button1.font,
+                                 titleFont: Fonts.caption1.font,
                                  mutedIconSize: 16)
+            .opacity(viewModel.isHold ? 0.6 : 1)
             if viewModel.isHold {
                 Text(viewModel.getOnHoldString())
                     .font(Fonts.caption1.font)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -109,6 +109,13 @@ struct ParticipantGridCellView: View {
                                  isMuted: $viewModel.isMuted,
                                  titleFont: Fonts.button1.font,
                                  mutedIconSize: 16)
+            if viewModel.isHold {
+                Text(viewModel.getOnHoldString())
+                    .font(Fonts.caption1.font)
+                    .lineLimit(1)
+                    .foregroundColor(Color(StyleProvider.color.onBackground))
+                    .padding(.top, 8)
+            }
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -22,6 +22,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
     @Published var displayName: String?
     @Published var isSpeaking: Bool
     @Published var isMuted: Bool
+    @Published var isHold: Bool
     @Published var participantIdentifier: String
     private var isScreenSharing: Bool = false
     private var participantName: String
@@ -35,6 +36,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
         self.participantName = participantModel.displayName
         self.displayName = participantModel.displayName
         self.isSpeaking = participantModel.isSpeaking
+        self.isHold = participantModel.status == .hold
         self.participantIdentifier = participantModel.userIdentifier
         self.isMuted = participantModel.isMuted
         self.videoViewModel = getDisplayingVideoStreamModel(participantModel)
@@ -76,6 +78,12 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
         if self.isMuted != participantModel.isMuted {
             self.isMuted = participantModel.isMuted
         }
+
+        let isOnHold = participantModel.status == .hold
+
+        if self.isHold != isOnHold {
+            self.isHold = isOnHold
+        }
     }
 
     func updateParticipantNameIfNeeded(with renderDisplayName: String?) {
@@ -92,6 +100,10 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
             name = participantName
         }
         displayName = name
+    }
+
+    func getOnHoldString() -> String {
+        localizationProvider.getLocalizedString(.onHold)
     }
 
     private func getAccessibilityLabel(participantModel: ParticipantInfoModel) -> String {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKEventsHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/CallingSDKEventsHandler.swift
@@ -58,13 +58,17 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
     }
 
     private func setupRemoteParticipantEventsAdapter() {
-        remoteParticipantEventAdapter.onIsMutedChanged = { [weak self] remoteParticipant in
+        let participantUpdate: ((RemoteParticipant) -> Void) = { [weak self] remoteParticipant in
             guard let self = self,
                   let userIdentifier = remoteParticipant.identifier.stringValue else {
                 return
             }
             self.updateRemoteParticipant(userIdentifier: userIdentifier, updateSpeakingStamp: false)
         }
+
+        remoteParticipantEventAdapter.onIsMutedChanged = participantUpdate
+        remoteParticipantEventAdapter.onVideoStreamsUpdated = participantUpdate
+        remoteParticipantEventAdapter.onStateChanged = participantUpdate
 
         remoteParticipantEventAdapter.onIsSpeakingChanged = { [weak self] remoteParticipant in
             guard let self = self,
@@ -73,14 +77,6 @@ class CallingSDKEventsHandler: NSObject, CallingSDKEventsHandling {
             }
             let updateSpeakingStamp = remoteParticipant.isSpeaking
             self.updateRemoteParticipant(userIdentifier: userIdentifier, updateSpeakingStamp: updateSpeakingStamp)
-        }
-
-        remoteParticipantEventAdapter.onVideoStreamsUpdated = { [weak self] remoteParticipant in
-            guard let self = self,
-                  let userIdentifier = remoteParticipant.identifier.stringValue else {
-                return
-            }
-            self.updateRemoteParticipant(userIdentifier: userIdentifier, updateSpeakingStamp: false)
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSCallingStateExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSCallingStateExtension.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
 import AzureCommunicationCalling
 
 extension CallState {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSParticipantStateExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/ACSParticipantStateExtension.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AzureCommunicationCalling
+
+extension ParticipantState {
+    func toCompositeParticipantStatus() -> ParticipantStatus {
+        switch self {
+        case .idle:
+            return .idle
+        case .earlyMedia:
+            return .earlyMedia
+        case .connecting:
+            return .connecting
+        case .connected:
+            return .connected
+        case .hold:
+            return .hold
+        case .inLobby:
+            return .inLobby
+        case .disconnected:
+            return .disconnected
+        case .ringing:
+            return .ringing
+        default:
+            return .idle
+        }
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/RemoteParticipantExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/Extension/RemoteParticipantExtension.swift
@@ -22,6 +22,7 @@ extension RemoteParticipant {
                                     isMuted: isMuted,
                                     isRemoteUser: true,
                                     userIdentifier: self.identifier.stringValue ?? "",
+                                    status: state.toCompositeParticipantStatus(),
                                     recentSpeakingStamp: recentSpeakingStamp,
                                     screenShareVideoStreamModel: screenShareVideoStreamModel,
                                     cameraVideoStreamModel: cameraVideoStreamModel)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/RemoteParticipantsEventsAdapter.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Service/Calling/RemoteParticipantsEventsAdapter.swift
@@ -9,6 +9,7 @@ class RemoteParticipantsEventsAdapter: NSObject, RemoteParticipantDelegate {
     var onVideoStreamsUpdated: ((RemoteParticipant) -> Void) = {_ in }
     var onIsSpeakingChanged: ((RemoteParticipant) -> Void) = {_ in }
     var onIsMutedChanged: ((RemoteParticipant) -> Void) = {_ in }
+    var onStateChanged: ((RemoteParticipant) -> Void) = {_ in }
 
     func remoteParticipant(_ remoteParticipant: RemoteParticipant,
                            didUpdateVideoStreams args: RemoteVideoStreamsEventArgs) {
@@ -23,5 +24,11 @@ class RemoteParticipantsEventsAdapter: NSObject, RemoteParticipantDelegate {
     func remoteParticipant(_ remoteParticipant: RemoteParticipant,
                            didChangeMuteState args: PropertyChangedEventArgs) {
         onIsMutedChanged(remoteParticipant)
+    }
+
+    func remoteParticipant(_ remoteParticipant: RemoteParticipant,
+                           didChangeState args: PropertyChangedEventArgs) {
+
+        onStateChanged(remoteParticipant)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Builder/ParticipantInfoModelBuilder.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Builder/ParticipantInfoModelBuilder.swift
@@ -31,6 +31,7 @@ struct ParticipantInfoModelBuilder {
                                     isMuted: isMuted,
                                     isRemoteUser: true,
                                     userIdentifier: participantIdentifier,
+                                    status: .idle,
                                     recentSpeakingStamp: recentSpeakingStamp,
                                     screenShareVideoStreamModel: screenShareIdInfoModel,
                                     cameraVideoStreamModel: videoStreamInfoModel)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -38,6 +38,7 @@ class AvatarManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
@@ -36,6 +36,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -45,6 +46,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier2",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -69,6 +71,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -86,6 +89,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -104,6 +108,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -126,6 +131,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -151,6 +157,7 @@ class RemoteParticipantsManagerTests: XCTestCase {
                 isMuted: false,
                 isRemoteUser: true,
                 userIdentifier: "testUserIdentifier\(i)",
+                status: .idle,
                 recentSpeakingStamp: Date(),
                 screenShareVideoStreamModel: nil,
                 cameraVideoStreamModel: nil))

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/InfoHeaderViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/InfoHeaderViewModelTests.swift
@@ -67,6 +67,7 @@ class InfoHeaderViewModelTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -99,6 +100,7 @@ class InfoHeaderViewModelTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -110,6 +112,7 @@ class InfoHeaderViewModelTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -276,6 +279,7 @@ class InfoHeaderViewModelTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)
@@ -287,6 +291,7 @@ class InfoHeaderViewModelTests: XCTestCase {
             isMuted: false,
             isRemoteUser: true,
             userIdentifier: "testUserIdentifier1",
+            status: .idle,
             recentSpeakingStamp: Date(),
             screenShareVideoStreamModel: nil,
             cameraVideoStreamModel: nil)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -161,6 +161,7 @@ class ParticipantsListViewModelTests: XCTestCase {
                                  isMuted: false,
                                  isRemoteUser: false,
                                  userIdentifier: "MockUUID",
+                                 status: .idle,
                                  recentSpeakingStamp: Date(),
                                  screenShareVideoStreamModel: nil,
                                  cameraVideoStreamModel: nil)
@@ -208,6 +209,7 @@ class ParticipantsListViewModelTests: XCTestCase {
                                  isMuted: false,
                                  isRemoteUser: false,
                                  userIdentifier: "MockUUID",
+                                 status: .idle,
                                  recentSpeakingStamp: Date(),
                                  screenShareVideoStreamModel: nil,
                                  cameraVideoStreamModel: nil)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/AppStateReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/AppStateReducerTests.swift
@@ -187,6 +187,7 @@ class AppStateReducerTests: XCTestCase {
                                                isMuted: true,
                                                isRemoteUser: false,
                                                userIdentifier: userId,
+                                               status: .idle,
                                                recentSpeakingStamp: Date(),
                                                screenShareVideoStreamModel: nil,
                                                cameraVideoStreamModel: nil)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add onHold state for remote participant with UI/UX update
![Simulator Screen Shot - iPhone 11 - 2022-05-27 at 10 12 03](https://user-images.githubusercontent.com/75647512/170755389-6154d470-2e7a-46a4-96f4-6978980483ea.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
