### PR TITLE
[Bugfix] Fixed Participant Drawer Height Calculation

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -54,18 +54,12 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
         }
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        resizeDrawer()
-    }
-
     func dismissDrawer(animated: Bool = false) {
         self.controller?.dismiss(animated: animated)
     }
 
     func updateDrawerList(items: [T]) {
         self.items = items
-        resizeDrawer()
     }
 
     private func showDrawerView() {
@@ -152,22 +146,10 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
 
     private func getTotalCellsHeight(tableView: UITableView,
                                      numberOfItems: Int) -> CGFloat {
-        // If we can't get all table cell heights,
-        // fall back to assumption all cells are the same height.
-        guard tableView.visibleCells.count == numberOfItems else {
-            let defaultCellHeight: CGFloat = 44
-            var firstCellHeight: CGFloat = defaultCellHeight
-            for cell in tableView.visibleCells {
-                firstCellHeight = cell.bounds.height
-                break
+        return (0..<tableView.numberOfSections).flatMap { section in
+            return (0..<tableView.numberOfRows(inSection: section)).map { row in
+                return IndexPath(row: row, section: section)
             }
-            return firstCellHeight * CGFloat(numberOfItems)
-        }
-
-        var totalCellsHeight: CGFloat = 0
-        for cell in tableView.visibleCells {
-            totalCellsHeight += cell.bounds.height
-        }
-        return totalCellsHeight
+        }.map { index in return tableView.rectForRow(at: index).height }.reduce(0, +)
     }
 }


### PR DESCRIPTION
## Purpose
The calculation of participant drawer height needs to be fixed so that user would not have content being cutoff when having large font enabled in accessibility.

## Context
The drawer container calculation was previously based on visible cells which is fine in the most of cases. 

But in some cases, the visible cells could be empty due to the fact that we had been calling resizeDrawer() multiple times which results in a race condition where tableview could be not ready and having no visible cells. Then, since there are no visible cells, current logic is to use a fixed default height for each cell and this height becomes too low (causing cutoff) when user had large fonts enabled in accessibility.

## Solution

To resolve this issue, we need to:
1. eliminate repeated calls to resizeDrawer() while table reload is in progress
2. use drawing area for each row to get cell height instead

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  enable large font in accessibility
*  enable zooms in display setting 
*  open the app
*  enter information such as token, display name and teams link
*  join the call
*  tap on participant list, see if drawer container shows up properly
*  tap on end call button, see if drawer container shows all content in the screen without being cutting off
*  tap on audio button, see if drawer shows up properly

## What to Check
Verify that the following are valid
* drawer should not be cutoff
* drawer contents are visible to contoso (except in landscape mode where user might need to scroll)

## Other Information

### How to reproduce original issue:
1. enable zoom and set font size to large in accessibility
2. open the app and join a call
3. rotate the device 360 degrees
4. tap on end call button, you would noticed that drawer got cutoff5. 

OR

1. enable zoom and set font size to large in accessibility
2. open the app and join a call
3. tap on end call button and hold it for one second
4. release the button, drawer should now show up and got cutoff

### Before - resizeDrawer being called multiple time which caused a race condition:
![image](https://user-images.githubusercontent.com/109105353/180891831-ddf3b910-03d4-4114-9dbc-1bfd81bc1fd2.png)
![image](https://user-images.githubusercontent.com/109105353/180892247-90bcab70-b2d6-4e38-95c8-feb73e14b377.png)

### After - resizeDrawer being called exactly once for each tap:
![image](https://user-images.githubusercontent.com/109105353/180890868-14fcda6b-ee70-4230-bf94-cd962abe2d92.png)

### Before:
![image](https://user-images.githubusercontent.com/109105353/180891548-99ce7c16-ec9a-4349-a259-51c74f782ec4.png)

### After:
![image](https://user-images.githubusercontent.com/109105353/180890962-a198ebbd-cc46-4b93-8427-4733d2e86141.png)

### Uneven row height test:
![image](https://user-images.githubusercontent.com/109105353/180891389-895b93a1-0bbc-40d4-99eb-138cb5ddc634.png)
