### PR TITLE
[Bug] Drawer Cutoff and Bouncing Animation Fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeAudioDevicesList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeAudioDevicesList.swift
@@ -18,8 +18,7 @@ struct CompositeAudioDevicesList: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> DrawerContainerViewController<AudioDevicesListCellViewModel> {
-        let controller = AudioDevicesListViewController(items: getAudioDevicesList(),
-                                                        sourceView: sourceView,
+        let controller = AudioDevicesListViewController(sourceView: sourceView,
                                                         isRightToLeft: layoutDirection == .rightToLeft)
         controller.delegate = context.coordinator
         return controller

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeLeaveCallConfirmationList.swift
@@ -18,8 +18,7 @@ struct CompositeLeaveCallConfirmationList: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> DrawerContainerViewController<LeaveCallConfirmationViewModel> {
-        let controller = LeaveCallConfirmationListViewController(items: getLeaveCallConfirmationList(),
-                                                                 sourceView: sourceView,
+        let controller = LeaveCallConfirmationListViewController(sourceView: sourceView,
                                                                  headerName: viewModel.headerName,
                                                                  showHeader: true,
                                                                  isRightToLeft: layoutDirection == .rightToLeft)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsList.swift
@@ -23,8 +23,7 @@ struct CompositeParticipantsList: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> DrawerContainerViewController<ParticipantsListCellViewModel> {
-        let controller = ParticipantsListViewController(items: getParticipantsList(),
-                                                        sourceView: sourceView,
+        let controller = ParticipantsListViewController(sourceView: sourceView,
                                                         avatarViewManager: avatarViewManager,
                                                         isRightToLeft: layoutDirection == .rightToLeft)
         controller.delegate = context.coordinator

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -17,18 +17,22 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
     private let sourceView: UIView
     private let showHeader: Bool
     private let isRightToLeft: Bool
+    private weak var controller: DrawerController?
+
+    // MARK: Constants
     private var halfScreenHeight: CGFloat {
         UIScreen.main.bounds.height / 2
     }
-    private weak var controller: DrawerController?
+    private var resizeBarHeight: CGFloat {
+        UIDevice.current.userInterfaceIdiom == .phone ? 20 : 0
+    }
+    private let drawerWidth: CGFloat = 400.0
 
-    init(items: [T],
-         sourceView: UIView,
+    init(sourceView: UIView,
          headerName: String? = nil,
          showHeader: Bool = false,
          isRightToLeft: Bool = false
     ) {
-        self.items = items
         self.sourceView = sourceView
         self.showHeader = showHeader
         self.headerName = headerName
@@ -144,7 +148,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
                 isScrollEnabled = true
             }
             drawerTableView.isScrollEnabled = isScrollEnabled
-            self.controller?.preferredContentSize = CGSize(width: 400,
+            self.controller?.preferredContentSize = CGSize(width: self.drawerWidth,
                                                            height: drawerHeight)
         }
     }
@@ -154,7 +158,6 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
                                  showHeader: Bool,
                                  isiPhoneLayout: Bool) -> CGFloat {
         let headerHeight = self.getHeaderHeight(tableView: tableView, isiPhoneLayout: isiPhoneLayout)
-        let resizeBarHeight: CGFloat = isiPhoneLayout ? 20 : 0
         let dividerOffsetHeight = CGFloat(numberOfItems * 3)
 
         var drawerHeight: CGFloat = getTotalCellsHeight(tableView: tableView, numberOfItems: numberOfItems)
@@ -182,9 +185,8 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         guard let tableView = self.drawerTableView else {
             return
         }
-        let resizeBarHeight: CGFloat = isiPhoneLayout ? 20 : 0
-        let width = UIScreen.main.bounds.width
-        tableView.frame = CGRect(x: 0.0, y: resizeBarHeight, width: width, height: 0.0)
+        let initialWidth = isiPhoneLayout ? UIScreen.main.bounds.width : drawerWidth
+        tableView.frame = CGRect(x: 0, y: resizeBarHeight, width: initialWidth, height: 0)
         tableView.setNeedsDisplay()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -6,7 +6,7 @@
 import FluentUI
 import UIKit
 
-class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelegate {
+class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerControllerDelegate {
     weak var delegate: DrawerControllerDelegate?
     lazy var drawerTableView: UITableView? = nil
     let backgroundColor: UIColor = UIDevice.current.userInterfaceIdiom == .pad
@@ -67,6 +67,9 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
     }
 
     func updateDrawerList(items: [T]) {
+        guard self.items != items else {
+            return
+        }
         guard self.items.count != items.count else {
             self.items = items
             self.drawerTableView?.reloadData()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -20,14 +20,18 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
     private weak var controller: DrawerController?
 
     // MARK: Constants
-    private var halfScreenHeight: CGFloat {
-        UIScreen.main.bounds.height / 2
+    private enum Constants {
+        static var drawerWidth: CGFloat { return 400.0 }
+        static var resizeBarHeight: CGFloat {
+            UIDevice.current.userInterfaceIdiom == .phone ? 20 : 0
+        }
+        static var halfScreenHeight: CGFloat {
+            UIScreen.main.bounds.height / 2
+        }
+        static var drawerHeaderMargin: CGFloat {
+            UIDevice.current.userInterfaceIdiom == .phone ? 20 : 35
+        }
     }
-    private var resizeBarHeight: CGFloat {
-        UIDevice.current.userInterfaceIdiom == .phone ? 20 : 0
-    }
-    private let drawerWidth: CGFloat = 400.0
-
     init(sourceView: UIView,
          headerName: String? = nil,
          showHeader: Bool = false,
@@ -143,12 +147,12 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
                 showHeader: self.showHeader,
                 isiPhoneLayout: isiPhoneLayout)
 
-            if drawerHeight > self.halfScreenHeight {
-                drawerHeight = self.halfScreenHeight
+            if drawerHeight > Constants.halfScreenHeight {
+                drawerHeight = Constants.halfScreenHeight
                 isScrollEnabled = true
             }
             drawerTableView.isScrollEnabled = isScrollEnabled
-            self.controller?.preferredContentSize = CGSize(width: self.drawerWidth,
+            self.controller?.preferredContentSize = CGSize(width: Constants.drawerWidth,
                                                            height: drawerHeight)
         }
     }
@@ -161,7 +165,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         let dividerOffsetHeight = CGFloat(numberOfItems * 3)
 
         var drawerHeight: CGFloat = getTotalCellsHeight(tableView: tableView, numberOfItems: numberOfItems)
-        drawerHeight += showHeader ? headerHeight : resizeBarHeight
+        drawerHeight += showHeader ? headerHeight : Constants.resizeBarHeight
         drawerHeight += dividerOffsetHeight
 
         return drawerHeight
@@ -169,7 +173,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
 
     private func getHeaderHeight(tableView: UITableView,
                                  isiPhoneLayout: Bool) -> CGFloat {
-        return isiPhoneLayout ? tableView.sectionHeaderHeight + 20 : tableView.sectionHeaderHeight + 35
+        return tableView.sectionHeaderHeight + Constants.drawerHeaderMargin
     }
 
     private func getTotalCellsHeight(tableView: UITableView,
@@ -185,8 +189,8 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         guard let tableView = self.drawerTableView else {
             return
         }
-        let initialWidth = isiPhoneLayout ? UIScreen.main.bounds.width : drawerWidth
-        tableView.frame = CGRect(x: 0, y: resizeBarHeight, width: initialWidth, height: 0)
+        let initialWidth = isiPhoneLayout ? UIScreen.main.bounds.width : Constants.drawerWidth
+        tableView.frame = CGRect(x: 0, y: Constants.resizeBarHeight, width: initialWidth, height: 0)
         tableView.setNeedsDisplay()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -134,7 +134,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
             drawerTableView.reloadData()
 
             if drawerTableView.frame == CGRect.zero {
-                self.setTableViewFrame(isiPhoneLayout)
+                self.setInitialTableViewFrame(isiPhoneLayout)
             }
 
             var drawerHeight = self.getDrawerHeight(
@@ -181,7 +181,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         }.map { index in return tableView.rectForRow(at: index).height }.reduce(0, +)
     }
 
-    private func setTableViewFrame(_ isiPhoneLayout: Bool) {
+    private func setInitialTableViewFrame(_ isiPhoneLayout: Bool) {
         guard let tableView = self.drawerTableView else {
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -67,6 +67,11 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
     }
 
     func updateDrawerList(items: [T]) {
+        guard self.items.count != items.count else {
+            self.items = items
+            self.drawerTableView?.reloadData()
+            return
+        }
         self.items = items
         resizeDrawer()
     }
@@ -115,8 +120,11 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
             guard let self = self, let drawerTableView = self.drawerTableView else {
                 return
             }
-
             drawerTableView.reloadData()
+
+            if drawerTableView.frame == CGRect.zero {
+                self.setTableViewFrame(isiPhoneLayout)
+            }
 
             var drawerHeight = self.getDrawerHeight(
                 tableView: drawerTableView,
@@ -161,5 +169,15 @@ class DrawerContainerViewController<T>: UIViewController, DrawerControllerDelega
                 return IndexPath(row: row, section: section)
             }
         }.map { index in return tableView.rectForRow(at: index).height }.reduce(0, +)
+    }
+
+    private func setTableViewFrame(_ isiPhoneLayout: Bool) {
+        guard let tableView = self.drawerTableView else {
+            return
+        }
+        let resizeBarHeight: CGFloat = isiPhoneLayout ? 20 : 0
+        let width = UIScreen.main.bounds.width
+        tableView.frame = CGRect(x: 0.0, y: resizeBarHeight, width: width, height: 0.0)
+        tableView.setNeedsDisplay()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -74,21 +74,15 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         self.controller?.dismiss(animated: animated)
     }
 
-    func updateDrawerList(items: [T]) {
+    func updateDrawerList(items updatedItems: [T]) {
         // if contents are identical, do nothing
-        guard self.items != items else {
+        guard self.items != updatedItems else {
             return
         }
-        // if contents are different but total count stays the same
-        // reload table and skip height update
-        guard self.items.count != items.count else {
-            self.items = items
-            self.drawerTableView?.reloadData()
-            return
-        }
-        // else reload table and update drawer height
-        self.items = items
-        resizeDrawer()
+        // should update layout if items count increases/decreases
+        let shouldUpdateLayout = self.items.count != updatedItems.count
+        self.items = updatedItems
+        resizeDrawer(withLayoutUpdate: shouldUpdateLayout)
     }
 
     private func showDrawerView() {
@@ -127,7 +121,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
         return controller
     }
 
-    private func resizeDrawer() {
+    private func resizeDrawer(withLayoutUpdate shouldUpdateLayout: Bool = true) {
         let isiPhoneLayout = UIDevice.current.userInterfaceIdiom == .phone
         var isScrollEnabled = !isiPhoneLayout
 
@@ -136,6 +130,10 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
                 return
             }
             drawerTableView.reloadData()
+
+            guard shouldUpdateLayout else {
+                return
+            }
 
             if drawerTableView.frame == CGRect.zero {
                 self.setInitialTableViewFrame(isiPhoneLayout)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -67,14 +67,18 @@ class DrawerContainerViewController<T: Equatable>: UIViewController, DrawerContr
     }
 
     func updateDrawerList(items: [T]) {
+        // if contents are identical, do nothing
         guard self.items != items else {
             return
         }
+        // if contents are different but total count stays the same
+        // reload table and skip height update
         guard self.items.count != items.count else {
             self.items = items
             self.drawerTableView?.reloadData()
             return
         }
+        // else reload table and update drawer height
         self.items = items
         resizeDrawer()
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/ParticipantsListViewController.swift
@@ -26,13 +26,12 @@ class ParticipantsListViewController: DrawerContainerViewController<Participants
         set { participantsListTableView = newValue }
     }
 
-    init(items: [ParticipantsListCellViewModel],
-         sourceView: UIView,
+    init(sourceView: UIView,
          avatarViewManager: AvatarViewManager,
          isRightToLeft: Bool
     ) {
         self.avatarViewManager = avatarViewManager
-        super.init(items: items, sourceView: sourceView, isRightToLeft: isRightToLeft)
+        super.init(sourceView: sourceView, isRightToLeft: isRightToLeft)
     }
 
     required init?(coder: NSCoder) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListCellViewModel.swift
@@ -75,3 +75,14 @@ class ParticipantsListCellViewModel {
         localizationProvider.getLocalizedString(.onHold)
     }
 }
+
+extension ParticipantsListCellViewModel: Equatable {
+     static func == (lhs: ParticipantsListCellViewModel,
+                     rhs: ParticipantsListCellViewModel) -> Bool {
+         lhs.participantId == rhs.participantId &&
+         lhs.isMuted == rhs.isMuted &&
+         lhs.isHold == rhs.isHold &&
+         lhs.isLocalParticipant == rhs.isLocalParticipant &&
+         lhs.displayName == rhs.displayName
+     }
+ }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/AudioDevicesListCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/AudioDevicesListCellViewModel.swift
@@ -21,3 +21,12 @@ class AudioDevicesListCellViewModel {
         self.switchAudioDevice = onSelected
     }
 }
+
+extension AudioDevicesListCellViewModel: Equatable {
+     static func == (lhs: AudioDevicesListCellViewModel,
+                     rhs: AudioDevicesListCellViewModel) -> Bool {
+         return lhs.title == rhs.title &&
+         lhs.isSelected == rhs.isSelected &&
+         lhs.icon == rhs.icon
+     }
+ }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/LeaveCallConfirmationViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/LeaveCallConfirmationViewModel.swift
@@ -21,3 +21,12 @@ class LeaveCallConfirmationViewModel {
         self.action = action
     }
 }
+
+extension LeaveCallConfirmationViewModel: Equatable {
+     static func == (lhs: LeaveCallConfirmationViewModel,
+                     rhs: LeaveCallConfirmationViewModel) -> Bool {
+         return lhs.title == rhs.title &&
+         lhs.accessibilityIdentifier == rhs.accessibilityIdentifier &&
+         lhs.icon == rhs.icon
+     }
+ }


### PR DESCRIPTION
## Purpose
The drawer resize function being called when table view not ready which results the incorrect height being defined for drawer and causing the content being cutoff.

The solution is to check if table view content is ready. If it's not ready, we would not call resize() function to prevent incorrect  drawer height being set.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
for bouncing animation:
1. enable slow animation
2. tap on audio list
3. make a selection
4. audio should be dismissed without janky animations
5. test the same thing for end call as well

for cutoff:
1. enable large font size in a11y
2. leave display name empty
3. join a call
4. tap on participant list button repeatedly until cutoff occurs (since it's a race condition, you might need to try multiple times for it to happen)

## What to Check
1. no bouncing animations when selections are made
2. no text being cutoff
3. participant list gets dynamically updated
4. drawer still work as before on both iPad and iPhone (note: on iPads, there's no animation when presenting the drawer, this behaviour is consistent with 1.0.0 GA release.)
5. no blank drawer shown up under any conditions

## Other Informatio

## Issue 1 Fix - Bouncing Animation

### before

https://user-images.githubusercontent.com/109105353/193646243-06cb32bd-9791-4652-a26e-df6457389235.mov

### after

https://user-images.githubusercontent.com/109105353/193640285-ec6858cc-bf9e-425f-80f4-b8281e59685d.mov

## Issue 2 Fix - Text Cut Off

### before

https://user-images.githubusercontent.com/109105353/194431133-c07d5b28-79e1-4750-8a66-83bb7c680282.mov

### after

https://user-images.githubusercontent.com/109105353/194431043-d3571eb4-0d7f-4a48-bc66-7ccfb5946c65.mov


## Testing

https://user-images.githubusercontent.com/109105353/193653494-ac83d6a4-ba6e-4f7b-b997-7c1ad3fca12b.mov
