### PR TITLE
[Bugfix] Fixed VoiceOver functionality for InfoHeaderView

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
@@ -76,7 +76,7 @@ class InfoHeaderViewModel: ObservableObject {
         isHoldingCall(callingState: callingState)
 
         callingStatus = callingState.status
-        let newDisplayInfoHeaderValue = callingStatus != .inLobby
+        let newDisplayInfoHeaderValue = shouldDisplayInfoHeader(for: callingStatus)
         if isVoiceOverEnabled && newDisplayInfoHeaderValue != shouldDisplayInfoHeader {
             updateInfoHeaderAvailability()
         }
@@ -91,7 +91,6 @@ class InfoHeaderViewModel: ObservableObject {
     private func isHoldingCall(callingState: CallingState) {
         guard callingState.status == .localHold,
               callingStatus != callingState.status else {
-
             return
         }
         if isInfoHeaderDisplayed {
@@ -135,7 +134,7 @@ class InfoHeaderViewModel: ObservableObject {
     }
 
     private func updateInfoHeaderAvailability() {
-        shouldDisplayInfoHeader = callingStatus != .inLobby
+        shouldDisplayInfoHeader = shouldDisplayInfoHeader(for: callingStatus)
         isVoiceOverEnabled = accessibilityProvider.isVoiceOverEnabled
         // invalidating timer is required for setting the next timer and when VoiceOver is enabled
         infoHeaderDismissTimer?.invalidate()
@@ -144,6 +143,10 @@ class InfoHeaderViewModel: ObservableObject {
         } else if shouldDisplayInfoHeader {
             displayWithTimer()
         }
+    }
+
+    private func shouldDisplayInfoHeader(for callingStatus: CallingStatus) -> Bool {
+        return callingStatus != .inLobby && callingStatus != .localHold
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
@@ -18,7 +18,6 @@ class InfoHeaderViewModel: ObservableObject {
     private var infoHeaderDismissTimer: Timer?
     private var participantsCount: Int = 0
     private var callingStatus: CallingStatus = .none
-    private var shouldDisplayInfoHeader: Bool = true
 
     let participantsListViewModel: ParticipantsListViewModel
     var participantListButtonViewModel: IconButtonViewModel!
@@ -74,10 +73,10 @@ class InfoHeaderViewModel: ObservableObject {
                 remoteParticipantsState: RemoteParticipantsState,
                 callingState: CallingState) {
         isHoldingCall(callingState: callingState)
-
+        let shouldDisplayInfoHeaderValue = shouldDisplayInfoHeader(for: callingStatus)
+        let newDisplayInfoHeaderValue = shouldDisplayInfoHeader(for: callingState.status)
         callingStatus = callingState.status
-        let newDisplayInfoHeaderValue = shouldDisplayInfoHeader(for: callingStatus)
-        if isVoiceOverEnabled && newDisplayInfoHeaderValue != shouldDisplayInfoHeader {
+        if isVoiceOverEnabled && newDisplayInfoHeaderValue != shouldDisplayInfoHeaderValue {
             updateInfoHeaderAvailability()
         }
         if participantsCount != remoteParticipantsState.participantInfoList.count {
@@ -134,7 +133,7 @@ class InfoHeaderViewModel: ObservableObject {
     }
 
     private func updateInfoHeaderAvailability() {
-        shouldDisplayInfoHeader = shouldDisplayInfoHeader(for: callingStatus)
+        let shouldDisplayInfoHeader = shouldDisplayInfoHeader(for: callingStatus)
         isVoiceOverEnabled = accessibilityProvider.isVoiceOverEnabled
         // invalidating timer is required for setting the next timer and when VoiceOver is enabled
         infoHeaderDismissTimer?.invalidate()


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixed InfoHeaderView availability when VoiceOver is on and after `On Hold` page was shown

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

## What to Check
Verify that the following are valid
* InfoHeaderView is always visible when VoiceOver is turned on but when `Lobby` or `On Hold` screens are shown 

![IMG_0060 1](https://user-images.githubusercontent.com/98852890/180871985-dad9d8e5-1256-4938-afb2-f0a29cfb96a9.PNG)
![IMG_0061](https://user-images.githubusercontent.com/98852890/180872007-84835ead-213b-4927-80e1-72c5b2b0d19a.PNG)


