### PR TITLE
[Bug] Video Going Blank After Returning to Foreground

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -126,6 +126,7 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
 
             do {
                 try await callingService.stopLocalVideoStream()
+                dispatch(.localUserAction(.cameraPausedSucceeded))
             } catch {
                 dispatch(.localUserAction(.cameraPausedFailed(error: error)))
             }


### PR DESCRIPTION
## Purpose
This PR fixed the issue where local participant's video not shown up when returning from background back to foreground.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. start a call on other devices
2. set branch to this PR and run it on simulator
3. join the call with video on
4. go to background then go back to the app


## What to Check
1. check if video shows up to other participants when returned back to foreground
2. video still shows up for web and android 

## Other Information
N/A

## Testing


https://user-images.githubusercontent.com/109105353/190504662-6732acb1-d89f-4687-9efe-4895d3a9b02f.mov



