### PR TITLE
[Feature] Show error banner when video start/stop fails

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
@@ -98,3 +98,4 @@
 "AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallTitle"="Unable to resume call";
 "AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallSubTitle"="Your mic is in use by another app";
 "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied"="You were denied access to the call.";
+"AzureCommunicationUICalling.SnackBar.Text.CameraOnFailed"="Error toggling video";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
@@ -12,10 +12,9 @@ struct CallingView: View {
         static let infoHeaderViewHorizontalPadding: CGFloat = 8.0
         static let infoHeaderViewMaxWidth: CGFloat = 380.0
         static let infoHeaderViewHeight: CGFloat = 46.0
+        static let controlBarHeight: CGFloat = 92
+        static let errorHorizontalPadding: CGFloat = 8
     }
-
-    let controlBarHeight: CGFloat = 92
-    let errorHorizontalPadding: CGFloat = 8
 
     @ObservedObject var viewModel: CallingViewModel
     let avatarManager: AvatarViewManager
@@ -172,9 +171,9 @@ struct CallingView: View {
             Spacer()
             ErrorInfoView(viewModel: viewModel.errorInfoViewModel)
                 .padding(EdgeInsets(top: 0,
-                                    leading: errorHorizontalPadding,
-                                    bottom: controlBarHeight,
-                                    trailing: errorHorizontalPadding)
+                                    leading: Constants.errorHorizontalPadding,
+                                    bottom: Constants.controlBarHeight,
+                                    trailing: Constants.errorHorizontalPadding)
                 )
                 .accessibilityElement(children: .contain)
                 .accessibilityAddTraits(.isModal)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingView.swift
@@ -14,6 +14,9 @@ struct CallingView: View {
         static let infoHeaderViewHeight: CGFloat = 46.0
     }
 
+    let controlBarHeight: CGFloat = 92
+    let errorHorizontalPadding: CGFloat = 8
+
     @ObservedObject var viewModel: CallingViewModel
     let avatarManager: AvatarViewManager
     let viewManager: VideoViewManager
@@ -35,6 +38,7 @@ struct CallingView: View {
             } else {
                 landscapeCallingView
             }
+            errorInfoView
         }
         .environment(\.screenSizeClass, getSizeClass())
         .environment(\.appPhase, viewModel.appState)
@@ -160,6 +164,20 @@ struct CallingView: View {
             } else {
                 localVideoFullscreenView
             }
