### PR TITLE
[Bug] Fix drawer orientation changes when device is on a flat surface

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/LockPhoneOrientation.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/LockPhoneOrientation.swift
@@ -18,7 +18,11 @@ struct LockPhoneOrientation: ViewModifier {
         case .iphonePortraitScreenSize:
             return .portrait
         case .iphoneLandscapeScreenSize:
-            return UIDevice.current.orientation == .landscapeLeft ? .landscapeRight : .landscapeLeft
+            if UIDevice.current.orientation.isLandscape {
+                return UIDevice.current.orientation == .landscapeLeft ? .landscapeRight : .landscapeLeft
+            } else {
+                return .landscape
+            }
         default:
             return SupportedOrientationsPreferenceKey.defaultValue
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Currently when we join a call and go to landscape mode, then put device on a flat surface and open any drawer, the device rotate to a different direction, for example, from landscapeLeft to LandscapeRight.
* This PR fix that issue by catching the scenario that screenSizeClass is .iphoneLandscapeScreenSize but UIDevice.current.orientation is not landscape, which could be faceUp or faceDown.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get and run the code
* Join a call and go to landscape mode
* put device on a flat surface
* open drawer by tapping on end call button

## What to Check
Verify that the following are valid
* Device orientation should not change

## Other Information
<!-- Add any other helpful information that may be needed here. -->