### PR TITLE
[Bug] Info Header Font Size Fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderView.swift
@@ -59,6 +59,7 @@ struct InfoHeaderView: View {
                 .font(Fonts.caption1.font)
                 .accessibilityLabel(Text(viewModel.accessibilityLabel))
                 .accessibilitySortPriority(1)
+                .scaledToFill()
                 .minimumScaleFactor(sizeCategory.isAccessibilityCategory ?
                                     Constants.accessibilityFontScale :
                                         Constants.defaultFontScale)


### PR DESCRIPTION
## Purpose
A11y wanted the info header to support large font size.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. open app in simulator
2. go to settings
3. go to accessibility
4. enable large font
5. go back to app, join a call

## What to Check
1. text not getting cutoff
2. text does appear bigger when a11y is enabled

## Other Information

before and after:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/109105353/188038955-0216374f-eb15-4fb4-aab1-36eab407ddd1.png">

## Scale down test
longest text in info header currently:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/109105353/188039022-59112ec0-244b-4564-a532-ba68baa79755.png">
<img width="447" alt="image" src="https://user-images.githubusercontent.com/109105353/188039077-49e53fbd-bd55-4ce0-ba40-55bb67edd8bc.png">
<img width="445" alt="image" src="https://user-images.githubusercontent.com/109105353/188039128-2d3cc246-2d23-4afa-bd52-dfdafcbd45e1.png">
