### PR TITLE
[Refactor] Updated Remote Manager to Protocol

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
@@ -100,7 +100,7 @@ public class CallComposite {
         self.permissionManager = dependencyContainer.resolve() as PermissionsManagerProtocol
         self.audioSessionManager = dependencyContainer.resolve() as AudioSessionManagerProtocol
         self.avatarViewManager = dependencyContainer.resolve() as AvatarViewManager
-        self.remoteParticipantsManager = dependencyContainer.resolve() as RemoteParticipantsManager
+        self.remoteParticipantsManager = dependencyContainer.resolve() as RemoteParticipantsManagerProtocol
     }
 
     private func cleanUpManagers() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/DI/DependancyContainer.swift
@@ -69,7 +69,7 @@ final class DependencyContainer {
         register(RemoteParticipantsManager(store: resolve(),
                                            callCompositeEventsHandler: callCompositeEventsHandler,
                                            callingSDKWrapper: resolve(),
-                                           avatarViewManager: resolve()) as RemoteParticipantsManager)
+                                           avatarViewManager: resolve()) as RemoteParticipantsManagerProtocol)
     }
 
     private func makeStore(displayName: String?) -> Store<AppState> {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/DI/DependencyContainerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/DI/DependencyContainerTests.swift
@@ -48,7 +48,7 @@ class DependencyContainerTests: XCTestCase {
         XCTAssertNotNil(dependencyContainer.resolve() as PermissionsManagerProtocol)
         XCTAssertNotNil(dependencyContainer.resolve() as AudioSessionManagerProtocol)
         XCTAssertNotNil(dependencyContainer.resolve() as AvatarViewManager)
-        XCTAssertNotNil(dependencyContainer.resolve() as RemoteParticipantsManager)
+        XCTAssertNotNil(dependencyContainer.resolve() as RemoteParticipantsManagerProtocol)
         XCTAssertNotNil(dependencyContainer.resolve() as NetworkManager)
     }
 }


### PR DESCRIPTION
## Purpose
This refactor is meant to address the inconsistency we had when creating view managers. Ideally, all of view managers should be protocol rather than its concrete class

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. run the app
2. open settings to turn on remote participant injection
3. join a call
## What to Check
1. avatar does show up
2. no crash upon launching composite
3. no crash upon joining the call

## Other Information
1. AvatarViewManager remains as is since we have additional refactor coming up for it. So this PR only addresses remote participant view manager.