### PR TITLE
[Bugfix] Fixed accessibility label not reflecting on hold status

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -55,10 +55,9 @@ class ParticipantsListCellViewModel {
     }
 
     func getCellAccessibilityLabel(with participantViewData: ParticipantViewData?) -> String {
-        let displayName = getCellDisplayName(with: participantViewData)
-        return isMuted
-        ? displayName + localizationProvider.getLocalizedString(.muted)
-        : displayName + localizationProvider.getLocalizedString(.unmuted)
+        let status = isHold ? getOnHoldString() :
+        localizationProvider.getLocalizedString(isMuted ? .muted : .unmuted)
+        return "\(getCellDisplayName(with: participantViewData)) \(status)"
     }
 
     func getParticipantName(with participantViewData: ParticipantViewData?) -> String {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -64,6 +64,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
 
         if self.participantName != participantModel.displayName ||
             self.isMuted != participantModel.isMuted ||
+            self.isSpeaking != participantModel.isSpeaking ||
             self.isHold != (participantModel.status == .hold) {
             self.accessibilityLabel = getAccessibilityLabel(participantModel: participantModel)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -107,8 +107,9 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
     }
 
     private func getAccessibilityLabel(participantModel: ParticipantInfoModel) -> String {
-        let status = localizationProvider.getLocalizedString(
-            participantModel.isSpeaking ? .speaking : participantModel.isMuted ? .muted : .unmuted)
+        let status = isHold ? getOnHoldString() :
+        localizationProvider.getLocalizedString(participantModel.isSpeaking ? .speaking :
+                                                    participantModel.isMuted ? .muted : .unmuted)
         return "\(participantModel.displayName) \(status)"
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -62,7 +62,9 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
                                                  videoStreamId: videoViewModel.videoStreamId)
         }
 
-        if self.participantName != participantModel.displayName || self.isMuted != participantModel.isMuted {
+        if self.participantName != participantModel.displayName ||
+            self.isMuted != participantModel.isMuted ||
+            self.isHold != (participantModel.status == .hold) {
             self.accessibilityLabel = getAccessibilityLabel(participantModel: participantModel)
         }
 
@@ -107,7 +109,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
     }
 
     private func getAccessibilityLabel(participantModel: ParticipantInfoModel) -> String {
-        let status = isHold ? getOnHoldString() :
+        let status = participantModel.status == .hold ? getOnHoldString() :
         localizationProvider.getLocalizedString(participantModel.isSpeaking ? .speaking :
                                                     participantModel.isMuted ? .muted : .unmuted)
         return "\(participantModel.displayName) \(status)"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR is meant to fix an issue where accessibility label did not reflect true status of participants. Specifically, when one of participant goes on hold, their accessibility label does not get updated.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

0. Get the code
1. open accessibility inspector
2. set target to simulator
3. run the app
4. enter token, display name and teams URL/ Call ID
5. put one of participant goes on hold
6. use accessibility inspector to navigate to the participant's avatar
7. make sure label reads "XXXX on hold"
8. open participant list
9. navigate inspector to on-hold-participant
10. make sure label reads "XXXX on hold"

## What to Check
Verify that the following are valid
1. should a participant put on hold, their other status would be ignored (such as microphone and speaking status)
2. if the participant is not on hold, then their speaking or microphone status would be read out 

## Other Information
<!-- Add any other helpful information that may be needed here. -->
1. clarified with accessibility team, if a participant being on hold, other status should be ignored (muted/speaking/etc.)
2. I have also noticed that speaking status change would not trigger accessibility label update, so I have included changes for this issue as well. 

## Screenshots:

### participant grid - before:
<img width="738" alt="image" src="https://user-images.githubusercontent.com/109105353/180269340-42f77af3-c130-40bf-ae19-9d1a79a2346e.png">

### participant grid - after:
![image](https://user-images.githubusercontent.com/109105353/180278429-cce602af-17af-438f-b3bf-6f6071f795a4.png)

### participant list - before:
![image](https://user-images.githubusercontent.com/109105353/180270546-9a6bcee6-d148-4ec9-973a-362847894320.png)

### participant list - after:
![image](https://user-images.githubusercontent.com/109105353/180269837-2ec7d1c6-2fbe-439c-930e-a02abc57cc78.png)

### participant grid speaking - before:
![image](https://user-images.githubusercontent.com/109105353/180283310-5aeafc06-221d-4e0d-9b92-50024ae4eb19.png)

### participant grid speaking - after:
![image](https://user-images.githubusercontent.com/109105353/180283054-26fb2790-631c-401d-9519-e9633f645024.png)

