### PR TITLE
[Refactor] Made Title Required in LocalOptions 

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
@@ -43,9 +43,9 @@ public struct ParticipantViewData {
 }
 /// Object to represent the data needed to customize navigation bar
 public struct NavigationBarViewData {
-    /// The required title that would be used for the navigation bar of setup view
+    /// The title that would be used for the navigation bar of setup view
     let title: String
-    /// The optional subtitle that would be used for the navigation bar of setup view
+    /// The subtitle that would be used for the navigation bar of setup view
     let subtitle: String?
     /// Create an instance of a NavigationBarViewData.
     /// All information in this object is only stored locally in the composite.

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LocalOptions.swift
@@ -43,9 +43,9 @@ public struct ParticipantViewData {
 }
 /// Object to represent the data needed to customize navigation bar
 public struct NavigationBarViewData {
-    /// The title that would be used for the navigation bar of setup view
-    let title: String?
-    /// The subtitle that would be used for the navigation bar of setup view
+    /// The required title that would be used for the navigation bar of setup view
+    let title: String
+    /// The optional subtitle that would be used for the navigation bar of setup view
     let subtitle: String?
     /// Create an instance of a NavigationBarViewData.
     /// All information in this object is only stored locally in the composite.
@@ -54,7 +54,7 @@ public struct NavigationBarViewData {
     ///              If this is `nil` the default title "Setup" would be used
     ///    - subtitle: The String that would be displayed as the subtitle in setup view
     ///                   If this is `nil` the subtitle would be hidden
-    public init(title: String? = nil,
+    public init(title: String,
                 subtitle: String? = nil) {
         self.title = title
         self.subtitle = subtitle


### PR DESCRIPTION
## Purpose
This PR is meant to address feedback from review board.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. run the app in simulator
2. open settings page, enter title/subtitle
3. tap on "start experience" to see if changes are reflected on set up view


## What to Check
Verify that the following are valid
1. if no title/subtitle given, default title would be used
2. if only title is, title would be shown and subtitle would be hidden
3. if only subtitle is given, this would be ignored and default title would be shown with no subtitle
4. if both are given, both would be shown on set up view

## Other Information
N/A