### PR TITLE
[Task] Change unknownError to cameraFailure error

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## TBA (upcoming release)
 ### New Features
-- Implemented new error message `unknownError` that can be sent to developers in rare cases device manager throws an error. [#301](https://github.com/Azure/communication-ui-library-ios/pull/301)
-- Implemented new error message `cameraFailure` that can be sent to developers when turning on camera fails. [#311](https://github.com/Azure/communication-ui-library-ios/pull/311)
+- Implemented new error message `cameraFailure` that can be sent to developers when:
+    - turning on camera fails. [#311](https://github.com/Azure/communication-ui-library-ios/pull/311)
+    - in rare cases device manager throws an error [#301](https://github.com/Azure/communication-ui-library-ios/pull/301) [#334](https://github.com/Azure/communication-ui-library-ios/pull/334)
+    
 - Introduced NavigationBarViewData as a new local launch option to customize title and subtitle in set up view. [#309](https://github.com/Azure/communication-ui-library-ios/pull/309)
 - Handled the case where user joining the call with no active network connection [#328](https://github.com/Azure/communication-ui-library-ios/pull/328) 
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeError.swift
@@ -19,9 +19,6 @@ public struct CallCompositeErrorCode {
     /// Error when the input token is expired.
     public static let tokenExpired: String = "tokenExpired"
 
-    /// Error when something unexpected has occured 
-    public static let unknownError: String = "unknownError"
-
     /// Error when a participant is evicted from the call by another participant
     static let callEvicted: String = "callEvicted"
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
@@ -21,7 +21,7 @@ enum CallCompositeInternalError: Error, Equatable {
     func toCallCompositeErrorCode() -> String? {
         switch self {
         case .deviceManagerFailed:
-            return CallCompositeErrorCode.unknownError
+            return CallCompositeErrorCode.cameraFailure
         case .callTokenFailed:
             return CallCompositeErrorCode.tokenExpired
         case .callJoinFailed:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When in rare cases device manager throws an error, instead of sending an unknown error, we send a cameraFailure error since this device manager error is usually caused by camera related issues.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
## Other Information
<!-- Add any other helpful information that may be needed here. -->