+        }
+    }
+
+    var errorInfoView: some View {
+        return VStack {
+            Spacer()
+            ErrorInfoView(viewModel: viewModel.errorInfoViewModel)
+                .padding(EdgeInsets(top: 0,
+                                    leading: errorHorizontalPadding,
+                                    bottom: controlBarHeight,
+                                    trailing: errorHorizontalPadding)
+                )
+                .accessibilityElement(children: .contain)
+                .accessibilityAddTraits(.isModal)
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -30,6 +30,7 @@ class CallingViewModel: ObservableObject {
 
     var controlBarViewModel: ControlBarViewModel!
     var infoHeaderViewModel: InfoHeaderViewModel!
+    var errorInfoViewModel: ErrorInfoViewModel!
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,
          logger: Logger,
@@ -77,6 +78,8 @@ class CallingViewModel: ObservableObject {
             }.store(in: &cancellables)
 
         updateIsLocalCameraOn(with: store.state)
+        errorInfoViewModel = compositeViewModelFactory.makeErrorInfoViewModel(title: "",
+                                                                              subtitle: "")
     }
 
     func dismissConfirmLeaveDrawerList() {
@@ -134,6 +137,7 @@ class CallingViewModel: ObservableObject {
         }
 
         updateIsLocalCameraOn(with: state)
+        errorInfoViewModel.update(errorState: state.errorState)
     }
 
     private func updateIsLocalCameraOn(with state: AppState) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
@@ -62,6 +62,8 @@ class ErrorInfoViewModel: ObservableObject {
             title = localizationProvider.getLocalizedString(.snackBarErrorCallEvicted)
         case .callDenied:
             title = localizationProvider.getLocalizedString(.snackBarErrorCallDenied)
+        case .cameraOnFailed:
+            title = localizationProvider.getLocalizedString(.snackBarErrorCameraOnFailed)
         default:
             title = localizationProvider.getLocalizedString(.snackBarError)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -117,4 +117,5 @@ enum LocalizationKey: String {
     case snackBarErrorOnHoldSubtitle = "AzureCommunicationUICalling.SnackBar.Text.ErrorResumeCallSubTitle"
     case snackBarErrorCallDenied =
             "AzureCommunicationUICalling.SnackBar.Text.ErrorCallDenied"
+    case snackBarErrorCameraOnFailed = "AzureCommunicationUICalling.SnackBar.Text.CameraOnFailed"
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -83,6 +83,17 @@ class ErrorInfoViewModelTests: XCTestCase {
         XCTAssertEqual(sut.isDisplayed, false)
     }
 
+    func test_errorInfoViewModel_update_when_errorStateCameraOnFailedSet_then_snackBarErrorCameraOnFailedMessageDisplayed() {
+        let sut = makeSUT()
+        let state = ErrorState(internalError: .cameraOnFailed,
+                               error: nil,
+                               errorCategory: .callState)
+
+        sut.update(errorState: state)
+        XCTAssertEqual(sut.isDisplayed, true)
+        XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.CameraOnFailed")
+    }
+
     func makeSUT() -> ErrorInfoViewModel {
         return ErrorInfoViewModel(localizationProvider: localizationProvider)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -32,7 +32,7 @@ class ErrorInfoViewModelTests: XCTestCase {
                                errorCategory: .callState)
 
         sut.update(errorState: state)
-        XCTAssertEqual(sut.isDisplayed, true)
+        XCTAssertTrue(sut.isDisplayed)
         XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallJoin")
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -32,7 +32,7 @@ class ErrorInfoViewModelTests: XCTestCase {
                                errorCategory: .callState)
 
         sut.update(errorState: state)
-        XCTAssertTrue(sut.isDisplayed)
+        XCTAssertEqual(sut.isDisplayed, true)
         XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.ErrorCallJoin")
     }
 
@@ -90,7 +90,7 @@ class ErrorInfoViewModelTests: XCTestCase {
                                errorCategory: .callState)
 
         sut.update(errorState: state)
-        XCTAssertEqual(sut.isDisplayed, true)
+        XCTAssertTrue(sut.isDisplayed)
         XCTAssertEqual(sut.title, "AzureCommunicationUICalling.SnackBar.Text.CameraOnFailed")
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Show error banner when turning on camera failed

<img src="https://user-images.githubusercontent.com/107075081/185516104-43fb4c01-e070-48a2-8abb-e7b2b11f5cdb.png" width=300> 
<img src="https://user-images.githubusercontent.com/107075081/185516108-ab1f66e0-c0bd-4305-b64c-5058c150faef.png" width=300> 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* download the code and run it
* Mimic camera on failed error by replacing requestCameraPreviewOn and requestCameraOn functions with the following code:
```
    func requestCameraPreviewOn(state: AppState, dispatch: @escaping ActionDispatch) {
        if state.permissionState.cameraPermission == .notAsked {
            dispatch(.permissionAction(.cameraPermissionRequested))
        } else {
            callingService.requestCameraPreviewOn().map { videoStream in
                LocalUserAction.cameraOnSucceeded(videoStreamIdentifier: videoStream)
            }.sink(receiveCompletion: { completion in
                switch completion {
                case .finished:
                    break
                case .failure(let error):
                    dispatch(.localUserAction(.cameraOnFailed(error: error)))
                }
            }, receiveValue: { _ in
//                dispatch(.localUserAction(newAction))
                let error = CallCompositeInternalError.cameraOnFailed
                dispatch(.localUserAction(.cameraOnFailed(error: error)))
            }).store(in: cancelBag)
        }
    }

    func requestCameraOn(state: AppState, dispatch: @escaping ActionDispatch) {
        if state.permissionState.cameraPermission == .notAsked {
            dispatch(.permissionAction(.cameraPermissionRequested))
        } else {
            callingService.startLocalVideoStream()
                .delay(for: .seconds(1.0), scheduler: DispatchQueue.main)
                .map { videoStream in
                    LocalUserAction.cameraOnSucceeded(videoStreamIdentifier: videoStream)
                }.sink(receiveCompletion: { completion in
                    switch completion {
                    case .failure(let error):
                        dispatch(.localUserAction(.cameraOnFailed(error: error)))
                    case .finished:
                        break
                    }
                }, receiveValue: { _ in
//                    dispatch(.localUserAction(newAction))
                    let error = CallCompositeInternalError.cameraOnFailed
                    dispatch(.localUserAction(.cameraOnFailed(error: error)))
                }).store(in: cancelBag)
        }
    }
```

## What to Check
Verify that the following are valid
* Error banner shows up on both PreviewView and CallingView
* Error banner shows the right error message: "Error toggling video"


## Other Information
<!-- Add any other helpful information that may be needed here. -->