### PR TITLE
[Bug] Fixed Low Contrast Ratio for On-hold Label and Drawer Icons

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Assets.xcassets/Color/iconSecondaryColor.colorset/Contents.json
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Assets.xcassets/Color/iconSecondaryColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x6E",
-          "green" : "0x6E",
-          "red" : "0x6E"
+          "blue" : "0x91",
+          "green" : "0x91",
+          "red" : "0x91"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x91",
-          "green" : "0x91",
-          "red" : "0x91"
+          "blue" : "0x6E",
+          "green" : "0x6E",
+          "red" : "0x6E"
         }
       },
       "idiom" : "universal"

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Assets.xcassets/Color/textSecondaryColor.colorset/Contents.json
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Assets.xcassets/Color/textSecondaryColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6E",
+          "green" : "0x6E",
+          "red" : "0x6E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x91",
+          "red" : "0x91"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationListCell.swift
@@ -14,7 +14,7 @@ class CompositeLeaveCallConfirmationListCell: TableViewCell {
         let isNameEmpty = viewModel.title.trimmingCharacters(in: .whitespaces).isEmpty
         var micImageView: UIImageView?
         let micImage = StyleProvider.icon.getUIImage(for: viewModel.icon)?
-            .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
+            .withTintColor(StyleProvider.color.iconSecondary, renderingMode: .alwaysOriginal)
         micImageView = UIImageView(image: micImage)
 
         selectionStyle = .none

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -50,7 +50,7 @@ class CompositeParticipantsListCell: TableViewCell {
         guard !isHold else {
             let label = Label(style: .body, colorStyle: .secondary)
             label.text = onHoldString
-            label.textColor = StyleProvider.color.textSecondaryColor
+            label.textColor = StyleProvider.color.textSecondary
             label.sizeToFit()
             label.numberOfLines = 0
             return label
@@ -58,10 +58,10 @@ class CompositeParticipantsListCell: TableViewCell {
         var micImage: UIImage?
         if isMuted {
             micImage = StyleProvider.icon.getUIImage(for: .micOffRegular)?
-                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
+                .withTintColor(StyleProvider.color.iconSecondary, renderingMode: .alwaysOriginal)
         } else {
             micImage = StyleProvider.icon.getUIImage(for: .micOnRegular)?
-                .withTintColor(StyleProvider.color.mute, renderingMode: .alwaysOriginal)
+                .withTintColor(StyleProvider.color.iconSecondary, renderingMode: .alwaysOriginal)
         }
         return UIImageView(image: micImage)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -50,7 +50,7 @@ class CompositeParticipantsListCell: TableViewCell {
         guard !isHold else {
             let label = Label(style: .body, colorStyle: .secondary)
             label.text = onHoldString
-            label.textColor = StyleProvider.color.mute
+            label.textColor = StyleProvider.color.textSecondaryColor
             label.sizeToFit()
             label.numberOfLines = 0
             return label

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -38,6 +38,7 @@ class ColorThemeProvider {
     let hangup = UIColor.compositeColor(.hangup)
     let overlay = UIColor.compositeColor(.overlay)
     let onHoldBackground = UIColor.compositeColor(.onHoldBackground)
+    let textSecondaryColor = UIColor.compositeColor(.textSecondaryColor)
 
     init(themeOptions: ThemeOptions?) {
         self.colorSchemeOverride = themeOptions?.colorSchemeOverride ?? .unspecified

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -38,7 +38,8 @@ class ColorThemeProvider {
     let hangup = UIColor.compositeColor(.hangup)
     let overlay = UIColor.compositeColor(.overlay)
     let onHoldBackground = UIColor.compositeColor(.onHoldBackground)
-    let textSecondaryColor = UIColor.compositeColor(.textSecondaryColor)
+    let textSecondary = UIColor.compositeColor(.textSecondary)
+    let iconSecondary = UIColor.compositeColor(.iconSecondary)
 
     init(themeOptions: ThemeOptions?) {
         self.colorSchemeOverride = themeOptions?.colorSchemeOverride ?? .unspecified

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/ColorExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/ColorExtension.swift
@@ -31,6 +31,7 @@ enum CompositeColor: String {
     case hangup = "hangupColor"
     case overlay = "overlayColor"
     case onHoldBackground = "onHoldBackground"
+    case textSecondaryColor
 }
 
 extension UIColor {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/ColorExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/ColorExtension.swift
@@ -31,7 +31,8 @@ enum CompositeColor: String {
     case hangup = "hangupColor"
     case overlay = "overlayColor"
     case onHoldBackground = "onHoldBackground"
-    case textSecondaryColor
+    case textSecondary = "textSecondaryColor"
+    case iconSecondary = "iconSecondaryColor"
 }
 
 extension UIColor {


### PR DESCRIPTION
## Purpose
the text and icon colours have low contrast ratio which is not align with accessibility guidelines. After talking with accessibility team and UI team, they asked to:

1. change the text colour of "on hold" label from "text disable" to "text secondary"
2. change icon colours of call/mute/close from "text disable" to "icon secondary" 

I have confirmed with UI team that colour inconsistency between text label and icons are expected and they accept this inconsistency.

![image](https://user-images.githubusercontent.com/109105353/182959149-67893302-7fde-4003-8d0a-a8848dfc7f95.png)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
0. get the code, run the app in simulator, start a call with one participant on hold
1. use Digital color picker to get the colour of mute/call/cross icons
4. go to https://webaim.org/resources/contrastchecker/
5. type colour measured then see if contrast ratio is aligned with guidelines 
6. repeat 1-3 for "on hold" label 

## What to Check
Verify that the following are valid
1. for texts, its contrast ratio has to be 4.5:1 or better
2. for icons, its contrast ratio has to be 3.1:1 or better

## Other Information
## before (left), after (right)
![image](https://user-images.githubusercontent.com/109105353/182955317-46e231e3-bb5e-4302-9f47-c08eb1edfc33.png)
![image](https://user-images.githubusercontent.com/109105353/182955613-29e210d1-ae34-42c6-a11e-ba6156673a0a.png)
![image](https://user-images.githubusercontent.com/109105353/182956648-39693951-ac05-4171-b4b0-9b6ef9887c89.png)
![image](https://user-images.githubusercontent.com/109105353/182957104-2b89d157-4c33-4b2d-88f7-f9dd7d4efd5b.png)
![image](https://user-images.githubusercontent.com/109105353/182957483-f00691c9-8bc8-4ca1-b4fa-99588784a11e.png)
