### PR TITLE
[Feature] Remove the interruption end handling

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddleware.swift
@@ -47,8 +47,6 @@ struct CallingMiddleware: Middleware {
                     actionHandler.enterForeground(state: getState(), dispatch: dispatch)
                 case _ as AudioInterrupted:
                     actionHandler.audioSessionInterrupted(state: getState(), dispatch: dispatch)
-                case _ as AudioInterruptEnded:
-                    actionHandler.audioSessionInterruptEnded(state: getState(), dispatch: dispatch)
                 default:
                     break
                 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -15,7 +15,6 @@ protocol CallingMiddlewareHandling {
     func enterBackground(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func enterForeground(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func audioSessionInterrupted(state: ReduxState?, dispatch: @escaping ActionDispatch)
-    func audioSessionInterruptEnded(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func requestCameraPreviewOn(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func requestCameraOn(state: ReduxState?, dispatch: @escaping ActionDispatch)
     func requestCameraOff(state: ReduxState?, dispatch: @escaping ActionDispatch)
@@ -283,15 +282,6 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
         }
 
         dispatch(CallingAction.HoldRequested())
-    }
-
-    func audioSessionInterruptEnded(state: ReduxState?, dispatch: @escaping ActionDispatch) {
-        guard let state = state as? AppState,
-              state.callingState.status == .localHold else {
-            return
-        }
-
-        dispatch(CallingAction.ResumeRequested())
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallingMiddlewareHandlerMocking.swift
@@ -86,8 +86,4 @@ class CallingMiddlewareHandlerMocking: CallingMiddlewareHandling {
     func audioSessionInterrupted(state: ReduxState?, dispatch: @escaping ActionDispatch) {
 
     }
-
-    func audioSessionInterruptEnded(state: ReduxState?, dispatch: @escaping ActionDispatch) {
-
-    }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* As per discussion with team, remove the automatically call resume after interruptionEnd for the GA release. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

