### PR TITLE
[Refactor] Unit tests retain cycle fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallCompositeOptions/DiagnosticConfigTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CallCompositeOptions/DiagnosticConfigTests.swift
@@ -19,7 +19,6 @@ class DiagnosticConfigTests: XCTestCase {
         }
 
         XCTAssertEqual(tag, expectedCompositeTag)
-
     }
 
     func test_init_when_init_then_returnRegExValidTags() {
@@ -31,7 +30,6 @@ class DiagnosticConfigTests: XCTestCase {
         let validationRegEx = "aci110/[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?(-(alpha|beta)(.[0-9][0-9]?)?)?"
         let validationPred = NSPredicate(format: "SELF MATCHES %@", validationRegEx)
         XCTAssertTrue(validationPred.evaluate(with: tag))
-
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 import FluentUI
 @testable import AzureCommunicationUICalling
 
-class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
+struct CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     private let logger: Logger
     private let store: Store<AppState>

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/CompositeViewModelFactoryMocking.swift
@@ -12,6 +12,7 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
     private let logger: Logger
     private let store: Store<AppState>
     private let accessibilityProvider: AccessibilityProviderProtocol
+    private let localizationProvider: LocalizationProviderProtocol
 
     var bannerTextViewModel: BannerTextViewModel?
     var controlBarViewModel: ControlBarViewModel?
@@ -40,24 +41,26 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     init(logger: Logger,
          store: Store<AppState>,
-         accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()) {
+         accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking(),
+         localizationProvider: LocalizationProviderProtocol = LocalizationProviderMocking()) {
         self.logger = logger
         self.store = store
         self.accessibilityProvider = accessibilityProvider
+        self.localizationProvider = localizationProvider
     }
 
     func getSetupViewModel() -> SetupViewModel {
         return setupViewModel ?? SetupViewModel(compositeViewModelFactory: self,
                                                 logger: logger,
                                                 store: store,
-                                                localizationProvider: LocalizationProviderMocking())
+                                                localizationProvider: localizationProvider)
     }
 
     func getCallingViewModel() -> CallingViewModel {
         return callingViewModel ?? CallingViewModel(compositeViewModelFactory: self,
                                                     logger: logger,
                                                     store: store,
-                                                    localizationProvider: LocalizationProviderMocking(),
+                                                    localizationProvider: localizationProvider,
                                                     accessibilityProvider: accessibilityProvider,
                                                     isIpadInterface: false)
     }
@@ -87,7 +90,7 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
     func makeLocalVideoViewModel(dispatchAction: @escaping ActionDispatch) -> LocalVideoViewModel {
         return localVideoViewModel ?? LocalVideoViewModel(compositeViewModelFactory: self,
                                                           logger: logger,
-                                                          localizationProvider: LocalizationProviderMocking(),
+                                                          localizationProvider: localizationProvider,
                                                           dispatchAction: dispatchAction)
     }
 
@@ -108,12 +111,12 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
         return audioDevicesListViewModel ?? AudioDevicesListViewModel(compositeViewModelFactory: self,
                                                                       dispatchAction: dispatchAction,
                                                                       localUserState: localUserState,
-                                                                      localizationProvider: LocalizationProviderMocking())
+                                                                      localizationProvider: localizationProvider)
     }
 
     func makeErrorInfoViewModel(title: String,
                                 subtitle: String) -> ErrorInfoViewModel {
-        return errorInfoViewModel ?? ErrorInfoViewModel(localizationProvider: LocalizationProviderMocking(),
+        return errorInfoViewModel ?? ErrorInfoViewModel(localizationProvider: localizationProvider,
                                                         title: title,
                                                         subtitle: subtitle)
     }
@@ -130,7 +133,7 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     // MARK: CallingViewModels
     func makeLobbyOverlayViewModel() -> LobbyOverlayViewModel {
-        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: LocalizationProviderMocking(),
+        return lobbyOverlayViewModel ?? LobbyOverlayViewModel(localizationProvider: localizationProvider,
                                                               accessibilityProvider: accessibilityProvider)
     }
 
@@ -139,7 +142,7 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
                                  localUserState: LocalUserState) -> ControlBarViewModel {
         return controlBarViewModel ?? ControlBarViewModel(compositeViewModelFactory: self,
                                                           logger: logger,
-                                                          localizationProvider: LocalizationProviderMocking(),
+                                                          localizationProvider: localizationProvider,
                                                           dispatchAction: dispatchAction,
                                                           endCallConfirm: endCallConfirm,
                                                           localUserState: localUserState)
@@ -149,20 +152,20 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
         return infoHeaderViewModel ?? InfoHeaderViewModel(compositeViewModelFactory: self,
                                                           logger: logger,
                                                           localUserState: localUserState,
-                                                          localizationProvider: LocalizationProviderMocking(),
+                                                          localizationProvider: localizationProvider,
                                                           accessibilityProvider: accessibilityProvider)
     }
 
     func makeParticipantCellViewModel(participantModel: ParticipantInfoModel) -> ParticipantGridCellViewModel {
         return createMockParticipantGridCellViewModel?(participantModel) ?? ParticipantGridCellViewModel(
-            localizationProvider: LocalizationProviderMocking(),
-            accessibilityProvider: AccessibilityProviderMocking(),
+            localizationProvider: localizationProvider,
+            accessibilityProvider: accessibilityProvider,
             participantModel: participantModel)
     }
 
     func makeParticipantGridsViewModel(isIpadInterface: Bool) -> ParticipantGridViewModel {
         return participantGridViewModel ?? ParticipantGridViewModel(compositeViewModelFactory: self,
-                                                                    localizationProvider: LocalizationProviderMocking(),
+                                                                    localizationProvider: localizationProvider,
 																	accessibilityProvider: accessibilityProvider,
                                                                     isIpadInterface: isIpadInterface)
     }
