### PR TITLE
[Bugfix] Prevented the pip view from being repositioned when the there is already overlay / drawer displayed on the screen.

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/CallingView.swift
@@ -36,10 +36,18 @@ struct CallingView: View {
         .environment(\.appPhase, viewModel.appState)
         .edgesIgnoringSafeArea(safeAreaIgnoreArea)
         .onRotate { newOrientation in
+            guard !viewModel.controlBarViewModel.isAudioDeviceSelectionDisplayed,
+                  !viewModel.controlBarViewModel.isConfirmLeaveListDisplayed,
+                  !viewModel.infoHeaderViewModel.isParticipantsListDisplayed else {
+                return
+            }
+            let areAllOrientationsSupported = SupportedOrientationsPreferenceKey.defaultValue == .all
             if newOrientation != orientation
                 && newOrientation != .unknown
                 && newOrientation != .faceDown
-                && newOrientation != .faceUp {
+                && newOrientation != .faceUp
+                && (areAllOrientationsSupported || (!areAllOrientationsSupported
+                                                    && newOrientation != .portraitUpsideDown)) {
                 orientation = newOrientation
             }
         }


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Prevented the pip view from being repositioned when the there is already overlay / drawer displayed on the screen.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
* Join a call with one remote participant (any meeting type is fine)
* drag the pip view to some position, then launch participant drawer (audio drawer / leave call drawer are also fine)
* change device orientation 
* see if the pip view position is not changed

## What to Check
Verify that the following are valid
* check if the pip view position is not changed

## Other Information
<!-- Add any other helpful information that may be needed here. -->