### PR TITLE
[Bugfix] Not trigger CameraPreviewOnTriggered when have internal error

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -52,7 +52,8 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
                 }
             }, receiveValue: {
                 if state.permissionState.cameraPermission == .granted,
-                   state.localUserState.cameraState.operation == .off {
+                   state.localUserState.cameraState.operation == .off,
+                   state.errorState.internalError == nil {
                     dispatch(LocalUserAction.CameraPreviewOnTriggered())
                 }
             })

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed issue where header was still selectable with voiceover on and overlay visible. [#256](https://github.com/Azure/communication-ui-library-ios/pull/256)
 - Fixed hold overlay to have a solid colour. [#262](https://github.com/Azure/communication-ui-library-ios/pull/262) 
 - Fixed the issue that resume a call without internet could stop user from exit. [#268](https://github.com/Azure/communication-ui-library-ios/pull/268)
+- Fixed issue inconsistent camera state is inconsistent in setup view when being denied to or evicted from a call. [#273](https://github.com/Azure/communication-ui-library-ios/pull/273)
 
 ### Other Changes
 - Added delay for camera status update. [#270](https://github.com/Azure/communication-ui-library-ios/pull/270)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Not trigger CameraPreviewOnTriggered when have internal error when going back to setupView

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* When callEvicted or callDenied, or other internal error will have same camera state when going back to setupView
* eg. Test if camera is on in a call, camera in setupView will remain on when being evicted
* eg. Test if camera is off in a call, camera in setupView will remain off when being evicted

## Other Information
<!-- Add any other helpful information that may be needed here. -->