### PR TITLE
[Bug] Fixed Text Getting Cut Off in Accessibility Mode

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
@@ -46,7 +46,7 @@ struct InfoHeaderView: View {
                 .font(Fonts.caption1.font)
                 .accessibilityLabel(Text(viewModel.accessibilityLabel))
                 .accessibilitySortPriority(1)
-                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 0.75)
+                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.2 : 0.75)
             Spacer()
             participantListButton
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
@@ -8,7 +8,7 @@ import FluentUI
 
 struct InfoHeaderView: View {
     @ObservedObject var viewModel: InfoHeaderViewModel
-
+    @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
     @State var participantsListButtonSourceView = UIView()
     let avatarViewManager: AvatarViewManager
     let foregroundColor: Color = .white
@@ -42,9 +42,11 @@ struct InfoHeaderView: View {
                                     bottom: infoLabelHorizontalPadding,
                                     trailing: 0))
                 .foregroundColor(foregroundColor)
+                .lineLimit(1)
                 .font(Fonts.caption1.font)
                 .accessibilityLabel(Text(viewModel.accessibilityLabel))
                 .accessibilitySortPriority(1)
+                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 0.75)
             Spacer()
             participantListButton
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
@@ -11,10 +11,23 @@ struct InfoHeaderView: View {
     @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
     @State var participantsListButtonSourceView = UIView()
     let avatarViewManager: AvatarViewManager
-    let foregroundColor: Color = .white
-    let shapeCornerRadius: CGFloat = 5
-    let infoLabelHorizontalPadding: CGFloat = 16.0
-    let hStackHorizontalPadding: CGFloat = 20.0
+
+    private enum Constants {
+        static let shapeCornerRadius: CGFloat = 5
+        static let infoLabelHorizontalPadding: CGFloat = 16.0
+        static let hStackHorizontalPadding: CGFloat = 20.0
+        static let hSpace: CGFloat = 4
+        static let foregroundColor: Color = .white
+
+        // MARK: Font Minimum Scale Factor
+        // Under accessibility mode, the largest size is 35
+        // so the scale factor would be 9/35 or 0.2
+        static let accessibilityFontScale: CGFloat = 0.2
+        // UI guideline suggested min font size should be 9.
+        // Since Fonts.caption1 has font size of 12,
+        // so min scale factor should be 9/12 or 0.75 as default.
+        static let defaultFontScale: CGFloat = 0.75
+    }
 
     var body: some View {
         ZStack {
@@ -37,25 +50,27 @@ struct InfoHeaderView: View {
     var infoHeader: some View {
         HStack {
             Text(viewModel.infoLabel)
-                .padding(EdgeInsets(top: infoLabelHorizontalPadding,
+                .padding(EdgeInsets(top: Constants.infoLabelHorizontalPadding,
                                     leading: 0,
-                                    bottom: infoLabelHorizontalPadding,
+                                    bottom: Constants.infoLabelHorizontalPadding,
                                     trailing: 0))
-                .foregroundColor(foregroundColor)
+                .foregroundColor(Constants.foregroundColor)
                 .lineLimit(1)
                 .font(Fonts.caption1.font)
                 .accessibilityLabel(Text(viewModel.accessibilityLabel))
                 .accessibilitySortPriority(1)
-                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.2 : 0.75)
+                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ?
+                                    Constants.accessibilityFontScale :
+                                        Constants.defaultFontScale)
             Spacer()
             participantListButton
         }
         .padding(EdgeInsets(top: 0,
-                            leading: hStackHorizontalPadding,
+                            leading: Constants.hStackHorizontalPadding,
                             bottom: 0,
-                            trailing: hStackHorizontalPadding / 2.0))
+                            trailing: Constants.hStackHorizontalPadding / 2.0))
         .background(Color(StyleProvider.color.surfaceDarkColor))
-        .clipShape(RoundedRectangle(cornerRadius: shapeCornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: Constants.shapeCornerRadius))
     }
 
     var participantListButton: some View {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -108,6 +108,7 @@ struct ParticipantTitleView: View {
     @Binding var displayName: String?
     @Binding var isMuted: Bool
     @Binding var isHold: Bool
+    @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
     let titleFont: Font
     let mutedIconSize: CGFloat
     private let hSpace: CGFloat = 4
@@ -122,6 +123,7 @@ struct ParticipantTitleView: View {
                 Text(displayName)
                     .font(titleFont)
                     .lineLimit(1)
+                    .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 0.75)
                     .foregroundColor(Color(StyleProvider.color.onBackground))
             }
             if isMuted && !isHold {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -123,7 +123,7 @@ struct ParticipantTitleView: View {
                 Text(displayName)
                     .font(titleFont)
                     .lineLimit(1)
-                    .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 0.75)
+                    .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.2 : 0.75)
                     .foregroundColor(Color(StyleProvider.color.onBackground))
             }
             if isMuted && !isHold {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellView.swift
@@ -111,19 +111,33 @@ struct ParticipantTitleView: View {
     @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
     let titleFont: Font
     let mutedIconSize: CGFloat
-    private let hSpace: CGFloat = 4
     private var isEmpty: Bool {
         return !isMuted && displayName?.trimmingCharacters(in: .whitespaces).isEmpty == true
     }
 
+    private enum Constants {
+        static let hSpace: CGFloat = 4
+
+        // MARK: Font Minimum Scale Factor
+        // Under accessibility mode, the largest size is 35
+        // so the scale factor would be 9/35 or 0.2
+        static let accessibilityFontScale: CGFloat = 0.2
+        // UI guideline suggested min font size should be 9.
+        // Since Fonts.caption1 has font size of 12,
+        // so min scale factor should be 9/12 or 0.75 as default.
+        static let defaultFontScale: CGFloat = 0.75
+    }
+
     var body: some View {
-        HStack(alignment: .center, spacing: hSpace, content: {
+        HStack(alignment: .center, spacing: Constants.hSpace, content: {
             if let displayName = displayName,
                !displayName.trimmingCharacters(in: .whitespaces).isEmpty {
                 Text(displayName)
                     .font(titleFont)
                     .lineLimit(1)
-                    .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.2 : 0.75)
+                    .minimumScaleFactor(sizeCategory.isAccessibilityCategory ?
+                                        Constants.accessibilityFontScale :
+                                            Constants.defaultFontScale)
                     .foregroundColor(Color(StyleProvider.color.onBackground))
             }
             if isMuted && !isHold {


### PR DESCRIPTION
## Purpose
There's an inconsistency between normal text size and accessibility text size. For example, in accessibility mode, text might appear being cut off while it's not getting cut off in normal text size. 

This PR is meant to address this inconsistency.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. go to settings, accessibility, enable large font
2. open the app
3. start/join a call

## What to Check
1. make sure participant info header has content shown up correctly and texts are not getting cut off
2. make sure participant's name below its avatar is not getting cut off

## Other Information
#### 1. This PR is meant to fix inconsistency between normal font size and accessibility large font sizes. If content was getting cutoff in normal mode (e.g. very long participant's name), it would still be cutoff in accessibility mode (just like how Teams behaves currently). 

#### 2. UI team has requested that content be shown in one line and do not wrap the text.

#### 3. testing was done on iPod touch with large font enabled (smallest screen with biggest font sizes):

## Testing

#### Before
![image](https://user-images.githubusercontent.com/109105353/184007718-66875845-5ea1-40cf-9a15-eb5ad0129020.png)


#### After

### shown longest text we had for info banner on smallest screen we currently support:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/109105353/184001780-2cb8713a-16dc-4c3a-ae15-abe582bbcf6b.png">

![image](https://user-images.githubusercontent.com/109105353/184003877-88064226-59fd-4fd1-a280-cf07cf99a77d.png)



