### PR TITLE
[Feature] Send error to Contoso when my video start fails

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBA (upcoming release)
 ### New Features
 - Implemented new error message `unknownError` that can be sent to developers in rare cases device manager throws an error.  
+- Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails.
 
 ### Bugs Fixed
 - Fixed an issue where demo app can't dismiss setting page when in landscape mode. [#280](https://github.com/Azure/communication-ui-library-ios/pull/280)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## TBA (upcoming release)
 ### New Features
 - Implemented new error message `unknownError` that can be sent to developers in rare cases device manager throws an error.  
-- Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails.
+- Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails. [#311](https://github.com/Azure/communication-ui-library-ios/pull/311)
+
 
 ### Bugs Fixed
 - Fixed an issue where demo app can't dismiss setting page when in landscape mode. [#280](https://github.com/Azure/communication-ui-library-ios/pull/280)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeError.swift
@@ -13,6 +13,9 @@ public struct CallCompositeErrorCode {
     /// Error when a call disconnects unexpectedly or fails on ending.
     public static var callEnd: String = "callEnd"
 
+    /// Error when camera failed to start or stop
+    public static let cameraFailure: String = "cameraFailure"
+
     /// Error when the input token is expired.
     public static let tokenExpired: String = "tokenExpired"
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Reducer/ErrorReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Reducer/ErrorReducer.swift
@@ -26,6 +26,10 @@ extension Reducer where State == ErrorState,
             errorType = nil
             error = nil
             errorCategory = .none
+        case .localUserAction(.cameraOnFailed):
+            errorType = .cameraOnFailed
+            error = nil
+            errorCategory = .callState
 
             // Exhaustive unimplemented actions
         case .audioSessionAction(_),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
@@ -27,12 +27,13 @@ enum CallCompositeInternalError: Error, Equatable {
             return CallCompositeErrorCode.callJoin
         case .callEndFailed:
             return CallCompositeErrorCode.callEnd
+        case .cameraOnFailed:
+            return CallCompositeErrorCode.cameraFailure
         case .callHoldFailed,
                 .callResumeFailed,
                 .callEvicted,
                 .callDenied,
-                .cameraSwitchFailed,
-                .cameraOnFailed:
+                .cameraSwitchFailed:
             return nil
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Reducer/ErrorReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Reducer/ErrorReducerTests.swift
@@ -71,6 +71,16 @@ class ErrorReducerTests: XCTestCase {
         XCTAssertEqual(resultState.internalError, nil)
         XCTAssertEqual(resultState.errorCategory, .none)
     }
+
+    func test_handleErrorReducer_reduce_when_cameraOnFailed_then_returnErrorState_categoryCallState() {
+        let state = ErrorState()
+        let action = Action.localUserAction(.cameraOnFailed(error: CallCompositeInternalError.cameraOnFailed))
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        XCTAssertEqual(resultState.internalError, .cameraOnFailed)
+        XCTAssertEqual(resultState.errorCategory, .callState)
+    }
 }
 
 extension ErrorReducerTests {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* In both PreviewView and CallingView, when it failed to turn on the camera, we want to send this error to Contoso

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
<!-- Add any other helpful information that may be needed here. -->