### PR TITLE
[Bug] Set speaker as default audio device

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
@@ -128,7 +128,7 @@ class AudioSessionManager: AudioSessionManagerProtocol {
                 return .receiver
             }
         }
-        return .receiver
+        return .speaker
     }
 
     private func switchAudioDevice(to selectedAudioDevice: AudioDeviceType) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModel.swift
@@ -27,7 +27,7 @@ class ControlBarViewModel: ObservableObject {
                                                  device: .front,
                                                  transmission: .local)
     var audioState = LocalUserState.AudioState(operation: .off,
-                                               device: .receiverSelected)
+                                               device: .speakerSelected)
     var displayEndCallConfirm: (() -> Void)
 
     init(compositeViewModelFactory: CompositeViewModelFactoryProtocol,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/AudioDevicesListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Drawer/AudioDevicesListViewModel.swift
@@ -61,7 +61,7 @@ class AudioDevicesListViewModel: ObservableObject {
                     systemDefaultAudio = .receiver
                 }
             } else {
-                systemDefaultAudio = .receiver
+                systemDefaultAudio = .speaker
             }
         }
         previousConnectedDevice = systemDefaultAudio

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/State/LocalUserState.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/State/LocalUserState.swift
@@ -143,7 +143,7 @@ struct LocalUserState {
                                                 device: .front,
                                                 transmission: .local),
          audioState: AudioState = AudioState(operation: .off,
-                                             device: .receiverSelected),
+                                             device: .speakerSelected),
          displayName: String? = nil,
          localVideoStreamIdentifier: String? = nil) {
         self.cameraState = cameraState


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Android created this ticket due to a case that when they launch the composite with video on, receiver will automatically be selected.
* iOS doesn't have this bug to start with but there's still a few places in code that indicate receiver is the default option.
* This PR is to make sure speaker is the default option for rare edge cases

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Fresh install the app
*  Tap on `Start Experience` 
*  Observe whether the default audio device is Speaker
*  Connect to a bluetooth or headphone, then disconnect it
*  Observe whether it get back to Speaker instead of receiver
*  Tap on `Join call`
*  Observe whether the default audio device is Speaker
*  Connect to a bluetooth or headphone, then disconnect it
*  Observe whether it get back to Speaker instead of receiver

## Other Information
<!-- Add any other helpful information that may be needed here. -->