### PR TITLE
[Bugfix] End call animation in landscape janky

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp.xcodeproj/project.pbxproj
@@ -361,6 +361,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		1FC9AB9927BC4E8F0027F9DB /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -379,6 +380,7 @@
 		};
 		1FF252D427B5E44E006A113E /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1413,6 +1413,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		1F7BF43F270D758800974139 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -1448,6 +1449,7 @@
 		};
 		508E82962670110100ED93C6 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
@@ -73,7 +73,6 @@ struct LocalVideoView: View {
 
                     ZStack(alignment: viewType.cameraSwitchButtonAlignment) {
                         VideoRendererView(rendererView: rendererView)
-                            .scaledToFill()
                             .frame(width: geometry.size.width,
                                    height: geometry.size.height)
                         if viewType.hasGradient {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/VideoRenderView.swift
@@ -24,20 +24,20 @@ class VideoRendererUIView: UIView {
 
     init(rendererView: UIView) {
         super.init(frame: .zero)
-        update(rendererView: rendererView)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rendererView?.frame = bounds
+    }
+
     func update(rendererView: UIView) {
         guard rendererView !== self.rendererView ||
               rendererView.superview !== self else {
-            if self.rendererView?.frame != bounds {
-                self.rendererView?.frame = bounds
-            }
-
             return
         }
 
@@ -45,11 +45,6 @@ class VideoRendererUIView: UIView {
         for view in subviews {
             view.removeFromSuperview()
         }
-        // the frame should be updated manually
-        // as setting constrains may cause updateUIView(_ uiView: VideoRendererUIView, context: Context) call
-        rendererView.translatesAutoresizingMaskIntoConstraints = true
-        rendererView.frame = bounds
-        rendererView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(rendererView)
         self.rendererView = rendererView
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Store.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Store.swift
@@ -24,7 +24,7 @@ class Store<State>: ObservableObject {
             .reduce({ [unowned self] action in
                 self._dispatch(action: action)
             }, { nextDispatch, middleware in
-                let dispatch: (Action) -> Void = { [unowned self] in self.dispatch(action: $0) }
+                let dispatch: (Action) -> Void = { [weak self] in self?.dispatch(action: $0) }
                 let getState = { [unowned self] in self.state }
                 return middleware.apply(dispatch, getState)(nextDispatch)
             })


### PR DESCRIPTION
## Purpose
When ending a call in landscape mode on iPhone, the video screen would not slide off the bottom of the screen correctly.
This was due to the underlying renderer view being the incorrect dimensions.


## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Test the code
Join a group call with video.
Change the orientation to landscape and end the call. 

## What to Check
Verify that the following are valid
* Video screen now slides off the bottom of the screen properly.

