### PR TITLE
[Bug] Fixing speaking overly custom color 

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellVideoView.swift
@@ -8,11 +8,6 @@ import FluentUI
 import Combine
 
 struct ParticipantGridCellVideoView: View {
-
-    private struct Constants {
-        static let borderColor = Color(StyleProvider.color.primaryColor)
-    }
-
     var videoRendererViewInfo: ParticipantRendererViewInfo!
     let rendererViewManager: RendererViewManager?
     let zoomable: Bool
@@ -46,7 +41,7 @@ struct ParticipantGridCellVideoView: View {
 
         }.overlay(
             isSpeaking && !isMuted ? RoundedRectangle(cornerRadius: 4)
-                .strokeBorder(Constants.borderColor, lineWidth: 4) : nil
+                .strokeBorder(Color(StyleProvider.color.primaryColor), lineWidth: 4) : nil
         ).animation(.default)
     }
 


### PR DESCRIPTION
## Purpose
Updated custom colours do not appear on the speaking indicator border of the video view.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. In settings page set a custom theme colour to something (maybe green)
2. Join call with a participant who has their video turned on 
3. Have the participant talk and notice the speaking indicator is green 
4. leave the call
5. Go into setting page and change theme colour to something else (maybe yellow)
6. Join call with a participant who has their video turned on 
7. Have the participant talk and notice the speaking indicator should now be the new colour (yellow) 

## What to Check
Speaking overlay should always be the correct colour 
