### PR TITLE
[Bug] Updated Error Banner Colour Scheme

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -52,17 +52,17 @@ class ColorThemeProvider {
     }()
 
     // MARK: - Button Icon Colours
+    let hangup = UIColor.compositeColor(.hangup)
+    let disableColor: UIColor = Colors.iconDisabled
+    let drawerIconDark: UIColor = Colors.iconSecondary
+
+    // MARK: - View Background Colours
     let error: UIColor = Colors.error
+    let success: UIColor = Colors.Palette.successPrimary.color
     lazy var warning: UIColor = {
         return dynamicColor(light: Colors.Palette.warningTint40.color,
                             dark: Colors.warning)
     }()
-    let hangup = UIColor.compositeColor(.hangup)
-    let disableColor: UIColor = Colors.iconDisabled
-    let drawerIconDark: UIColor = Colors.iconSecondary
-    let success: UIColor = Colors.Palette.successPrimary.color
-
-    // MARK: - View Background Colours
     let overlay = UIColor.compositeColor(.overlay)
     let gridLayoutBackground: UIColor = Colors.surfacePrimary
     let gradientColor = UIColor.black.withAlphaComponent(0.7)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -17,7 +17,10 @@ class ColorThemeProvider {
 
     // MARK: Text Label Colours
     let onHoldLabel: UIColor = Colors.textSecondary
-    let onWarning: UIColor = Colors.Palette.gray950.color
+    lazy var onWarning: UIColor = {
+        return dynamicColor(light: Colors.Palette.warningShade30.color,
+                            dark: Colors.Palette.gray950.color)
+    }()
     let onHoldBackground = UIColor.compositeColor(.onHoldBackground)
     lazy var onError: UIColor = {
         return dynamicColor(light: Colors.surfacePrimary,
@@ -50,7 +53,10 @@ class ColorThemeProvider {
 
     // MARK: - Button Icon Colours
     let error: UIColor = Colors.error
-    let warning: UIColor = Colors.warning
+    lazy var warning: UIColor = {
+        return dynamicColor(light: Colors.Palette.warningTint40.color,
+                            dark: Colors.warning)
+    }()
     let hangup = UIColor.compositeColor(.hangup)
     let disableColor: UIColor = Colors.iconDisabled
     let drawerIconDark: UIColor = Colors.iconSecondary

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Style/ColorThemeProvider.swift
@@ -19,7 +19,7 @@ class ColorThemeProvider {
     let onHoldLabel: UIColor = Colors.textSecondary
     lazy var onWarning: UIColor = {
         return dynamicColor(light: Colors.Palette.warningShade30.color,
-                            dark: Colors.Palette.gray950.color)
+                            dark: Colors.surfacePrimary)
     }()
     let onHoldBackground = UIColor.compositeColor(.onHoldBackground)
     lazy var onError: UIColor = {


### PR DESCRIPTION
## Purpose
This PR updates the colour scheme used in error banner to the latest FluentUI design.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. run the app
2. disable internet 
3. tap on join call
4. wait for error banner to show up 

## What to Check
1. check in light mode, the text colour is "Message / Mobile / Warning / Light / Shade 30" and background colour is "Message / Mobile / Warning / Light / Tint 40"
2. check in dark mode, the text colour is "Neutrals / Mobile / Black  #000000" and background colour is "Message / Mobile / Warning / Dark / Primary" 

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Screenshot
UI Spec: 
![image](https://user-images.githubusercontent.com/109105353/186717493-1ab08d08-83d1-4bdf-a425-82d21894b8d6.png)
<img width="807" alt="image" src="https://user-images.githubusercontent.com/109105353/186725038-53f7f1d5-f25a-4a98-87e9-d84713215c91.png">

before:
![image](https://user-images.githubusercontent.com/109105353/186717424-579c086a-3bf0-4c90-b5b5-1b4973206211.png)
after:
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/109105353/186757913-4a3c238e-e47f-4639-9104-1a5c7144dbe5.png">
