### PR TITLE
[Bug] Fix callingMiddleware unit test async running issue

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
@@ -41,40 +41,37 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.unmuteLocalMicCalled)
     }
 
-    func test_callingMiddlewareHandler_requestMicMute_when_returnsError_then_updateMicrophoneStatusIsError() {
+    func test_callingMiddlewareHandler_requestMicMute_when_returnsError_then_updateMicrophoneStatusIsError() async {
         let sut = makeSUT()
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.microphoneOffFailed(error: error)))
         }
         mockCallingService.error = error
-        _ = sut.requestMicrophoneMute(state: getEmptyState(), dispatch: dispatch)
+        await sut.requestMicrophoneMute(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_requestMicUnmute_when_returnsError_then_updateMicrophoneStatusIsError() {
+    func test_callingMiddlewareHandler_requestMicUnmute_when_returnsError_then_updateMicrophoneStatusIsError() async {
         let sut = makeSUT()
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.microphoneOnFailed(error: error)))
         }
         mockCallingService.error = error
-        _ = sut.requestMicrophoneUnmute(state: getEmptyState(), dispatch: dispatch)
+        await sut.requestMicrophoneUnmute(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_requestCameraOn_when_cameraPermissionNotAsked_then_shouldDispatchCameraPermissionRequested() {
+    func test_callingMiddlewareHandler_requestCameraOn_when_cameraPermissionNotAsked_then_shouldDispatchCameraPermissionRequested() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.permissionAction(.cameraPermissionRequested))
-            expectation.fulfill()
         }
         let state: AppState = getState(callingState: .connected,
                                        cameraStatus: .off,
                                        cameraDeviceStatus: .front,
                                        cameraPermission: .notAsked)
 
