### PR TITLE
[BugFix] Fix the issue that local video status is inconsistent after call resume from background

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -161,7 +161,7 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
 
     func enterForeground(state: ReduxState?, dispatch: @escaping ActionDispatch) {
         guard let state = state as? AppState,
-              state.callingState.status == .connected,
+              state.callingState.status == .connected || state.callingState.status == .localHold,
               state.localUserState.cameraState.operation == .paused else {
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/LocalUserReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Reducer/LocalUserReducer.swift
@@ -38,6 +38,7 @@ struct LocalUserReducer: Reducer {
         case let action as LocalUserAction.CameraOffFailed:
             cameraStatus = .error(action.error)
         case _ as LocalUserAction.CameraPausedSucceeded:
+            localVideoStreamIdentifier = nil
             cameraStatus = .paused
         case let action as LocalUserAction.CameraPausedFailed:
             cameraStatus = .error(action.error)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
@@ -407,6 +407,27 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_callingMiddlewareHandler_enterForeground_when_callLocalHold_cameraStatusOn_noError_then_updateCameraStatusOnUpdate() {
+        let expectation = XCTestExpectation(description: "Dispatch the new action")
+        let id = "identifier"
+        func dispatch(action: Action) {
+            XCTAssertTrue(action is LocalUserAction.CameraOnSucceeded)
+            switch action {
+            case let action as LocalUserAction.CameraOnSucceeded:
+                XCTAssertEqual(action.videoStreamIdentifier, id)
+                expectation.fulfill()
+            default:
+                XCTFail("Should not be default \(action)")
+            }
+        }
+        mockCallingService.videoStreamId = id
+        callingMiddlewareHandler.enterForeground(state: getState(callingState: .localHold,
+                                                                 cameraStatus: .paused,
+                                                                 cameraDeviceStatus: .front),
+                                                 dispatch: dispatch)
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusOn_returnsError_then_updateCameraStatusIsError() {
         let error = getError()
         func dispatch(action: Action) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/LocalUserReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/LocalUserReducerTests.swift
@@ -259,6 +259,20 @@ class LocalUserReducerTests: XCTestCase {
         XCTAssertEqual(resultState.cameraState.operation, expectedCameraStatus)
     }
 
+    func test_localUserReducer_reduce_when_localUserActionCameraPausedSucceeded_then_cameraStatusIsPaused_localVideoStreamIdNil() {
+        let state = LocalUserState()
+        let expectedCameraStatus = LocalUserState.CameraOperationalStatus.paused
+        let action = LocalUserAction.CameraPausedSucceeded()
+        let sut = getSUT()
+        guard let resultState = sut.reduce(state, action) as? LocalUserState else {
+            XCTFail("Failed with state validation")
+            return
+        }
+
+        XCTAssertEqual(resultState.cameraState.operation, expectedCameraStatus)
+        XCTAssertNil(resultState.localVideoStreamIdentifier)
+    }
+
     func test_localUserReducer_reduce_when_mockingAction_then_stateNotUpdate() {
         let expectedVideoId = "expected"
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When Siri is triggered, the composite would go to `background` mode first, we would trigger the `CameraPausedSucceeded` action for background mode, which update the camera status to `paused`. 
* Update the localVideoStream id to nil. This would prevent the local video pip displaying the video when camera is `.off` icon
* Then interruption ended would be triggered, call become `onHold` even in the background mode. 
* When back to foreground, add the `callingState == .localHold` check, resume the local video stream even the call is inHold state


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
