### PR TITLE
[Refactoring] Fluent UI Refactoring Part 1 - Setup View

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -49,14 +49,14 @@ class ColorThemeProvider {
     let genericIconDisabled: UIColor = FluentUI.Colors.iconDisabled
 
     // MARK: - Setup View Colours
-    lazy var setupTitleText: UIColor = genericLabel
+    lazy var setupTitleLabel: UIColor = genericLabel
+    lazy var premissionIcon: UIColor = genericIcon
+    lazy var permissionText: UIColor = genericLabel
+    lazy var previewGradient = UIColor.black.withAlphaComponent(0.7)
     lazy var videoBackground: UIColor = {
         return dynamicColor(light: FluentUI.Colors.surfaceQuaternary,
                             dark: FluentUI.Colors.surfaceTertiary)
     }()
-    lazy var premissionIcon: UIColor = genericIcon
-    lazy var permissionText: UIColor = genericLabel
-    lazy var previewGradient = UIColor.black.withAlphaComponent(0.7)
     lazy var warningLabel: UIColor = {
         return dynamicColor(light: FluentUI.Colors.Palette.warningShade30.color,
                             dark: UIColor.black)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -15,6 +15,7 @@ class ColorThemeProvider {
     let primaryColorTint20: UIColor
     let primaryColorTint30: UIColor
 
+    // MARK: To Be Deleted After Refactoring Part 2 is done
     let backgroundColor = UIColor.compositeColor(.background)
     let gridLayoutBackground = UIColor.compositeColor(.gridLayoutBackground)
     let onSurfaceColor = UIColor.compositeColor(.onSurface)
@@ -41,6 +42,32 @@ class ColorThemeProvider {
     let textSecondary = UIColor.compositeColor(.textSecondary)
     let iconSecondary = UIColor.compositeColor(.iconSecondary)
 
+    // MARK: - Fluent UI Refactoring Starts - Part 1
+    // MARK: - Shared
+    let genericLabel: UIColor = FluentUI.Colors.textPrimary
+    let genericIcon: UIColor = FluentUI.Colors.textPrimary
+    let genericIconDisabled: UIColor = FluentUI.Colors.iconDisabled
+
+    // MARK: - Setup View Colours
+    lazy var setupTitleText: UIColor = genericLabel
+    lazy var videoBackground: UIColor = {
+        return dynamicColor(light: FluentUI.Colors.surfaceQuaternary,
+                            dark: FluentUI.Colors.surfaceTertiary)
+    }()
+    lazy var premissionIcon: UIColor = genericIcon
+    lazy var permissionText: UIColor = genericLabel
+    lazy var previewGradient = UIColor.black.withAlphaComponent(0.7)
+    lazy var warningLabel: UIColor = {
+        return dynamicColor(light: FluentUI.Colors.Palette.warningShade30.color,
+                            dark: UIColor.black)
+    }()
+    lazy var warningBanner: UIColor = {
+        return dynamicColor(light: FluentUI.Colors.Palette.warningTint40.color,
+                            dark: FluentUI.Colors.warning)
+    }()
+
+    // MARK: - Calling View Colours - Coming up in Part 2
+
     init(themeOptions: ThemeOptions?) {
         self.colorSchemeOverride = themeOptions?.colorSchemeOverride ?? .unspecified
 
@@ -48,6 +75,10 @@ class ColorThemeProvider {
         self.primaryColorTint10 = themeOptions?.primaryColorTint10 ?? Colors.Palette.communicationBlueTint10.color
         self.primaryColorTint20 = themeOptions?.primaryColorTint20 ?? Colors.Palette.communicationBlueTint20.color
         self.primaryColorTint30 = themeOptions?.primaryColorTint30 ?? Colors.Palette.communicationBlueTint30.color
+    }
+
+    private func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+        return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
@@ -148,7 +148,7 @@ struct CallingView: View {
                            viewManager: viewManager,
                            viewType: .localVideofull,
                            avatarManager: avatarManager)
-                .background(Color(StyleProvider.color.surface))
+                .background(Color(StyleProvider.color.videoBackground))
                 .edgesIgnoringSafeArea(safeAreaIgnoreArea)
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -35,7 +35,7 @@ struct SetupView: View {
                                                 avatarManager: avatarManager)
                                 SetupControlBarView(viewModel: viewModel.setupControlBarViewModel)
                             }
-                            .background(Color(StyleProvider.color.surface))
+                            .background(Color(StyleProvider.color.videoBackground))
                             .cornerRadius(4)
                             joinCallView
                                 .padding(.bottom)
@@ -131,7 +131,7 @@ struct SetupTitleView: View {
                     Spacer()
                     Text(viewModel.title)
                         .font(Fonts.headline.font)
-                        .foregroundColor(Color(StyleProvider.color.onBackground))
+                        .foregroundColor(Color(StyleProvider.color.setupTitleLabel))
                         .accessibilityAddTraits(.isHeader)
                     Spacer()
                 }.accessibilitySortPriority(1)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/JoiningCallActivityView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/JoiningCallActivityView.swift
@@ -17,7 +17,7 @@ struct JoiningCallActivityView: View {
                 .isAnimating(true)
             Text(viewModel.title)
                 .font(Fonts.subhead.font)
-                .foregroundColor(Color(StyleProvider.color.onSurfaceColor))
+                .foregroundColor(Color(StyleProvider.color.genericLabel))
             Spacer()
         }.frame(height: containerHeight)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/PreviewAreaView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/PreviewAreaView.swift
@@ -42,12 +42,12 @@ struct PermissionWarningView: View {
         GeometryReader { geometry in
             VStack(spacing: verticalSpacing) {
                 Icon(name: displayIcon, size: iconSize)
-                    .foregroundColor(Color(StyleProvider.color.onSurface))
+                    .foregroundColor(Color(StyleProvider.color.premissionIcon))
                 Text(displayText)
                     .frame(width: width)
                     .font(Fonts.subhead.font)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(Color(StyleProvider.color.onSurface))
+                    .foregroundColor(Color(StyleProvider.color.permissionText))
             }.frame(width: geometry.size.width,
                     height: geometry.size.height)
             .accessibilityElement(children: .combine)
@@ -65,7 +65,7 @@ struct GradientView: View {
                 .fill(
                     LinearGradient(gradient: Gradient(stops: [
                         Gradient.Stop(color: .black.opacity(0), location: 0.3914),
-                        Gradient.Stop(color: Color(StyleProvider.color.gradientColor), location: 0.9965)
+                        Gradient.Stop(color: Color(StyleProvider.color.previewGradient), location: 0.9965)
                     ]), startPoint: .top, endPoint: .bottom)
                 )
                 .frame(maxHeight: height)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Button/IconButton.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Button/IconButton.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct IconButton: View {
     @ObservedObject var viewModel: IconButtonViewModel
 
-    private let buttonDisabledColor = Color(StyleProvider.color.disableColor)
+    private let buttonDisabledColor = Color(StyleProvider.color.genericIconDisabled)
     private var iconImageSize: CGFloat {
         switch viewModel.buttonType {
         case .dismissButton:
@@ -60,10 +60,8 @@ struct IconButton: View {
     }
     var buttonForegroundColor: Color {
         switch viewModel.buttonType {
-        case .controlButton:
-            return Color(StyleProvider.color.onSurfaceColor)
-        case .dismissButton:
-            return Color(StyleProvider.color.onBackground)
+        case .controlButton, .dismissButton:
+            return Color(StyleProvider.color.genericIcon)
         default:
             return .white
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Button/IconWithLabelButton.swift
@@ -15,12 +15,12 @@ struct IconWithLabelButton: View {
     private let verticalSpacing: CGFloat = 8
     private let width: CGFloat = 85
     private let height: CGFloat = 85
-    private let buttonDisabledColor = Color(StyleProvider.color.disableColor)
+    private let buttonDisabledColor = Color(StyleProvider.color.genericIconDisabled)
 
     var buttonForegroundColor: Color {
         switch viewModel.buttonTypeColor {
         case .colorThemedWhite:
-            return Color(StyleProvider.color.onSurfaceColor)
+            return Color(StyleProvider.color.genericIcon)
         case .white:
             return Color(.white)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoView.swift
@@ -17,13 +17,13 @@ struct ErrorInfoView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(viewModel.title)
                         .font(Fonts.button1.font)
-                        .foregroundColor(Color(StyleProvider.color.onWarning))
+                        .foregroundColor(Color(StyleProvider.color.warningLabel))
                         .accessibilitySortPriority(1)
 
                     if !viewModel.subtitle.isEmpty {
                         Text(viewModel.subtitle)
                             .font(Fonts.subhead.font)
-                            .foregroundColor(Color(StyleProvider.color.onWarning))
+                            .foregroundColor(Color(StyleProvider.color.warningLabel))
                             .accessibilitySortPriority(2)
                     }
                 }.padding([.top, .leading, .bottom])
@@ -31,14 +31,14 @@ struct ErrorInfoView: View {
                 Button(action: viewModel.dismiss) {
                     Text(viewModel.dismissContent)
                         .font(Fonts.button1.font)
-                        .foregroundColor(Color(StyleProvider.color.onWarning))
+                        .foregroundColor(Color(StyleProvider.color.warningLabel))
                 }
                 .padding([.top, .bottom, .trailing])
                 .accessibilityLabel(Text(viewModel.dismissAccessibilitylabel))
                 .accessibilityHint(Text(viewModel.dismissAccessibilityHint))
                 .accessibilitySortPriority(0)
             }
-            .background(Color(StyleProvider.color.warning))
+            .background(Color(StyleProvider.color.warningBanner))
             .cornerRadius(cornerRadius)
         }
     }


### PR DESCRIPTION
## Purpose
This PR updates colours we are using in the app to Fluent UI colours. This is part 1 PR which would refactor colours used in Set-up View only.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


## How to Test
1. use digital colour picker to see if colour from before and after are aligned.

## What to Check
1. if no changes are mentioned, colour should match
2. if changes are mentioned, new colour should match the UI spec
## Other Information
1. changed with UI design, the given UI spec does not follow Fluent UI exactly. It's okay to use custom dark/light mode combo rather than the ones from Fluent UI
2. some colours might not exist in Fluent UI, we should be using custom colours in this case
3. some icons follows text primary colour and this is expected. UI mentioned that they would change the spec later on, but for now, keep it as is

## Screenshot:
![Group 2](https://user-images.githubusercontent.com/109105353/185243495-fa9b3c6a-e90f-424d-91f1-8755f3d1f231.png)

