### PR TITLE
[Hotfix] Update podspec to use the info.plist from repo

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling.podspec
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.source_files         = 'AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/**/*.swift'
   spec.resources            = 'AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/**/*.{xcassets,strings}'
 
-  spec.pod_target_xcconfig  = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64", "ENABLE_BITCODE": "NO"}
+  spec.pod_target_xcconfig  = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64", "ENABLE_BITCODE": "NO", 'INFOPLIST_FILE' => '$(PODS_TARGET_SRCROOT)/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/info.plist'}
   
   spec.dependency             'AzureCommunicationCalling', '2.2.0'
   spec.dependency             'MicrosoftFluentUI/Avatar_ios', '0.3.9'

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling.podspec
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |spec|
 
   spec.source_files         = 'AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/**/*.swift'
   spec.resources            = 'AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/**/*.{xcassets,strings}'
-
-  spec.pod_target_xcconfig  = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64", "ENABLE_BITCODE": "NO", 'INFOPLIST_FILE' => '$(PODS_TARGET_SRCROOT)/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/info.plist'}
+  spec.preserve_paths            = 'AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Info.plist'
+  spec.pod_target_xcconfig  = { "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64", "ENABLE_BITCODE": "NO", 'INFOPLIST_FILE' => '$(PODS_TARGET_SRCROOT)/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling/Info.plist'}
   
   spec.dependency             'AzureCommunicationCalling', '2.2.0'
   spec.dependency             'MicrosoftFluentUI/Avatar_ios', '0.3.9'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Cocoapod would generate an info.plist during building time, but that info.plist wouldn't include the `custom value/keys` we defined in our repo plist file. We use the `custom value/keys` to store the current library versioning. And it is missing from the Cocoapod generated info.plist when customer use Cocoapod to install our UI lib. 
* To fix the issue, find some solutions from Github community: https://github.com/CocoaPods/CocoaPods/issues/8753
Note: use `spec.resources` to include `plist` file would introduce `duplicated info.plist` issue. Find an alternative to use `spec.preserve_paths ` to include the `plist` file. 
* Based on [vhuseinova-msft](https://github.com/Azure/communication-ui-library-ios/commits?author=vhuseinova-msft) and mine test, the new podspec file should be able to include the `info.plist` directly from our repo, and read the correct `UILibrarySemVersion` 


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
```