-        _ = sut.requestCameraOn(state: state, dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.requestCameraOn(state: state, dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_requestCameraOff_then_stopLocalVideoStreamCalled() async {
@@ -86,16 +83,12 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.stopLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_requestCameraOff_when_permissionNotAsked_then_updateCameraStatusOffUpdate() {
+    func test_callingMiddlewareHandler_requestCameraOff_when_permissionNotAsked_then_updateCameraStatusOffUpdate() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOffSucceeded))
-            expectation.fulfill()
         }
-        _ = sut.requestCameraOff(state: getEmptyState(), dispatch: dispatch)
-
-        wait(for: [expectation], timeout: 1)
+        await sut.requestCameraOff(state: getEmptyState(), dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_requestCameraOn_then_startLocalVideoStreamCalled() async {
@@ -105,10 +98,8 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.startLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_requestCameraOn_when_noError_then_updateCameraStatusOnUpdate() {
+    func test_callingMiddlewareHandler_requestCameraOn_when_noError_then_updateCameraStatusOnUpdate() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
-
         let videoId = "Identifier"
         mockCallingService.videoStreamId = videoId
         func dispatch(action: Action) {
@@ -117,40 +108,32 @@ class CallingMiddlewareHandlerTests: XCTestCase {
             case .localUserAction(let localUserAction):
                 if case let LocalUserAction.cameraOnSucceeded(videoStreamIdentifier) = localUserAction {
                     XCTAssertEqual(videoStreamIdentifier, videoId)
-                    expectation.fulfill()
-                }
+                    }
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
-        _ = sut.requestCameraOn(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+        await sut.requestCameraOn(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_requestCameraOff_when_returnsError_then_updateCameraStatusIsError() {
+    func test_callingMiddlewareHandler_requestCameraOff_when_returnsError_then_updateCameraStatusIsError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Request Camera Off Dispatch Action Should Return Error")
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOffFailed(error: error)))
-            expectation.fulfill()
         }
         mockCallingService.error = error
-        _ = sut.requestCameraOff(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.requestCameraOff(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_requestCameraOn_when_returnsError_then_updateCameraStatusIsError() {
+    func test_callingMiddlewareHandler_requestCameraOn_when_returnsError_then_updateCameraStatusIsError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Request Camera On Dispatch Action Should Return Error")
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOnFailed(error: error)))
-            expectation.fulfill()
         }
         mockCallingService.error = error
-        _ = sut.requestCameraOn(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+        await sut.requestCameraOn(state: getEmptyState(), dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_requestCameraSwitch_then_switchCameraCalled() async {
@@ -162,9 +145,8 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.switchCameraCalled)
     }
 
-    func test_callingMiddlewareHandler_requestCameraSwitch_when_noError_then_updateCameraDeviceStatusOnUpdate() {
+    func test_callingMiddlewareHandler_requestCameraSwitch_when_noError_then_updateCameraDeviceStatusOnUpdate() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
 
         let cameraDevice = CameraDevice.front
         mockCallingService.cameraDevice = cameraDevice
@@ -173,26 +155,21 @@ class CallingMiddlewareHandlerTests: XCTestCase {
             switch action {
             case let .localUserAction(.cameraSwitchSucceeded(device)):
                 XCTAssertEqual(device, cameraDevice)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
-        _ = sut.requestCameraSwitch(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+        await sut.requestCameraSwitch(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_requestCameraSwitch_when_returnsError_then_updateCameraDeviceStatusIsError() {
+    func test_callingMiddlewareHandler_requestCameraSwitch_when_returnsError_then_updateCameraDeviceStatusIsError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Request Camera Switch Dispatch Action Should Return Error")
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraSwitchFailed(error: error)))
-            expectation.fulfill()
         }
         mockCallingService.error = error
-        _ = sut.requestCameraSwitch(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+        await sut.requestCameraSwitch(state: getEmptyState(), dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_endCall_then_endCallCalled() async {
@@ -213,9 +190,8 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.startCallCalled)
     }
 
-    func test_callingMiddlewareHandler_endCall_when_returnNSError_then_firstUpdateCallError() {
+    func test_callingMiddlewareHandler_endCall_when_returnNSError_then_firstUpdateCallError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
 
         let errorCode = 50
         let error = getError(code: errorCode)
@@ -228,7 +204,6 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                     let nserror = err as? NSError
                     XCTAssertEqual(nserror?.code, errorCode)
                     XCTAssertEqual(internalError, .callEndFailed)
-                    expectation.fulfill()
                 default:
                     XCTFail("Should not be default \(action)")
                 }
@@ -237,15 +212,12 @@ class CallingMiddlewareHandlerTests: XCTestCase {
             }
         }
         mockCallingService.error = error
-        _ = sut.endCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.endCall(state: getEmptyState(), dispatch: dispatch).value
 
     }
 
-    func test_callingMiddlewareHandler_endCall_when_returnsCompositeError_then_firstUpdateClientError() {
+    func test_callingMiddlewareHandler_endCall_when_returnsCompositeError_then_firstUpdateClientError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
-
         let error = CallCompositeInternalError.cameraSwitchFailed
 
         var callBackCount: Int = 0
@@ -256,7 +228,6 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                 case let .errorAction(.fatalErrorUpdated(internalError, err)):
                     XCTAssertEqual(internalError, error)
                     XCTAssertNil(err)
-                    expectation.fulfill()
                 default:
                     XCTFail("Should not be default \(action)")
                 }
@@ -264,13 +235,11 @@ class CallingMiddlewareHandlerTests: XCTestCase {
             }
         }
         mockCallingService.error = error
-        _ = sut.endCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.endCall(state: getEmptyState(), dispatch: dispatch).value
 
     }
 
-    func test_callingMiddlewareHandler_endCall_when_returnNSError_then_updateRequestFailed() {
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
+    func test_callingMiddlewareHandler_endCall_when_returnNSError_then_updateRequestFailed() async {
         let sut = makeSUT()
         let errorCode = 50
         let error = getError(code: errorCode)
@@ -280,18 +249,15 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                 callBackCount += 1
             } else if callBackCount == 1 {
                 XCTAssertTrue(action == Action.callingAction(.requestFailed))
-                expectation.fulfill()
             }
         }
         mockCallingService.error = error
-        _ = sut.endCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.endCall(state: getEmptyState(), dispatch: dispatch).value
 
     }
 
-    func test_callingMiddlewareHandler_startCall_when_returnsNSError_then_updateCallingCoreError() {
+    func test_callingMiddlewareHandler_startCall_when_returnsNSError_then_updateCallingCoreError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         let errorCode = 50
         let error = getError(code: errorCode)
         func dispatch(action: Action) {
@@ -301,19 +267,16 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                 let nserror = err as? NSError
                 XCTAssertEqual(nserror?.code, errorCode)
                 XCTAssertEqual(internalError, .callJoinFailed)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
         mockCallingService.error = error
-        _ = sut.startCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.startCall(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_startCall_when_returnsCompositeError_then_updateClientErrorCompositeError() {
+    func test_callingMiddlewareHandler_startCall_when_returnsCompositeError_then_updateClientErrorCompositeError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         let error = CallCompositeInternalError.callEndFailed
 
         func dispatch(action: Action) {
@@ -321,14 +284,12 @@ class CallingMiddlewareHandlerTests: XCTestCase {
             switch action {
             case let .errorAction(.fatalErrorUpdated(internalError, _)):
                 XCTAssertEqual(internalError, error)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
         mockCallingService.error = error
-        _ = sut.startCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.startCall(state: getEmptyState(), dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_setupCall_then_setupCallCalled() async {
@@ -339,42 +300,34 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.setupCallCalled)
     }
 
-    func test_callingMiddlewareHandler_setupCall_when_cameraPermissionGranted_then_cameraOnTriggered() {
+    func test_callingMiddlewareHandler_setupCall_when_cameraPermissionGranted_then_cameraOnTriggered() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
 
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraPreviewOnTriggered))
-            expectation.fulfill()
         }
-        _ = sut.setupCall(state: getState(callingState: .connected,
+        await sut.setupCall(state: getState(callingState: .connected,
                                                            cameraStatus: .off,
                                                            cameraDeviceStatus: .front,
                                                            cameraPermission: .granted),
-                                           dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+                            dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_setupCall_when_cameraPermissionDenied_then_skipCameraOnTriggered() {
+    func test_callingMiddlewareHandler_setupCall_when_cameraPermissionDenied_then_skipCameraOnTriggered() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
-        expectation.isInverted = true
 
         func dispatch(action: Action) {
-            XCTAssertTrue(action == Action.localUserAction(.cameraOnTriggered))
-            expectation.fulfill()
+            XCTAssertFalse(action == Action.localUserAction(.cameraOnTriggered))
         }
-        _ = sut.setupCall(state: getState(callingState: .connected,
+        await sut.setupCall(state: getState(callingState: .connected,
                                                            cameraStatus: .off,
                                                            cameraDeviceStatus: .front,
                                                            cameraPermission: .denied),
-                                           dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+                            dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_setupCall_when_returnsError_then_updateCallingCoreError() {
+    func test_callingMiddlewareHandler_setupCall_when_returnsError_then_updateCallingCoreError() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         let errorCode = 50
         let error = getError(code: errorCode)
 
@@ -384,31 +337,26 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                 let nserror = err as? NSError
                 XCTAssertEqual(nserror!.code, errorCode)
                 XCTAssertEqual(internalErr, .callJoinFailed)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
         mockCallingService.error = error
-        _ = sut.setupCall(state: getEmptyState(), dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+        await sut.setupCall(state: getEmptyState(), dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_setupCall_when_internalErrorNotNil_then_shouldNotDispatch() {
+    func test_callingMiddlewareHandler_setupCall_when_internalErrorNotNil_then_shouldNotDispatch() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
-        expectation.isInverted = true
 
         func dispatch(action: Action) {
             XCTFail("Should not dispatch")
         }
-        _ = sut.setupCall(state: getState(callingState: .none,
+        await sut.setupCall(state: getState(callingState: .none,
                                                            cameraStatus: .off,
                                                            cameraDeviceStatus: .front,
                                                            cameraPermission: .granted,
                                                            internalError: .callEvicted),
-                                           dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+                            dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_enterBackground_when_callConnected_cameraStatusOn_then_cameraPausedDispatched() async {
@@ -434,46 +382,46 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.stopLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterBackground_when_callNotConnected_then_stopLocalVideoStreamNotCalled() {
+    func test_callingMiddlewareHandler_enterBackground_when_callNotConnected_then_stopLocalVideoStreamNotCalled() async {
         let sut = makeSUT()
-        _ = sut.enterBackground(state: getState(callingState: .disconnected,
+        await sut.enterBackground(state: getState(callingState: .disconnected,
                                                                  cameraStatus: .on,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: getEmptyDispatch())
+                                  dispatch: getEmptyDispatch()).value
         XCTAssertFalse(mockCallingService.stopLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterBackground_when_cameraStatusNotOn_then_stopLocalVideoStreamNotCalled() {
+    func test_callingMiddlewareHandler_enterBackground_when_cameraStatusNotOn_then_stopLocalVideoStreamNotCalled() async {
         let sut = makeSUT()
-        _ = sut.enterBackground(state: getState(callingState: .connected,
+        await sut.enterBackground(state: getState(callingState: .connected,
                                                                  cameraStatus: .off,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: getEmptyDispatch())
+                                  dispatch: getEmptyDispatch()).value
         XCTAssertFalse(mockCallingService.stopLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterBackground_when_callConnected_cameraStatusOn_noError_then_updateCameraStatusPauseUpdate() {
+    func test_callingMiddlewareHandler_enterBackground_when_callConnected_cameraStatusOn_noError_then_updateCameraStatusPauseUpdate() async {
         let sut = makeSUT()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraPausedSucceeded))
         }
-        _ = sut.enterBackground(state: getState(callingState: .connected,
+        await sut.enterBackground(state: getState(callingState: .connected,
                                                                  cameraStatus: .on,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: dispatch)
+                                  dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_enterBackground_when_callConnected_cameraStatusOn_returnsError_then_updateCameraStatusIsError() {
+    func test_callingMiddlewareHandler_enterBackground_when_callConnected_cameraStatusOn_returnsError_then_updateCameraStatusIsError() async {
         let sut = makeSUT()
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraPausedFailed(error: error)))
         }
         mockCallingService.error = error
-        _ = sut.enterBackground(state: getState(callingState: .connected,
+        await sut.enterBackground(state: getState(callingState: .connected,
                                                                  cameraStatus: .on,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: dispatch)
+                                  dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusPaused_then_startLocalVideoStreamCalled() async {
@@ -487,44 +435,41 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.startLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterForeground_when_callNotStarted_then_startLocalVideoStreamNotCalled() {
+    func test_callingMiddlewareHandler_enterForeground_when_callNotStarted_then_startLocalVideoStreamNotCalled() async {
         let sut = makeSUT()
-        _ = sut.enterForeground(state: getState(callingState: .disconnected,
+        await sut.enterForeground(state: getState(callingState: .disconnected,
                                                                  cameraStatus: .paused,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: getEmptyDispatch())
+                                  dispatch: getEmptyDispatch()).value
         XCTAssertFalse(mockCallingService.startLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterForeground_when_cameraStatusNotPaused_then_startLocalVideoStreamNotCalled() {
+    func test_callingMiddlewareHandler_enterForeground_when_cameraStatusNotPaused_then_startLocalVideoStreamNotCalled() async {
         let sut = makeSUT()
-        _ = sut.enterForeground(state: getState(callingState: .connected,
+        await sut.enterForeground(state: getState(callingState: .connected,
                                                                  cameraStatus: .off,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: getEmptyDispatch())
+                                  dispatch: getEmptyDispatch()).value
         XCTAssertFalse(mockCallingService.startLocalVideoStreamCalled)
     }
 
-    func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusOn_noError_then_updateCameraStatusOnUpdate() {
+    func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusOn_noError_then_updateCameraStatusOnUpdate() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         let id = "identifier"
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOnSucceeded(videoStreamIdentifier: id)))
             switch action {
             case let .localUserAction(.cameraOnSucceeded(videoStreamIdentifier)):
                 XCTAssertEqual(videoStreamIdentifier, id)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
         mockCallingService.videoStreamId = id
-        _ = sut.enterForeground(state: getState(callingState: .connected,
+        await sut.enterForeground(state: getState(callingState: .connected,
                                                                  cameraStatus: .paused,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+                                                 dispatch: dispatch).value
     }
 
     func test_callingMiddlewareHandler_holdCall_then_holdCallCalled() async {
@@ -549,86 +494,80 @@ class CallingMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockCallingService.resumeCallCalled)
     }
 
-    func test_callingMiddlewareHandler_enterForeground_when_callLocalHold_cameraStatusOn_noError_then_updateCameraStatusOnUpdate() {
+    func test_callingMiddlewareHandler_enterForeground_when_callLocalHold_cameraStatusOn_noError_then_updateCameraStatusOnUpdate() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Dispatch the new action")
         let id = "identifier"
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOnSucceeded(videoStreamIdentifier: id)))
             switch action {
             case let Action.localUserAction(.cameraOnSucceeded(videoStreamIdentifier)):
                 XCTAssertEqual(videoStreamIdentifier, id)
-                expectation.fulfill()
             default:
                 XCTFail("Should not be default \(action)")
             }
         }
         mockCallingService.videoStreamId = id
-        _ = sut.enterForeground(state: getState(callingState: .localHold,
+        await sut.enterForeground(state: getState(callingState: .localHold,
                                                                  cameraStatus: .paused,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: dispatch)
-        wait(for: [expectation], timeout: 1.5)
+                                  dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusOn_returnsError_then_updateCameraStatusIsError() {
+    func test_callingMiddlewareHandler_enterForeground_when_callConnected_cameraStatusOn_returnsError_then_updateCameraStatusIsError() async {
         let sut = makeSUT()
         let error = getError()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOnFailed(error: error)))
         }
         mockCallingService.error = error
-        _ = sut.enterForeground(state: getState(callingState: .connected,
+        await sut.enterForeground(state: getState(callingState: .connected,
                                                                  cameraStatus: .paused,
                                                                  cameraDeviceStatus: .front),
-                                                 dispatch: dispatch)
+                                  dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionLocal_cameraPermissionRequesting_then_updateCameraPreviewOnTriggered() {
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionLocal_cameraPermissionRequesting_then_updateCameraPreviewOnTriggered() async {
         let sut = makeSUT()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraPreviewOnTriggered))
         }
-        _ = sut.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
+        await sut.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
                                                                          cameraTransmissionStatus: .local),
-                                                         dispatch: dispatch)
+                                          dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionRequesting_then_updateCameraOnTriggered() {
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionRequesting_then_updateCameraOnTriggered() async {
         let sut = makeSUT()
         func dispatch(action: Action) {
             XCTAssertTrue(action == Action.localUserAction(.cameraOnTriggered))
         }
-        _ = sut.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
+        await sut.onCameraPermissionIsSet(state: getState(cameraPermission: .requesting,
                                                                          cameraTransmissionStatus: .remote),
-                                                         dispatch: dispatch)
+                                          dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionNotRequesting_then_updateCameraOnTriggered() {
+    func test_callingMiddlewareHandler_onCameraPermissionIsSet_when_callTransmissionRemote_cameraPermissionNotRequesting_then_updateCameraOnTriggered() async {
         let sut = makeSUT()
         func dispatch(action: Action) {
             XCTFail("Failed with unknown action dispatched")
         }
-        _ = sut.onCameraPermissionIsSet(state: getState(cameraPermission: .granted,
+        await sut.onCameraPermissionIsSet(state: getState(cameraPermission: .granted,
                                                                          cameraTransmissionStatus: .remote),
-                                                         dispatch: dispatch)
+                                          dispatch: dispatch).value
     }
 
-    func test_callingMiddlewareHandler_setupCall_when_networkFailed_then_shouldNotDispatch() {
+    func test_callingMiddlewareHandler_setupCall_when_networkFailed_then_shouldNotDispatch() async {
         let sut = makeSUT()
-        let expectation = XCTestExpectation(description: "Should Dispatch If Network Failed")
-        expectation.isInverted = true
 
         func dispatch(action: Action) {
             XCTFail("Should not dispatch")
         }
-        _ = sut.setupCall(state: getState(callingState: .none,
+        await sut.setupCall(state: getState(callingState: .none,
                                                            cameraStatus: .off,
                                                            cameraDeviceStatus: .front,
                                                            cameraPermission: .granted,
                                                            internalError: .connectionFailed),
-                                           dispatch: dispatch)
-        wait(for: [expectation], timeout: 1)
+                            dispatch: dispatch).value
     }
 }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Part of the unit tests always run successfully without checking `XCTAssert` because there is no `async await` or `expectation` fulfill
* Fix the issue by applying all unit tests in CallingMiddleware with `async await`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

