### PR TITLE
[Bugfix] Demo app can't dismiss setting page when in landscape mode (#2899277)

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp/Views/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
     }
 
     @ObservedObject var envConfigSubject: EnvConfigSubject
-
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     let avatarChoices: [String] = ["cat", "fox", "koala", "monkey", "mouse", "octopus"]
 
     var body: some View {
@@ -36,7 +36,14 @@ struct SettingsView: View {
                 avatarSettings
                 remoteParticipantsAvatarsSettings
                 themeSettings
-            }.navigationTitle("UI Library - Settings")
+            }
+            .navigationTitle("UI Library - Settings")
+            .toolbar {
+                Button(
+                    action: { self.presentationMode.wrappedValue.dismiss() },
+                    label: { Image(systemName: "xmark") }
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes the case where the settings screen cannot be dismissed when iPhone is in landscape orientation

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
Bug fix and UI change

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Install app
* Run demo app
* Tap settings button
* Rotate phone to landscape
* Observe close button and is functional (previously this was not possible to dismiss)

## Impact
Limited to settings screen, enables dismissal in landscape