@@ -178,24 +181,24 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     func makeBannerTextViewModel() -> BannerTextViewModel {
         return bannerTextViewModel ?? BannerTextViewModel(accessibilityProvider: accessibilityProvider,
-                                                          localizationProvider: LocalizationProviderMocking())
+                                                          localizationProvider: localizationProvider)
     }
 
     func makeLocalParticipantsListCellViewModel(localUserState: LocalUserState) -> ParticipantsListCellViewModel {
         localParticipantsListCellViewModel ?? ParticipantsListCellViewModel(localUserState: localUserState,
-                                                                            localizationProvider: LocalizationProviderMocking())
+                                                                            localizationProvider: localizationProvider)
     }
 
     func makeParticipantsListCellViewModel(participantInfoModel: ParticipantInfoModel) -> ParticipantsListCellViewModel {
         createParticipantsListCellViewModel?(participantInfoModel) ?? ParticipantsListCellViewModel(participantInfoModel: participantInfoModel,
-                                                                                                    localizationProvider: LocalizationProviderMocking())
+                                                                                                    localizationProvider: localizationProvider)
     }
 
     // MARK: SetupViewModels
     func makePreviewAreaViewModel(dispatchAction: @escaping ActionDispatch) -> PreviewAreaViewModel {
         return previewAreaViewModel ?? PreviewAreaViewModel(compositeViewModelFactory: self,
                                                             dispatchAction: dispatchAction,
-                                                            localizationProvider: LocalizationProviderMocking())
+                                                            localizationProvider: localizationProvider)
     }
 
     func makeSetupControlBarViewModel(dispatchAction: @escaping ActionDispatch,
@@ -204,18 +207,18 @@ class CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
                                                                     logger: logger,
                                                                     dispatchAction: dispatchAction,
                                                                     localUserState: localUserState,
-                                                                    localizationProvider: LocalizationProviderMocking())
+                                                                    localizationProvider: localizationProvider)
     }
 
     func makeJoiningCallActivityViewModel() -> JoiningCallActivityViewModel {
-        JoiningCallActivityViewModel(localizationProvider: LocalizationProviderMocking())
+        JoiningCallActivityViewModel(localizationProvider: localizationProvider)
     }
 
     func makeOnHoldOverlayViewModel(resumeAction: @escaping (() -> Void)) -> OnHoldOverlayViewModel {
-        return onHoldOverlayViewModel ?? OnHoldOverlayViewModel(localizationProvider: LocalizationProviderMocking(),
+        return onHoldOverlayViewModel ?? OnHoldOverlayViewModel(localizationProvider: localizationProvider,
                                       compositeViewModelFactory: self,
-                                      logger: LoggerMocking(),
-                                      accessibilityProvider: AccessibilityProviderMocking(),
+                                      logger: logger,
+                                      accessibilityProvider: accessibilityProvider,
                                       resumeAction: {})
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/AvatarManagerTests.swift
@@ -9,10 +9,16 @@ import AzureCommunicationCommon
 @testable import AzureCommunicationUICalling
 
 class AvatarManagerTests: XCTestCase {
-    var mockStoreFactory = StoreFactoryMocking()
+    var mockStoreFactory: StoreFactoryMocking!
 
     override func setUp() {
         super.setUp()
+        mockStoreFactory = StoreFactoryMocking()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        mockStoreFactory = nil
     }
 
     func test_avatarManager_when_setLocalAvatar_then_getLocalAvatar_returnsSameUIImage() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/CompositeErrorManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/CompositeErrorManagerTests.swift
@@ -8,18 +8,29 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class CompositeErrorManagerTests: XCTestCase {
-    var mockStoreFactory = StoreFactoryMocking()
+    var mockStoreFactory: StoreFactoryMocking!
     var cancellable: CancelBag!
     var compositeManager: CompositeErrorManager!
 
-    var handlerCallExpectation = XCTestExpectation(description: "Delegate expectation")
+    var handlerCallExpectation: XCTestExpectation!
     var expectedError: CallCompositeError?
 
     override func setUp() {
         super.setUp()
+        handlerCallExpectation = XCTestExpectation(description: "Delegate expectation")
+        mockStoreFactory = StoreFactoryMocking()
         cancellable = CancelBag()
         compositeManager = CompositeErrorManager(store: mockStoreFactory.store,
                                                  callCompositeEventsHandler: getEventsHandler())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        handlerCallExpectation = nil
+        mockStoreFactory = nil
+        cancellable = nil
+        compositeManager = nil
+        expectedError = nil
     }
 
     func test_errorManager_receiveState_when_noFatalError_navigationExit_then_nodidFailEventCalled_hostingVCDismissCalled() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Manager/RemoteParticipantsManagerTests.swift
@@ -14,17 +14,27 @@ class RemoteParticipantsManagerTests: XCTestCase {
     var callingSDKWrapper: CallingSDKWrapperMocking!
     var eventsHandler: CallComposite.Events!
     var remoteParticipantsJoinedExpectation: XCTestExpectation!
-    var expectedIds: [String] = []
+    var expectedIds: [String]!
 
     override func setUp() {
         super.setUp()
-        sut = nil
         remoteParticipantsJoinedExpectation = XCTestExpectation(description: "DidRemoteParticipantsJoin event expectation")
         mockStoreFactory = StoreFactoryMocking()
         eventsHandler = CallComposite.Events()
         callingSDKWrapper = CallingSDKWrapperMocking()
         avatarViewManager = AvatarViewManagerMocking(store: mockStoreFactory.store,
                                                      localOptions: nil)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+        remoteParticipantsJoinedExpectation = nil
+        mockStoreFactory = nil
+        eventsHandler = nil
+        callingSDKWrapper = nil
+        avatarViewManager = nil
+        expectedIds = []
     }
 
     func test_remoteParticipantsManager_receive_when_stateUpdated_and_participantRemoved_then_avatarViewManagerUpdateStorageCalled() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ParticipantGridCellViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Mocking/ViewModels/ParticipantGridCellViewModelMocking.swift
@@ -9,8 +9,7 @@ import Foundation
 class ParticipantGridCellViewModelMocking: ParticipantGridCellViewModel {
     private let updateParticipantModelCompletion: ((ParticipantInfoModel) -> Void)?
 
-    init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
-         participantModel: ParticipantInfoModel,
+    init(participantModel: ParticipantInfoModel,
          updateParticipantModelCompletion: ((ParticipantInfoModel) -> Void)?) {
         self.updateParticipantModelCompletion = updateParticipantModelCompletion
         super.init(localizationProvider: LocalizationProviderMocking(),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerInfoTypeTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerInfoTypeTests.swift
@@ -15,6 +15,11 @@ class BannerInfoTypeTests: XCTestCase {
         localizationProvider = LocalizationProvider(logger: LoggerMocking())
     }
 
+    override func tearDown() {
+        super.tearDown()
+        localizationProvider = nil
+    }
+
     func test_bannerInfoType_when_recordingAndTranscriptionStarted_then_shouldEqualExpectedString() {
         let bannerInfoType: BannerInfoType = .recordingAndTranscriptionStarted
         let expectedTitle = "Recording and transcription have started."

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerTextViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerTextViewModelTests.swift
@@ -15,6 +15,11 @@ class BannerTextViewModelTests: XCTestCase {
         localizationProvider = LocalizationProviderMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        localizationProvider = nil
+    }
+
     func test_bannerTextViewModel_update_when_withBannerInfoType_then_shouldBePublish() {
         let sut = makeSUT()
         let expectedTitle = "Recording and transcription have started."

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/BannerViewModelTests.swift
@@ -8,8 +8,17 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class BannerViewModelTests: XCTestCase {
+    var cancellable: CancelBag!
 
-    let cancellable = CancelBag()
+    override func setUp() {
+        super.setUp()
+        cancellable = CancelBag()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        cancellable = nil
+    }
 
     func test_bannerViewModel_isBannerDisplayedPublished_when_displayBannerWithRecordingOnAndTranscriptionOn_then_shouldBecomeTrueAndPublish() {
         let bannerViewModel = makeSut()
@@ -282,7 +291,7 @@ extension BannerViewModelTests {
     func makeSut(callingStateArray: [CallingState],
                  mockingBannerViewModel: BannerTextViewModelMocking) -> BannerViewModel {
         let storeFactory = StoreFactoryMocking()
-        let factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(),
+        var factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(),
                                                               store: storeFactory.store)
         factoryMocking.bannerTextViewModel = mockingBannerViewModel
         let sut = BannerViewModel(compositeViewModelFactory: factoryMocking)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/CallingViewModelTests.swift
@@ -13,6 +13,7 @@ class CallingViewModelTests: XCTestCase {
     var cancellable: CancelBag!
     var logger: LoggerMocking!
     var localizationProvider: LocalizationProviderMocking!
+    var accessibilityProvider: AccessibilityProviderMocking!
 
     private let timeout: TimeInterval = 10.0
 
@@ -22,9 +23,11 @@ class CallingViewModelTests: XCTestCase {
         logger = LoggerMocking()
         storeFactory = StoreFactoryMocking()
         localizationProvider = LocalizationProviderMocking()
+        accessibilityProvider = AccessibilityProviderMocking()
 
         factoryMocking = CompositeViewModelFactoryMocking(logger: logger,
                                                           store: storeFactory.store,
+                                                          accessibilityProvider: accessibilityProvider,
                                                           localizationProvider: localizationProvider)
     }
 
@@ -33,12 +36,13 @@ class CallingViewModelTests: XCTestCase {
         cancellable = nil
         storeFactory = nil
         localizationProvider = nil
+        accessibilityProvider = nil
         logger = nil
         factoryMocking = nil
     }
 
     func test_callingViewModel_endCall_when_confirmLeaveOverlayIsDisplayed_shouldEndCall() {
-        let sut = makeSUT(storeFactory: storeFactory)
+        let sut = makeSUT()
         let expectation = XCTestExpectation(description: "Verify Call End is Requested")
         storeFactory.store.$state
             .dropFirst(1)
@@ -177,11 +181,10 @@ class CallingViewModelTests: XCTestCase {
     func test_callingViewModel_receive_when_callingStateStatusUpdated_then_accessibilityFocusUpdated() {
         let expectation = XCTestExpectation(description: "Accessibility focus is updated")
         let appState = AppState(callingState: CallingState(status: .inLobby))
-        let accessibilityProvider = AccessibilityProviderMocking()
         accessibilityProvider.moveFocusToFirstElementBlock = {
             expectation.fulfill()
         }
-        let sut = makeSUT(accessibilityProvider: accessibilityProvider)
+        let sut = makeSUT()
         sut.receive(appState)
         wait(for: [expectation], timeout: timeout)
     }
@@ -229,11 +232,7 @@ class CallingViewModelTests: XCTestCase {
 }
 
 extension CallingViewModelTests {
-    func makeSUT(storeFactory: StoreFactoryMocking = StoreFactoryMocking(),
-                 accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProvider()) -> CallingViewModel {
-//        let factoryMocking = CompositeViewModelFactoryMocking(logger: logger,
-//                                                              store: storeFactory.store,
-//                                                              accessibilityProvider: accessibilityProvider)
+    func makeSUT() -> CallingViewModel {
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,
@@ -247,7 +246,7 @@ extension CallingViewModelTests {
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
@@ -263,7 +262,7 @@ extension CallingViewModelTests {
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
@@ -271,13 +270,13 @@ extension CallingViewModelTests {
         factoryMocking.infoHeaderViewModel = InfoHeaderViewModelMocking(compositeViewModelFactory: factoryMocking,
                                                                         logger: logger,
                                                                         localUserState: storeFactory.store.state.localUserState,
-                                                                        accessibilityProvider: AccessibilityProviderMocking(),
+                                                                        accessibilityProvider: accessibilityProvider,
                                                                         updateState: updateInfoHeaderViewModel)
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
@@ -291,20 +290,20 @@ extension CallingViewModelTests {
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
     func makeSUT(updateParticipantGridViewModel: @escaping ((CallingState, RemoteParticipantsState) -> Void)) -> CallingViewModel {
         factoryMocking.participantGridViewModel = ParticipantGridViewModelMocking(compositeViewModelFactory: factoryMocking,
                                                                                   localizationProvider: localizationProvider,
-                                                                                  accessibilityProvider: AccessibilityProviderMocking(),
+                                                                                  accessibilityProvider: accessibilityProvider,
                                                                                   updateState: updateParticipantGridViewModel)
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
@@ -315,7 +314,7 @@ extension CallingViewModelTests {
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 
@@ -323,14 +322,14 @@ extension CallingViewModelTests {
         factoryMocking.onHoldOverlayViewModel = OnHoldOverlayViewModelMocking(localizationProvider: localizationProvider,
                                                                               compositeViewModelFactory: factoryMocking,
                                                                               logger: logger,
-                                                                              accessibilityProvider: AccessibilityProvider(),
+                                                                              accessibilityProvider: accessibilityProvider,
                                                                               resumeAction: {},
                                                                               updateState: updateOnHoldOverlayViewModel)
         return CallingViewModel(compositeViewModelFactory: factoryMocking,
                                 logger: logger,
                                 store: storeFactory.store,
                                 localizationProvider: localizationProvider,
-                                accessibilityProvider: AccessibilityProvider(),
+                                accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ControlBarViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ControlBarViewModelTests.swift
@@ -26,6 +26,15 @@ class ControlBarViewModelTests: XCTestCase {
         localizationProvider = LocalizationProviderMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        cancellable = nil
+        logger = nil
+        factoryMocking = nil
+        localizationProvider = nil
+    }
+
     // MARK: Leave Call / Cancel test
     func test_controlBarViewModel_getLeaveCallButtonViewModel_shouldReturnLeaveCallButtonViewModel() {
         let sut = makeSUT()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/InfoHeaderViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/InfoHeaderViewModelTests.swift
@@ -21,11 +21,16 @@ class InfoHeaderViewModelTests: XCTestCase {
         storeFactory = StoreFactoryMocking()
         cancellable = CancelBag()
         localizationProvider = LocalizationProviderMocking()
-        factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(), store: storeFactory.store)
+        factoryMocking = CompositeViewModelFactoryMocking(logger: logger, store: storeFactory.store)
+    }
 
-        func dispatch(action: Action) {
-            storeFactory.store.dispatch(action: action)
-        }
+    override func tearDown() {
+        super.tearDown()
+        logger = nil
+        storeFactory = nil
+        cancellable = nil
+        localizationProvider = nil
+        factoryMocking = nil
     }
 
     func test_infoHeaderViewModel_update_when_participantInfoListCountSame_then_shouldNotBePublished() {
@@ -315,7 +320,7 @@ class InfoHeaderViewModelTests: XCTestCase {
 extension InfoHeaderViewModelTests {
     func makeSUT(accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProvider()) -> InfoHeaderViewModel {
         return InfoHeaderViewModel(compositeViewModelFactory: factoryMocking,
-                                   logger: LoggerMocking(),
+                                   logger: logger,
                                    localUserState: LocalUserState(),
                                    localizationProvider: LocalizationProvider(logger: logger),
                                    accessibilityProvider: accessibilityProvider)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/LobbyOverlayViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/LobbyOverlayViewModelTests.swift
@@ -15,6 +15,11 @@ class LobbyOverlayViewModelTests: XCTestCase {
         localizationProvider = LocalizationProviderMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        localizationProvider = nil
+    }
+
     func test_lobbyOverlayViewModel_displays_title_from_AppLocalization() {
         let sut = makeSUT()
         XCTAssertEqual(sut.title, "Waiting for host")
@@ -40,6 +45,7 @@ extension LobbyOverlayViewModelTests {
     }
 
     func makeSUTLocalizationMocking() -> LobbyOverlayViewModel {
-        return LobbyOverlayViewModel(localizationProvider: localizationProvider, accessibilityProvider: AccessibilityProviderMocking())
+        return LobbyOverlayViewModel(localizationProvider: localizationProvider,
+                                     accessibilityProvider: AccessibilityProviderMocking())
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/OnHoldOverlayViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/OnHoldOverlayViewModelTests.swift
@@ -23,6 +23,15 @@ class OnHoldOverlayViewModelTests: XCTestCase {
         accessibilityProvider = AccessibilityProviderMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        logger = nil
+        storeFactory = nil
+        localizationProvider = nil
+        factoryMocking = nil
+        accessibilityProvider = nil
+    }
+
     func test_onHoldOverlayViewModel_displays_title_from_AppLocalization() {
         let sut = makeSUT()
         XCTAssertEqual(sut.title, "You're on hold")
@@ -54,9 +63,9 @@ class OnHoldOverlayViewModelTests: XCTestCase {
 
 extension OnHoldOverlayViewModelTests {
     func makeSUT() -> OnHoldOverlayViewModel {
-        return OnHoldOverlayViewModel(localizationProvider: LocalizationProvider(logger: LoggerMocking()),
+        return OnHoldOverlayViewModel(localizationProvider: LocalizationProvider(logger: logger),
                                       compositeViewModelFactory: factoryMocking,
-                                      logger: LoggerMocking(),
+                                      logger: logger,
                                       accessibilityProvider: accessibilityProvider,
                                       resumeAction: {})
     }
@@ -64,15 +73,15 @@ extension OnHoldOverlayViewModelTests {
     func makeSUTLocalizationMocking() -> OnHoldOverlayViewModel {
         return OnHoldOverlayViewModel(localizationProvider: localizationProvider,
                                       compositeViewModelFactory: factoryMocking,
-                                      logger: LoggerMocking(),
+                                      logger: logger,
                                       accessibilityProvider: accessibilityProvider,
                                       resumeAction: {})
     }
 
     func makeSUT(withAction action: @escaping (() -> Void)) -> OnHoldOverlayViewModelMocking {
-        return OnHoldOverlayViewModelMocking(localizationProvider: LocalizationProvider(logger: LoggerMocking()),
+        return OnHoldOverlayViewModelMocking(localizationProvider: LocalizationProvider(logger: logger),
                                                   compositeViewModelFactory: factoryMocking,
-                                                  logger: LoggerMocking(),
+                                                  logger: logger,
                                                   accessibilityProvider: accessibilityProvider,
                                                   resumeAction: action)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantCellViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantCellViewModelTests.swift
@@ -8,7 +8,17 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class ParticipantCellViewModelTests: XCTestCase {
-    var cancellable = CancelBag()
+    var cancellable: CancelBag!
+
+    override func setUp() {
+        super.setUp()
+        cancellable = CancelBag()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        cancellable = nil
+    }
 
     func test_participantCellViewModel_init_then_getCorrectRendererViewModel() {
         let expectedParticipantIdentifier = "expectedParticipantIdentifier"

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantGridsViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantGridsViewModelTests.swift
@@ -8,7 +8,17 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class ParticipantGridViewModelTests: XCTestCase {
-    var cancellable = CancelBag()
+    var cancellable: CancelBag!
+
+    override func setUp() {
+        super.setUp()
+        cancellable = CancelBag()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        cancellable = nil
+    }
 
     // MARK: Sorting participant
     func test_participantGridsViewModel_updateParticipantsState_when_newSevenInfoModels_then_participantViewModelsSortedByRecentSpeakingTimeStamp() {
@@ -537,13 +547,12 @@ extension ParticipantGridViewModelTests {
     func makeSUT(participantGridCellViewUpdateCompletion: ((ParticipantInfoModel) -> Void)? = nil) -> ParticipantGridViewModel {
         let storeFactory = StoreFactoryMocking()
         let accessibilityProvider = AccessibilityProvider()
-        let factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(),
+        var factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(),
                                                               store: storeFactory.store,
                                                               accessibilityProvider: accessibilityProvider)
-        factoryMocking.createMockParticipantGridCellViewModel = { [unowned factoryMocking] infoModel in
+        factoryMocking.createMockParticipantGridCellViewModel = { infoModel in
             if let completion = participantGridCellViewUpdateCompletion {
-                return ParticipantGridCellViewModelMocking(compositeViewModelFactory: factoryMocking,
-                                                           participantModel: infoModel,
+                return ParticipantGridCellViewModelMocking(participantModel: infoModel,
                                                            updateParticipantModelCompletion: completion)
             }
             return nil

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -254,7 +254,6 @@ class ParticipantsListViewModelTests: XCTestCase {
     }
 
     func test_participantsListViewModel_update_when_remoteParticipantsStateChanged_then_participantsListUpdated() {
-        let sut = makeSUT()
         let participantInfoList = [ParticipantInfoModelBuilder.get(displayName: "Name 1"),
                                    ParticipantInfoModelBuilder.get(displayName: "Name 2"),
                                    ParticipantInfoModelBuilder.get(displayName: "Name 3")]
@@ -267,6 +266,7 @@ class ParticipantsListViewModelTests: XCTestCase {
             return ParticipantsListCellViewModel(participantInfoModel: infoModel,
                                                  localizationProvider: self?.localizationProvider ?? LocalizationProviderMocking())
         }
+        let sut = makeSUT()
         sut.update(localUserState: LocalUserState(),
                    remoteParticipantsState: remoteParticipantsState)
         XCTAssertEqual(sut.participantsList.map { $0.getParticipantName(with: nil) },

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -23,6 +23,15 @@ class ParticipantsListViewModelTests: XCTestCase {
         factoryMocking = CompositeViewModelFactoryMocking(logger: logger, store: storeFactory.store)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        logger = nil
+        cancellable = nil
+        localizationProvider = nil
+        storeFactory = nil
+        factoryMocking = nil
+    }
+
     // MARK: localParticipantsListCellViewModel test
     func test_participantsListViewModel_update_when_localUserStateMicOnAndUpdateWithMicOff_then_shouldBePublished() {
         let sut = makeSUT()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Factories/CompositeViewModelFactoryTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Factories/CompositeViewModelFactoryTests.swift
@@ -10,16 +10,24 @@ import XCTest
 class CompositeViewModelFactoryTests: XCTestCase {
 
     var logger: LoggerMocking!
-    var mockStoreFactory = StoreFactoryMocking()
+    var mockStoreFactory: StoreFactoryMocking!
     var compositeViewModelFactory: CompositeViewModelFactory!
 
     override func setUp() {
         super.setUp()
+        mockStoreFactory = StoreFactoryMocking()
         logger = LoggerMocking()
         compositeViewModelFactory = CompositeViewModelFactory(logger: logger,
-                                                                 store: mockStoreFactory.store,
-                                                                 localizationProvider: LocalizationProviderMocking(),
-                                                                 accessibilityProvider: AccessibilityProviderMocking())
+                                                              store: mockStoreFactory.store,
+                                                              localizationProvider: LocalizationProviderMocking(),
+                                                              accessibilityProvider: AccessibilityProviderMocking())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        logger = nil
+        compositeViewModelFactory = nil
+        mockStoreFactory = nil
     }
 
     func test_compositeViewModelFactory_getCallingViewModel_when_setupViewModelNotNil_then_getSetupViewModel_shouldReturnDifferentSetupViewModel() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Provider/LocalizationProviderTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Provider/LocalizationProviderTests.swift
@@ -16,6 +16,11 @@ class LocalizationProviderTests: XCTestCase {
         logger = LoggerMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        logger = nil
+    }
+
     func test_localizationProvider_applyRTL_when_layoutDirectionRightToLeft_then_shouldRTLReturnTrue() {
         let sut = makeSUT()
         let locale: Locale = SupportedLocale.en

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -7,11 +7,16 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class ErrorInfoViewModelTests: XCTestCase {
-    private var localizationProvier: LocalizationProviderMocking!
+    private var localizationProvider: LocalizationProviderMocking!
 
     override func setUp() {
         super.setUp()
-        localizationProvier = LocalizationProviderMocking()
+        localizationProvider = LocalizationProviderMocking()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        localizationProvider = nil
     }
 
     func test_errorInfoViewModel_dismissContent_alwaysReturns_snackBarDismissContent() {
@@ -79,6 +84,6 @@ class ErrorInfoViewModelTests: XCTestCase {
     }
 
     func makeSUT() -> ErrorInfoViewModel {
-        return ErrorInfoViewModel(localizationProvider: localizationProvier)
+        return ErrorInfoViewModel(localizationProvider: localizationProvider)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/JoiningCallActivityViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/JoiningCallActivityViewModelTests.swift
@@ -15,6 +15,11 @@ class JoiningCallActivityViewModelTests: XCTestCase {
         localizationProvider = LocalizationProviderMocking()
     }
 
+    override func tearDown() {
+        super.tearDown()
+        localizationProvider = nil
+    }
+
     func test_joiningCallActivityViewModel_when_getTitle_then_shouldLocalizedPlaceholderString() {
         let sut = makeSUT()
         XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SetupView.Button.JoiningCall")

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/PreviewAreaViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/PreviewAreaViewModelTests.swift
@@ -22,6 +22,14 @@ class PreviewAreaViewModelTests: XCTestCase {
                                                           store: storeFactory.store)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        logger = nil
+        localizationProvider = nil
+        factoryMocking = nil
+    }
+
     func test_previewAreaViewModel_when_audioPermissionDenied_then_shouldWarnAudioDisabled() {
         let cameraState = LocalUserState.CameraState(operation: .off,
                                                      device: .front,
@@ -161,7 +169,6 @@ class PreviewAreaViewModelTests: XCTestCase {
         XCTAssertEqual(sut.getPermissionWarningIcon(), expectedIcon)
         XCTAssertEqual(sut.getPermissionWarningText(), expectedTextKey)
     }
-
 }
 
 extension PreviewAreaViewModelTests {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/SetupControlBarViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/SetupControlBarViewModelTests.swift
@@ -26,6 +26,15 @@ class SetupControlBarViewModelTests: XCTestCase {
                                                           store: storeFactory.store)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        cancellable = nil
+        logger = nil
+        localizationProvider = nil
+        factoryMocking = nil
+    }
+
     func test_setupControlBarViewModel_when_videoButtonTapped_then_requestCameraOnIfPreviouslyOff() {
         let expectation = XCTestExpectation(description: "Verify Camera On")
         let cameraState = LocalUserState.CameraState(operation: .off,
@@ -346,7 +355,7 @@ class SetupControlBarViewModelTests: XCTestCase {
         let audioDevicesListViewModel = AudioDevicesListViewModelMocking(compositeViewModelFactory: factoryMocking,
                                                                          dispatchAction: storeFactory.store.dispatch,
                                                                          localUserState: localUserState,
-                                                                         localizationProvider: LocalizationProviderMocking())
+                                                                         localizationProvider: localizationProvider)
 
         audioDevicesListViewModel.updateState = { status in
             XCTAssertEqual(status, localUserState.audioState.device)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/SetupViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/Setup/SetupViewModelTests.swift
@@ -23,6 +23,14 @@ class SetupViewModelTests: XCTestCase {
                                                           store: storeFactory.store)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        cancellable = nil
+        logger = nil
+        factoryMocking = nil
+    }
+
     func test_setupViewModel_when_setupViewLoaded_then_shouldAskAudioPermission() {
         let sut = makeSUT()
         let expectation = XCTestExpectation(description: "Verify Last Action is Request Audio")

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/ViewComponents/AudioDevicesListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/ViewComponents/AudioDevicesListViewModelTests.swift
@@ -20,7 +20,16 @@ class AudioDevicesListViewModelTests: XCTestCase {
         cancellable = CancelBag()
         localizationProvider = LocalizationProviderMocking()
         factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(),
-                                                          store: storeFactory.store)
+                                                          store: storeFactory.store,
+                                                          localizationProvider: localizationProvider)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        cancellable = nil
+        localizationProvider = nil
+        factoryMocking = nil
     }
 
     func test_audioDevicesListViewModel_update_when_audioDevicesListFirstInitialized_then_shouldBePublished() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/ViewComponents/LocalVideoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Presentation/ViewComponents/LocalVideoViewModelTests.swift
@@ -20,11 +20,19 @@ class LocalVideoViewModelTests: XCTestCase {
         func dispatch(action: Action) {
             storeFactory.store.dispatch(action: action)
         }
-        let factoryMocking = CompositeViewModelFactoryMocking(logger: LoggerMocking(), store: storeFactory.store)
+        let logger = LoggerMocking()
+        let factoryMocking = CompositeViewModelFactoryMocking(logger: logger, store: storeFactory.store)
         localVideoViewModel = LocalVideoViewModel(compositeViewModelFactory: factoryMocking,
-                                                  logger: LoggerMocking(),
+                                                  logger: logger,
                                                   localizationProvider: LocalizationProviderMocking(),
                                                   dispatchAction: dispatch)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        cancellable = nil
+        localVideoViewModel = nil
     }
 
     func test_localVideoViewModel_when_updateWithLocalVideoStreamId_then_videoSteamIdUpdated() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
@@ -22,6 +22,14 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         callingMiddlewareHandler = CallingMiddlewareHandler(callingService: mockCallingService, logger: mockLogger)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        mockCallingService = nil
+        mockLogger = nil
+        callingMiddlewareHandler = nil
+    }
+
     func test_callingMiddlewareHandler_requestMicMute_then_muteLocalMicCalled() {
         callingMiddlewareHandler.requestMicrophoneMute(state: getEmptyState(), dispatch: getEmptyDispatch())
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Middleware/CallingMiddlewareTests.swift
@@ -20,6 +20,12 @@ class CallingMiddlewareTests: XCTestCase {
         callingMiddleware = CallingMiddleware(callingMiddlewareHandler: mockMiddlewareHandler)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        mockMiddlewareHandler = nil
+        callingMiddleware = nil
+    }
+
     func test_callingMiddleware_apply_when_setupCallCallingAction_then_handlerSetupCallBeingCalled() {
 
         let middlewareDispatch = getEmptyCallingMiddlewareFunction()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/ErrorReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/ErrorReducerTests.swift
@@ -8,10 +8,6 @@ import XCTest
 @testable import AzureCommunicationUICalling
 
 class ErrorReducerTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-    }
-
     func test_handleErrorReducer_reduce_when_notErrorState_then_return() {
         let state = StateMocking()
         let action = ErrorAction.FatalErrorUpdated(internalError: .callJoinFailed,
@@ -120,7 +116,6 @@ class ErrorReducerTests: XCTestCase {
 
         XCTAssertEqual(errorState.internalError, nil)
         XCTAssertEqual(errorState.errorCategory, .none)
-
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/LifeCycleReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Redux/Reducer/LifeCycleReducerTests.swift
@@ -61,5 +61,4 @@ extension LifeCycleReducerTests {
     func getSUT() -> LifeCycleReducer {
         return LifeCycleReducer()
     }
-
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Service/CallingServiceTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Service/CallingServiceTests.swift
@@ -23,6 +23,14 @@ class CallingServiceTests: XCTestCase {
         callingService = CallingService(logger: logger, callingSDKWrapper: callingSDKWrapper)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        cancellable = nil
+        logger = nil
+        callingSDKWrapper = nil
+        callingService = nil
+    }
+
     func test_callingService_setupCall_shouldCallcallingSDKWrapperSetupCall() {
         _ = callingService.setupCall()
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Service/NavigationRouterTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICallingTests/Service/NavigationRouterTests.swift
@@ -19,6 +19,13 @@ class NavigationRouterTests: XCTestCase {
         swiftUIRouter = NavigationRouter(store: storeFactory.store, logger: logger)
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storeFactory = nil
+        logger = nil
+        swiftUIRouter = nil
+    }
+
     func test_router_navigate_whenNavigateToNewView_shouldCallLog() {
         let state = AppState(navigationState: NavigationState(status: .inCall))
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added `tearDown` functions to clean up used memory
* Made `CompositeViewModelFactoryMocking` a struct
* Fixed retain cycles

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* All tests pass

## Other Information
<!-- Add any other helpful information that may be needed here. -->
A task for investigation of a better approach for VM and VMFactory mocking was created