### PR TITLE
[Feature] Allow customizing title and subtitle

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
@@ -33,6 +33,8 @@ class EnvConfigSubject: ObservableObject {
     @Published var displayName: String = EnvConfig.displayName.value()
     @Published var avatarImageName: String = ""
     @Published var renderedDisplayName: String = ""
+    @Published var navigationTitle: String = ""
+    @Published var navigationSubtitle: String = ""
     @Published var groupCallId: String = EnvConfig.groupCallId.value()
     @Published var teamsMeetingLink: String = EnvConfig.teamsMeetingLink.value()
 

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -86,7 +86,7 @@ struct SettingsView: View {
     }
 
     var navigationSettings: some View {
-        Section(header: Text("Navigation Bar Settigns")) {
+        Section(header: Text("Navigation Bar View Data")) {
             TextField("Navigation Title", text: $envConfigSubject.navigationTitle)
                 .disableAutocorrection(true)
                 .autocapitalization(.none)

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -35,6 +35,7 @@ struct SettingsView: View {
                 localizationSettings
                 localParticipantSettings
                 avatarSettings
+                navigationSettings
                 remoteParticipantsAvatarsSettings
                 themeSettings
             }
@@ -80,6 +81,21 @@ struct SettingsView: View {
             TextField("Rendered Display Name", text: $envConfigSubject.renderedDisplayName)
                 .disableAutocorrection(true)
                 .autocapitalization(.none)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    var navigationSettings: some View {
+        Section(header: Text("Navigation Bar Settigns")) {
+            TextField("Navigation Title", text: $envConfigSubject.navigationTitle)
+                .disableAutocorrection(true)
+                .autocapitalization(.none)
+                .textFieldStyle(.roundedBorder)
+                .textFieldStyle(.roundedBorder)
+            TextField("Navigation SubTitle", text: $envConfigSubject.navigationSubtitle)
+                .disableAutocorrection(true)
+                .autocapitalization(.none)
+                .textFieldStyle(.roundedBorder)
                 .textFieldStyle(.roundedBorder)
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -91,11 +91,9 @@ struct SettingsView: View {
                 .disableAutocorrection(true)
                 .autocapitalization(.none)
                 .textFieldStyle(.roundedBorder)
-                .textFieldStyle(.roundedBorder)
             TextField("Navigation SubTitle", text: $envConfigSubject.navigationSubtitle)
                 .disableAutocorrection(true)
                 .autocapitalization(.none)
-                .textFieldStyle(.roundedBorder)
                 .textFieldStyle(.roundedBorder)
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SwiftUIDemoView.swift
@@ -185,7 +185,7 @@ extension SwiftUIDemoView {
                                                           subtitle: envConfigSubject.navigationSubtitle)
         let localOptions = LocalOptions(participantViewData: participantViewData,
                                         navigationBarViewData: navigationBarViewData)
-        if let credential = try? getTokenCredential() {
+        if let credential = try? await getTokenCredential() {
             switch envConfigSubject.selectedMeetingType {
             case .groupCall:
                 let uuid = UUID(uuidString: link) ?? UUID()

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SwiftUIDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SwiftUIDemoView.swift
@@ -173,7 +173,10 @@ extension SwiftUIDemoView {
                                 nil:envConfigSubject.renderedDisplayName
         let participantViewData = ParticipantViewData(avatar: UIImage(named: envConfigSubject.avatarImageName),
                                                       displayName: renderDisplayName)
-        let localOptions = LocalOptions(participantViewData: participantViewData)
+        let navigationBarViewData = NavigationBarViewData(title: envConfigSubject.navigationTitle,
+                                                          subtitle: envConfigSubject.navigationSubtitle)
+        let localOptions = LocalOptions(participantViewData: participantViewData,
+                                        navigationBarViewData: navigationBarViewData)
         if let credential = try? getTokenCredential() {
             switch envConfigSubject.selectedMeetingType {
             case .groupCall:

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/UIKitDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/UIKitDemoViewController.swift
@@ -175,9 +175,12 @@ class UIKitDemoViewController: UIViewController {
         callComposite.events.onRemoteParticipantJoined = onRemoteParticipantJoinedHandler
         let renderDisplayName = envConfigSubject.renderedDisplayName.isEmpty ?
                                 nil : envConfigSubject.renderedDisplayName
+        let navigationBarViewData = NavigationBarViewData(title: envConfigSubject.navigationTitle,
+                                                          subtitle: envConfigSubject.navigationSubtitle)
         let participantViewData = ParticipantViewData(avatar: UIImage(named: envConfigSubject.avatarImageName),
                                                       displayName: renderDisplayName)
-        let localOptions = LocalOptions(participantViewData: participantViewData)
+        let localOptions = LocalOptions(participantViewData: participantViewData,
+                                        navigationBarViewData: navigationBarViewData)
 
         if let credential = try? await getTokenCredential() {
             switch selectedMeetingType {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## TBA (upcoming release)
 ### New Features
-- Implemented new error message `unknownError` that can be sent to developers in rare cases device manager throws an error.  
+- Implemented new error message `unknownError` that can be sent to developers in rare cases device manager throws an error. [#301](https://github.com/Azure/communication-ui-library-ios/pull/301)
+- Introduced NavigationBarViewData as a new launch option to customize title and subtitle in set up view. [#309](https://github.com/Azure/communication-ui-library-ios/pull/309)
 
 ### Bugs Fixed
 - Fixed an issue where demo app can't dismiss setting page when in landscape mode. [#280](https://github.com/Azure/communication-ui-library-ios/pull/280)
@@ -12,11 +13,11 @@
 
 ### Other Changes
 - Updated CallingSDK's version to GA in manual installation guide [#298](https://github.com/Azure/communication-ui-library-ios/pull/298)
- 
+
 ## 1.0.0 (2022-06-21)
 ### Bugs Fixed
 - Fixed issue where header was still selectable with voiceover on and overlay visible. [#256](https://github.com/Azure/communication-ui-library-ios/pull/256)
-- Fixed hold overlay to have a solid colour. [#262](https://github.com/Azure/communication-ui-library-ios/pull/262) 
+- Fixed hold overlay to have a solid colour. [#262](https://github.com/Azure/communication-ui-library-ios/pull/262)
 - Fixed the issue that resume a call without internet could stop user from exit. [#268](https://github.com/Azure/communication-ui-library-ios/pull/268)
 - Fixed issue inconsistent camera state is inconsistent in setup view when being denied to or evicted from a call. [#273](https://github.com/Azure/communication-ui-library-ios/pull/273)
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
@@ -9,14 +9,14 @@ import UIKit
 /// Object for local options for Call Composite
 public struct LocalOptions {
     /// The ParticipantViewData of the local participant when joining the call.
-    let participantViewData: ParticipantViewData
+    let participantViewData: ParticipantViewData?
     /// The NavigationBarViewData would be used to populate title and subtitle on setup view
     let navigationBarViewData: NavigationBarViewData?
     /// Create an instance of LocalOptions. All information in this object is only stored locally in the composite.
     /// - Parameters:
     ///    - participantViewData: The ParticipantViewData to be displayed for local participants avatar
     ///    - navigationBarViewData: The NavigationBarViewData to be shown on navigation bar of set up view
-    public init(participantViewData: ParticipantViewData,
+    public init(participantViewData: ParticipantViewData? = nil,
                 navigationBarViewData: NavigationBarViewData? = nil) {
         self.participantViewData = participantViewData
         self.navigationBarViewData = navigationBarViewData

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
@@ -10,11 +10,16 @@ import UIKit
 public struct LocalOptions {
     /// The ParticipantViewData of the local participant when joining the call.
     let participantViewData: ParticipantViewData
+    /// The NavigationBarViewData would be used to populate title and subtitle on setup view
+    let navigationBarViewData: NavigationBarViewData?
     /// Create an instance of LocalOptions. All information in this object is only stored locally in the composite.
     /// - Parameters:
     ///    - participantViewData: The ParticipantViewData to be displayed for local participants avatar
-    public init(participantViewData: ParticipantViewData) {
+    ///    - navigationBarViewData: The NavigationBarViewData to be shown on navigation bar of set up view
+    public init(participantViewData: ParticipantViewData,
+                navigationBarViewData: NavigationBarViewData? = nil) {
         self.participantViewData = participantViewData
+        self.navigationBarViewData = navigationBarViewData
     }
 }
 /// Object to represent participants data
@@ -26,7 +31,7 @@ public struct ParticipantViewData {
     /// Create an instance of a ParticipantViewData.
     /// All information in this object is only stored locally in the composite.
     /// - Parameters:
-    ///    - avatar: The UIImage that will be displayer in the avatar view.
+    ///    - avatar: The UIImage that will be displayed in the avatar view.
     ///              If this is `nil` the default avatar with user's initials will be used instead.
     ///    - displayName: The display name  to be rendered.
     ///                   If this is `nil` the display name provided in the Call Options will be used instead.
@@ -34,5 +39,24 @@ public struct ParticipantViewData {
                 displayName: String? = nil) {
         self.avatarImage = avatar
         self.displayName = displayName
+    }
+}
+/// Object to represent the data needed to customize navigation bar
+public struct NavigationBarViewData {
+    /// The title that would be used for the navigation bar of setup view
+    let title: String?
+    /// The subtitle that would be used for the navigation bar of setup view
+    let subtitle: String?
+    /// Create an instance of a NavigationBarViewData.
+    /// All information in this object is only stored locally in the composite.
+    /// - Parameters:
+    ///    - title: The String that would be displayed as the title in setup view
+    ///              If this is `nil` the default title "Setup" would be used
+    ///    - subtitle: The String that would be displayed as the subtitle in setup view
+    ///                   If this is `nil` the subtitle would be hidden
+    public init(title: String? = nil,
+                subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
@@ -51,7 +51,8 @@ final class DependencyContainer {
         register(CompositeViewModelFactory(logger: resolve(),
                                            store: resolve(),
                                            localizationProvider: resolve(),
-                                           accessibilityProvider: resolve()) as CompositeViewModelFactoryProtocol)
+                                           accessibilityProvider: resolve(),
+                                           localOptions: localOptions) as CompositeViewModelFactoryProtocol)
         register(CompositeViewFactory(logger: resolve(),
                                       avatarManager: resolve(),
                                       videoViewManager: resolve(),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
@@ -40,7 +40,7 @@ final class DependencyContainer {
         register(VideoViewManager(callingSDKWrapper: resolve(), logger: resolve()) as VideoViewManager)
         register(CallingService(logger: resolve(),
                                 callingSDKWrapper: resolve()) as CallingServiceProtocol)
-        let displayName = localOptions?.participantViewData.displayName ?? callConfiguration.displayName
+        let displayName = localOptions?.participantViewData?.displayName ?? callConfiguration.displayName
         register(makeStore(displayName: displayName) as Store<AppState>)
         register(NavigationRouter(store: resolve(),
                                   logger: resolve()) as NavigationRouter)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -63,6 +63,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     private let store: Store<AppState>
     private let accessibilityProvider: AccessibilityProviderProtocol
     private let localizationProvider: LocalizationProviderProtocol
+    private let localOptions: LocalOptions?
 
     private weak var setupViewModel: SetupViewModel?
     private weak var callingViewModel: CallingViewModel?
@@ -70,11 +71,13 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     init(logger: Logger,
          store: Store<AppState>,
          localizationProvider: LocalizationProviderProtocol,
-         accessibilityProvider: AccessibilityProviderProtocol) {
+         accessibilityProvider: AccessibilityProviderProtocol,
+         localOptions: LocalOptions?) {
         self.logger = logger
         self.store = store
         self.accessibilityProvider = accessibilityProvider
         self.localizationProvider = localizationProvider
+        self.localOptions = localOptions
     }
 
     // MARK: CompositeViewModels
@@ -83,7 +86,8 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
             let viewModel = SetupViewModel(compositeViewModelFactory: self,
                                            logger: logger,
                                            store: store,
-                                           localizationProvider: localizationProvider)
+                                           localizationProvider: localizationProvider,
+                                           navigationBarViewData: localOptions?.navigationBarViewData)
             self.setupViewModel = viewModel
             self.callingViewModel = nil
             return viewModel

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -72,7 +72,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
          store: Store<AppState>,
          localizationProvider: LocalizationProviderProtocol,
          accessibilityProvider: AccessibilityProviderProtocol,
-         localOptions: LocalOptions?) {
+         localOptions: LocalOptions? = nil) {
         self.logger = logger
         self.store = store
         self.accessibilityProvider = accessibilityProvider

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -40,6 +40,9 @@ class ColorThemeProvider {
     let onHoldBackground = UIColor.compositeColor(.onHoldBackground)
     let textSecondary = UIColor.compositeColor(.textSecondary)
     let iconSecondary = UIColor.compositeColor(.iconSecondary)
+    lazy var subtitleColor: UIColor = {
+        return dynamicColor(light: FluentUI.Colors.textSecondary, dark: UIColor.white)
+    }()
 
     init(themeOptions: ThemeOptions?) {
         self.colorSchemeOverride = themeOptions?.colorSchemeOverride ?? .unspecified
@@ -48,6 +51,10 @@ class ColorThemeProvider {
         self.primaryColorTint10 = themeOptions?.primaryColorTint10 ?? Colors.Palette.communicationBlueTint10.color
         self.primaryColorTint20 = themeOptions?.primaryColorTint20 ?? Colors.Palette.communicationBlueTint20.color
         self.primaryColorTint30 = themeOptions?.primaryColorTint30 ?? Colors.Palette.communicationBlueTint30.color
+    }
+
+    private func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+        return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -118,8 +118,11 @@ struct SetupView: View {
 
 struct SetupTitleView: View {
     let viewHeight: CGFloat = 44
+    let padding: CGFloat = 34.0
     let verticalSpacing: CGFloat = 0
     var viewModel: SetupViewModel
+
+    @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
 
     var body: some View {
         VStack(spacing: verticalSpacing) {
@@ -129,12 +132,25 @@ struct SetupTitleView: View {
                     .accessibilityIdentifier(AccessibilityIdentifier.dismisButtonAccessibilityID.rawValue)
                 HStack {
                     Spacer()
-                    Text(viewModel.title)
-                        .font(Fonts.headline.font)
-                        .foregroundColor(Color(StyleProvider.color.onBackground))
-                        .accessibilityAddTraits(.isHeader)
+                    VStack {
+                        Text(viewModel.title)
+                            .font(Fonts.headline.font)
+                            .foregroundColor(Color(StyleProvider.color.onBackground))
+                            .lineLimit(1)
+                            .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 1)
+                            .accessibilityAddTraits(.isHeader)
+                        if let subtitle = viewModel.subTitle, !subtitle.isEmpty {
+                            Text(subtitle)
+                                .font(Fonts.subhead.font)
+                                .foregroundColor(Color(StyleProvider.color.onBackground))
+                                .lineLimit(1)
+                                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 1)
+                                .accessibilityAddTraits(.isHeader)
+                        }
+                    }
                     Spacer()
                 }.accessibilitySortPriority(1)
+                    .padding(padding)
             }.frame(height: viewHeight)
             Divider()
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -141,8 +141,8 @@ struct SetupTitleView: View {
                             .accessibilityAddTraits(.isHeader)
                         if let subtitle = viewModel.subTitle, !subtitle.isEmpty {
                             Text(subtitle)
-                                .font(Fonts.subhead.font)
-                                .foregroundColor(Color(StyleProvider.color.onBackground))
+                                .font(Fonts.caption1.font)
+                                .foregroundColor(Color(StyleProvider.color.subtitleColor))
                                 .lineLimit(1)
                                 .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 1)
                                 .accessibilityAddTraits(.isHeader)
@@ -150,7 +150,7 @@ struct SetupTitleView: View {
                     }
                     Spacer()
                 }.accessibilitySortPriority(1)
-                    .padding(padding)
+                 .padding(padding)
             }.frame(height: viewHeight)
             Divider()
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -137,14 +137,14 @@ struct SetupTitleView: View {
                             .font(Fonts.headline.font)
                             .foregroundColor(Color(StyleProvider.color.onBackground))
                             .lineLimit(1)
-                            .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 1)
+                            .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.4 : 1)
                             .accessibilityAddTraits(.isHeader)
                         if let subtitle = viewModel.subTitle, !subtitle.isEmpty {
                             Text(subtitle)
                                 .font(Fonts.caption1.font)
                                 .foregroundColor(Color(StyleProvider.color.subtitleColor))
                                 .lineLimit(1)
-                                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.1 : 1)
+                                .minimumScaleFactor(sizeCategory.isAccessibilityCategory ? 0.4 : 1)
                                 .accessibilityAddTraits(.isHeader)
                         }
                     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -15,7 +15,8 @@ class SetupViewModel: ObservableObject {
 
     let isRightToLeft: Bool
     let previewAreaViewModel: PreviewAreaViewModel
-    let title: String
+    var title: String
+    var subTitle: String?
 
     var errorInfoViewModel: ErrorInfoViewModel
     var dismissButtonViewModel: IconButtonViewModel!
@@ -29,13 +30,22 @@ class SetupViewModel: ObservableObject {
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,
          store: Store<AppState>,
-         localizationProvider: LocalizationProviderProtocol) {
+         localizationProvider: LocalizationProviderProtocol,
+         navigationBarViewData: NavigationBarViewData?) {
         self.store = store
         self.localizationProvider = localizationProvider
         self.isRightToLeft = localizationProvider.isRightToLeft
         self.logger = logger
 
-        title = self.localizationProvider.getLocalizedString(.setupTitle)
+        if let title = navigationBarViewData?.title, !title.isEmpty {
+            // if title is not nil/empty, use given title and optional subtitle
+            self.title = title
+            self.subTitle = navigationBarViewData?.subtitle
+        } else {
+            // else if title is nil/empty, use default title and disregard given subtitle
+            self.title = self.localizationProvider.getLocalizedString(.setupTitle)
+            self.subTitle = nil
+        }
 
         previewAreaViewModel = compositeViewModelFactory.makePreviewAreaViewModel(dispatchAction: store.dispatch)
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -31,7 +31,7 @@ class SetupViewModel: ObservableObject {
          logger: Logger,
          store: Store<AppState>,
          localizationProvider: LocalizationProviderProtocol,
-         navigationBarViewData: NavigationBarViewData?) {
+         navigationBarViewData: NavigationBarViewData? = nil) {
         self.store = store
         self.localizationProvider = localizationProvider
         self.isRightToLeft = localizationProvider.isRightToLeft

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
@@ -111,7 +111,7 @@ struct LocalVideoView: View {
                 localVideoStreamId = $0
             }
         }.onReceive(avatarManager.$localOptions) {
-            avatarImage = $0?.participantViewData.avatarImage
+            avatarImage = $0?.participantViewData?.avatarImage
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Manager/AvatarManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Manager/AvatarManagerTests.swift
@@ -28,7 +28,7 @@ class AvatarManagerTests: XCTestCase {
         }
         let mockAvatarManager = makeSUT(mockImage)
         let mockImageData = mockImage.cgImage?.bitsPerPixel
-        let setAvatar = mockAvatarManager.localOptions?.participantViewData.avatarImage
+        let setAvatar = mockAvatarManager.localOptions?.participantViewData?.avatarImage
         let setAvatarImageData = setAvatar?.cgImage?.bitsPerPixel
         XCTAssertEqual(mockImageData, setAvatarImageData)
     }


### PR DESCRIPTION
## Purpose
This PR adds a new ability for Contoso developer to customize the title and subtitle on set up view. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[] Yes
[X] No
```

new options:
```
launch() -> 
    - remote options
    - local options
        - participant view data
        - navigation bar view data      <- NEW
            - title                     <- NEW
            - subtitle                  <- NEW
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. download the code, run it in simulator
2. tap on settings, enter title and subtitle
3. close settings, tap on start experience 


## What to Check
1. make sure title and subtitle are reflecting what you have entered in settings
2. if title is empty, check if default title "setup" was used and subtitle is hidden
3. if subtitle is empty, check if subtitle is hidden
4. title's colour is "text dominant" for both light/dark modes, subtitle's colour is "text secondary" for light mode and "text dominant" for dark mode.


## Other Information
1. checked with UI Design, contoso developer is able to enter unlimited characters, but we would truncate the title/subtitle when they become too long
2. Unit tests is coming up as a second PR for this ticket.3. 
3. Android PR: https://github.com/Azure/communication-ui-library-android/pull/383
## Screenshots

### happy path
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/109105353/184723676-c43f74cf-6e89-43c2-a80d-758c4714eba3.png">
<img width="422" alt="image" src="https://user-images.githubusercontent.com/109105353/184723730-335f3909-32f3-44a9-acce-78f5d672ec6a.png">

### edge cases
<img width="423" alt="image" src="https://user-images.githubusercontent.com/109105353/184723774-05708761-f74a-4aff-bf2c-3e851966d80f.png">
<img width="309" alt="image" src="https://user-images.githubusercontent.com/109105353/184724371-24e489d8-771c-45ba-93d4-65d4557aa9a1.png">

![image](https://user-images.githubusercontent.com/109105353/184930656-f04f3839-4acc-492b-be89-58e9cbf20671.png)

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-08-15 at 14 53 07](https://user-images.githubusercontent.com/109105353/184724825-f45421d1-4981-4935-9e6f-b893ef186b6c.png)

