### PR TITLE
[Bug] Error Banner Margin Fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -19,7 +19,6 @@ struct SetupView: View {
         static let spacing: CGFloat = 24
         static let spacingLarge: CGFloat = 40
         static let startCallButtonHeight: CGFloat = 52
-        static let errorHorizontalPadding: CGFloat = 8
         static let iPadLarge: CGFloat = 469.0
         static let iPadSmall: CGFloat = 375.0
         static let iPadSmallHeightWithMargin: CGFloat = iPadSmall + spacingLarge + startCallButtonHeight
@@ -75,9 +74,9 @@ struct SetupView: View {
             Spacer()
             ErrorInfoView(viewModel: viewModel.errorInfoViewModel)
                 .padding(EdgeInsets(top: 0,
-                                    leading: LayoutConstant.errorHorizontalPadding,
+                                    leading: 0,
                                     bottom: LayoutConstant.startCallButtonHeight + LayoutConstant.spacing,
-                                    trailing: LayoutConstant.errorHorizontalPadding)
+                                    trailing: 0)
                 )
                 .accessibilityElement(children: .contain)
                 .accessibilityAddTraits(.isModal)


### PR DESCRIPTION
## Purpose
UI spec for the error banner shows that it should have equal width as the join call button: 
<img width="404" alt="image" src="https://user-images.githubusercontent.com/109105353/193190733-417e8664-3d60-4f77-8d94-47d518e168c3.png">
but in our app, we have a small margin which makes the banner appeared to be shorter than join call button:
<img width="309" alt="image" src="https://user-images.githubusercontent.com/109105353/193190792-6694724b-2194-4f2b-b1cf-b13f9ed5fb07.png">

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. disconnect the internet
2. tap on join call

## What to Check
1. make sure button has the equal width as the join call button under both dark and light mode

## Other Information
<img width="935" alt="image" src="https://user-images.githubusercontent.com/109105353/193190634-96d06c12-5d74-421f-af5b-e5a16805f730.png">
