### PR TITLE
[Feature] Implemented send message for ChatComposite

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
@@ -53,8 +53,8 @@ struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {
         self.participants = participants
     }
 
-    mutating func replaceDummyId(realMessageId: String) {
-        self.id = realMessageId
+    mutating func replace(id: String) {
+        self.id = id
     }
 
     func hash(into hasher: inout Hasher) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
@@ -16,7 +16,6 @@ enum MessageType: Equatable {
 
 struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {
     var id: String
-    let internalId: String
     let version: String
     let type: MessageType
     var senderId: String?
@@ -30,7 +29,6 @@ struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {
     var participants: [ParticipantInfoModel]
 
     init(id: String? = nil,
-         internalId: String? = nil,
          version: String = "",
          type: MessageType = .text,
          senderId: String? = nil,
@@ -40,8 +38,7 @@ struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {
          editedOn: Iso8601Date? = nil,
          deletedOn: Iso8601Date? = nil,
          participants: [ParticipantInfoModel] = []) {
-        self.id = id ?? internalId ?? UUID().uuidString
-        self.internalId = internalId ?? UUID().uuidString
+        self.id = id ?? UUID().uuidString
         self.version = version
         self.type = type
         self.senderId = senderId
@@ -58,7 +55,7 @@ struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(internalId)
+        hasher.combine(id)
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -11,6 +11,8 @@ protocol MessageRepositoryManagerProtocol {
 
     // MARK: sending local events
     func addInitialMessages(initialMessages: [ChatMessageInfoModel])
+    func addNewSentMessage(message: ChatMessageInfoModel)
+    func replaceMessageId(internalId: String, actualId: String)
 
     // MARK: receiving remote events
     func addReceivedMessage(message: ChatMessageInfoModel)
@@ -29,8 +31,27 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
         messages = initialMessages
     }
 
-    func addReceivedMessage(message: ChatMessageInfoModel) {
+    func addNewSentMessage(message: ChatMessageInfoModel) {
         messages.append(message)
     }
 
+    func replaceMessageId(internalId: String, actualId: String) {
+        if let index = messages.firstIndex(where: {
+            $0.internalId == internalId
+        }) {
+            var msg = messages[index]
+            msg.replace(id: actualId)
+            messages[index] = msg
+        }
+    }
+
+    func addReceivedMessage(message: ChatMessageInfoModel) {
+        if let index = messages.firstIndex(where: {
+            $0.id == message.id
+        }) {
+            messages[index] = message
+        } else {
+            messages.append(message)
+        }
+    }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -37,7 +37,7 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
 
     func replaceMessageId(internalId: String, actualId: String) {
         if let index = messages.firstIndex(where: {
-            $0.internalId == internalId
+            $0.id == internalId
         }) {
             var msg = messages[index]
             msg.replace(id: actualId)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -11,7 +11,7 @@ protocol MessageRepositoryManagerProtocol {
 
     // MARK: sending local events
     func addInitialMessages(initialMessages: [ChatMessageInfoModel])
-    func addNewSentMessage(message: ChatMessageInfoModel)
+    func addNewSendingMessage(message: ChatMessageInfoModel)
     func replaceMessageId(internalId: String, actualId: String)
 
     // MARK: receiving remote events
@@ -31,7 +31,7 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
         messages = initialMessages
     }
 
-    func addNewSentMessage(message: ChatMessageInfoModel) {
+    func addNewSendingMessage(message: ChatMessageInfoModel) {
         messages.append(message)
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageInputViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageInputViewModel.swift
@@ -23,7 +23,9 @@ class MessageInputViewModel: ObservableObject {
         guard !message.isEmpty else {
             return
         }
-//        dispatch(.chatAction(.))
+        dispatch(.repositoryAction(.sendMessageTriggered(
+            internalId: UUID().uuidString,
+            content: message)))
         message = ""
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/ThreadViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/ThreadViewModel.swift
@@ -25,7 +25,10 @@ class ThreadViewModel: ObservableObject {
         if self.repositoryUpdatedTimestamp < repositoryState.lastUpdatedTimestamp {
             self.repositoryUpdatedTimestamp = repositoryState.lastUpdatedTimestamp
             // for testing
-            print("Messages count: \(messageRepositoryManager.messages.count)")
+            print("*Messages count: \(messageRepositoryManager.messages.count)")
+            for m in messageRepositoryManager.messages {
+                print("--*Messages: \(m.id) \(m.internalId) \(m.content)")
+            }
 //            self.messages = messageRepositoryManager.messages.toMessageViewModel
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/ThreadViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/ThreadViewModel.swift
@@ -27,7 +27,7 @@ class ThreadViewModel: ObservableObject {
             // for testing
             print("*Messages count: \(messageRepositoryManager.messages.count)")
             for m in messageRepositoryManager.messages {
-                print("--*Messages: \(m.id) \(m.internalId) \(m.content)")
+                print("--*Messages: \(m.id) \(m.content)")
             }
 //            self.messages = messageRepositoryManager.messages.toMessageViewModel
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/RepositoryAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/RepositoryAction.swift
@@ -12,6 +12,12 @@ enum RepositoryAction: Equatable {
     case fetchInitialMessagesSuccess(messages: [ChatMessageInfoModel])
     case fetchInitialMessagesFailed(error: Error)
 
+    case sendMessageTriggered(internalId: String,
+                              content: String)
+    case sendMessageSuccess(internalId: String,
+                            actualId: String)
+    case sendMessageFailed(error: Error)
+
     case repositoryUpdated
 
     // MARK: user action receive from chat

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
@@ -75,6 +75,11 @@ private func handleRepositoryAction(_ action: RepositoryAction,
     case .fetchInitialMessagesTriggered:
         actionHandler.getInitialMessages(state: getState(),
                                          dispatch: dispatch)
+    case .sendMessageTriggered(let internalId, let content):
+        actionHandler.sendMessage(internalId: internalId,
+                                  content: content,
+                                  state: getState(),
+                                  dispatch: dispatch)
     default:
         break
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -8,9 +8,28 @@ import Foundation
 
 protocol RepositoryMiddlewareHandling {
     @discardableResult
-    func loadInitialMessages(messages: [ChatMessageInfoModel]) -> Task<Void, Never>
+    func loadInitialMessages(
+        messages: [ChatMessageInfoModel],
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never>
     @discardableResult
-    func addReceivedMessage(message: ChatMessageInfoModel) -> Task<Void, Never>
+    func addNewSentMessage(
+        internalId: String,
+        content: String,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+    @discardableResult
+    func updateSentMessageId(
+        internalId: String,
+        actualId: String,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+
+    @discardableResult
+    func addReceivedMessage(
+        message: ChatMessageInfoModel,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never>
 }
 
 class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
@@ -22,13 +41,51 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
         self.logger = logger
     }
 
-    func loadInitialMessages(messages: [ChatMessageInfoModel]) -> Task<Void, Never> {
+    func loadInitialMessages(
+        messages: [ChatMessageInfoModel],
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             messageRepository.addInitialMessages(initialMessages: messages)
         }
     }
 
-    func addReceivedMessage(message: ChatMessageInfoModel) -> Task<Void, Never> {
+    func addNewSentMessage(
+        internalId: String,
+        content: String,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            guard let localUserId = state.chatState.localUser?.identifier.stringValue,
+                  let displayName = state.chatState.localUser?.displayName else {
+                return
+            }
+            let message = ChatMessageInfoModel(
+                internalId: internalId,
+                type: .text,
+                senderId: localUserId,
+                senderDisplayName: displayName,
+                content: content)
+            messageRepository.addNewSentMessage(message: message)
+            dispatch(.repositoryAction(.repositoryUpdated))
+        }
+    }
+
+    func updateSentMessageId(
+        internalId: String,
+        actualId: String,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            messageRepository.replaceMessageId(internalId: internalId,
+                                               actualId: actualId)
+        }
+    }
+
+    func addReceivedMessage(
+        message: ChatMessageInfoModel,
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             messageRepository.addReceivedMessage(message: message)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -66,7 +66,7 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
                 senderId: localUserId,
                 senderDisplayName: displayName,
                 content: content)
-            messageRepository.addNewSentMessage(message: message)
+            messageRepository.addNewSendingMessage(message: message)
             dispatch(.repositoryAction(.repositoryUpdated))
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -61,7 +61,7 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
                 return
             }
             let message = ChatMessageInfoModel(
-                internalId: internalId,
+                id: internalId,
                 type: .text,
                 senderId: localUserId,
                 senderDisplayName: displayName,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/RepositoryReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/RepositoryReducer.swift
@@ -14,6 +14,8 @@ extension Reducer where State == RepositoryState,
         case .repositoryAction(.repositoryUpdated):
             print("RepositoryAction `repositoryUpdated` not implemented")
         case .repositoryAction(.fetchInitialMessagesSuccess),
+                .repositoryAction(.sendMessageTriggered),
+                .repositoryAction(.sendMessageSuccess),
                 .repositoryAction(.chatMessageReceived):
                 lastUpdated = Date()
         default:

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
@@ -70,6 +70,29 @@ class ChatSDKWrapper: NSObject, ChatSDKWrapperProtocol {
         }
     }
 
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String {
+        do {
+            let messageRequest = SendChatMessageRequest(
+                content: content,
+                senderDisplayName: senderDisplayName
+            )
+            return try await withCheckedThrowingContinuation { continuation in
+                chatThreadClient?.send(message: messageRequest) { result, _ in
+                    switch result {
+                    case let .success(result):
+                        continuation.resume(returning: result.id)
+                    case .failure(let error):
+                        self.logger.error("Failed to send message: \(error)")
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        } catch {
+            logger.error("Retrieve Thread Topic failed: \(error)")
+            throw error
+        }
+    }
+
     private func createChatClient() throws {
         do {
             print("Creating Chat Client...")

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
@@ -9,6 +9,7 @@ import Combine
 protocol ChatSDKWrapperProtocol {
     func initializeChat() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String
 
     var chatEventsHandler: ChatSDKEventsHandling { get }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
@@ -9,6 +9,7 @@ import Foundation
 protocol ChatServiceProtocol {
     func initalize() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String
 
     var chatEventSubject: PassthroughSubject<ChatEventModel, Never> { get }
 }
@@ -35,4 +36,7 @@ class ChatService: NSObject, ChatServiceProtocol {
         return try await chatSDKWrapper.getInitialMessages()
     }
 
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String {
+        return try await chatSDKWrapper.sendMessage(content: content, senderDisplayName: senderDisplayName)
+    }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/Extension/ChatMessageExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/Extension/ChatMessageExtension.swift
@@ -10,7 +10,6 @@ extension ChatMessage {
     func toChatMessageInfoModel() -> ChatMessageInfoModel {
         return ChatMessageInfoModel(
             id: self.id,
-            internalId: UUID().uuidString,
             version: self.version,
             type: self.type.toMessageType(),
             senderId: self.sender?.stringValue,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
@@ -62,7 +62,7 @@ class MessageRepositoryManagerTests: XCTestCase {
             ChatMessageInfoModel(),
             ChatMessageInfoModel()
         ]
-        guard let internalId = initialMessages.last?.internalId else {
+        guard let internalId = initialMessages.last?.id else {
             XCTFail("Should have at least one message")
             return
         }
@@ -80,7 +80,7 @@ class MessageRepositoryManagerTests: XCTestCase {
             ChatMessageInfoModel(),
             ChatMessageInfoModel()
         ]
-        guard let internalId = initialMessages.last?.internalId else {
+        guard let internalId = initialMessages.last?.id else {
             XCTFail("Should have at least one message")
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
@@ -37,6 +37,61 @@ class MessageRepositoryManagerTests: XCTestCase {
         XCTAssertEqual(sut.messages.count, initialMessages.count)
     }
 
+    func test_messageRepositoryManager_addNewSentMessage_when_nonEmptyInitialMessages_then_messagesCountWillBeIncrementByOne() {
+        let initialMessages = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        let sut = makeSUT(messages: initialMessages)
+        let message = ChatMessageInfoModel()
+        sut.addNewSentMessage(message: message)
+        XCTAssertEqual(sut.messages.count, initialMessages.count + 1)
+    }
+
+    func test_messageRepositoryManager_addNewSentMessage_when_zeroInitialMessages_then_messagesCountWillBeIncrementByOne() {
+        let sut = makeSUT()
+        let message = ChatMessageInfoModel()
+        sut.addNewSentMessage(message: message)
+        XCTAssertEqual(sut.messages.count, 1)
+    }
+
+    func test_messageRepositoryManager_replaceMessageId_when_foundMatchingInternalId_then_actualIdWillBeUpdated() {
+        let initialMessages = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        guard let internalId = initialMessages.last?.internalId else {
+            XCTFail("Should have at least one message")
+            return
+        }
+        let expectedActualId = "actualMessageId"
+        let sut = makeSUT(messages: initialMessages)
+        let message = ChatMessageInfoModel()
+        sut.replaceMessageId(internalId: internalId, actualId: "actualMessageId")
+        XCTAssertEqual(sut.messages.count, initialMessages.count)
+        XCTAssertEqual(sut.messages.last?.id, expectedActualId)
+    }
+
+    func test_messageRepositoryManager_replaceMessageId_when_notFoundMatchingInternalId_then_messagesNotChanged() {
+        let initialMessages = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        guard let internalId = initialMessages.last?.internalId else {
+            XCTFail("Should have at least one message")
+            return
+        }
+        let expectedActualId = "actualMessageId"
+        let sut = makeSUT(messages: initialMessages)
+        let message = ChatMessageInfoModel()
+        sut.replaceMessageId(internalId: internalId + "notFound", actualId: "actualMessageId")
+        XCTAssertEqual(sut.messages.count, initialMessages.count)
+        XCTAssertNotEqual(sut.messages.last?.id, expectedActualId)
+    }
+
     func test_messageRepositoryManager_addReceivedMessage_when_zeroInitialMessages_then_messagesCountWillBeIncrementByOne() {
         let sut = makeSUT()
         let message = ChatMessageInfoModel()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
@@ -45,14 +45,14 @@ class MessageRepositoryManagerTests: XCTestCase {
         ]
         let sut = makeSUT(messages: initialMessages)
         let message = ChatMessageInfoModel()
-        sut.addNewSentMessage(message: message)
+        sut.addNewSendingMessage(message: message)
         XCTAssertEqual(sut.messages.count, initialMessages.count + 1)
     }
 
     func test_messageRepositoryManager_addNewSentMessage_when_zeroInitialMessages_then_messagesCountWillBeIncrementByOne() {
         let sut = makeSUT()
         let message = ChatMessageInfoModel()
-        sut.addNewSentMessage(message: message)
+        sut.addNewSendingMessage(message: message)
         XCTAssertEqual(sut.messages.count, 1)
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
@@ -17,6 +17,7 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
 
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
+    var sendMessageCalled: Bool = false
 
     func initializeChat() async throws {
         initializeCalled = true
@@ -27,6 +28,13 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
         getInitialMessagesCalled = true
         return try await Task<[ChatMessageInfoModel], Error> {
             []
+        }.value
+    }
+
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String {
+        sendMessageCalled = true
+        return try await Task<String, Error> {
+            "messageId"
         }.value
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
@@ -16,6 +16,7 @@ class ChatServiceMocking: ChatServiceProtocol {
 
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
+    var sendMessageCalled: Bool = false
 
     func initalize() async throws {
         initializeCalled = true
@@ -29,6 +30,17 @@ class ChatServiceMocking: ChatServiceProtocol {
                 throw error
             }
             return initialMessages
+        }
+        return try await task.value
+    }
+
+    func sendMessage(content: String, senderDisplayName: String) async throws -> String {
+        sendMessageCalled = true
+        let task = Task<String, Error> {
+            if let error = self.error {
+                throw error
+            }
+            return "messageId"
         }
         return try await task.value
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
@@ -19,7 +19,7 @@ class MessageRepositoryManagerMocking: MessageRepositoryManagerProtocol {
         messages = initialMessages
     }
 
-    func addNewSentMessage(message: ChatMessageInfoModel) {
+    func addNewSendingMessage(message: ChatMessageInfoModel) {
         addNewSentMessageCalled = true
         messages.append(message)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
@@ -10,11 +10,22 @@ class MessageRepositoryManagerMocking: MessageRepositoryManagerProtocol {
     var messages: [ChatMessageInfoModel] = []
 
     var addInitialMessagesCalled: Bool = false
+    var addNewSentMessageCalled: Bool = false
+    var replaceMessageIdCalled: Bool = false
     var addReceivedMessageCalled: Bool = false
 
     func addInitialMessages(initialMessages: [ChatMessageInfoModel]) {
         addInitialMessagesCalled = true
         messages = initialMessages
+    }
+
+    func addNewSentMessage(message: ChatMessageInfoModel) {
+        addNewSentMessageCalled = true
+        messages.append(message)
+    }
+
+    func replaceMessageId(internalId: String, actualId: String) {
+        replaceMessageIdCalled = true
     }
 
     func addReceivedMessage(message: ChatMessageInfoModel) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
@@ -11,6 +11,7 @@ class ChatActionHandlerMocking: ChatActionHandling {
     var enterForegroundCalled: ((Bool) -> Void)?
     var initializeCalled: ((Bool) -> Void)?
     var getInitialMessagesCalled: ((Bool) -> Void)?
+    var sendMessageCalled: ((Bool) -> Void)?
 
     func enterBackground(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
@@ -30,9 +31,15 @@ class ChatActionHandlerMocking: ChatActionHandling {
         }
     }
 
-    func getInitialMessages(state: AzureCommunicationUIChat.AppState, dispatch: @escaping AzureCommunicationUIChat.ActionDispatch) -> Task<Void, Never> {
+    func getInitialMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             getInitialMessagesCalled?(true)
+        }
+    }
+
+    func sendMessage(internalId: String, content: String, state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            sendMessageCalled?(true)
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/RepositoryHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/RepositoryHandlerMocking.swift
@@ -8,15 +8,29 @@ import Foundation
 
 class RepositoryHandlerMocking: RepositoryMiddlewareHandling {
     var loadInitialMessagesCalled: ((Bool) -> Void)?
+    var addNewSentMessageCalled: ((Bool) -> Void)?
+    var updateSentMessageIdCalled: ((Bool) -> Void)?
     var addReceivedMessageCalled: ((Bool) -> Void)?
 
-    func loadInitialMessages(messages: [ChatMessageInfoModel]) -> Task<Void, Never> {
+    func loadInitialMessages(messages: [ChatMessageInfoModel], state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             loadInitialMessagesCalled?(true)
         }
     }
 
-    func addReceivedMessage(message: ChatMessageInfoModel) -> Task<Void, Never> {
+    func addNewSentMessage(internalId: String, content: String, state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            addNewSentMessageCalled?(true)
+        }
+    }
+
+    func updateSentMessageId(internalId: String, actualId: String, state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            updateSentMessageIdCalled?(true)
+        }
+    }
+
+    func addReceivedMessage(message: ChatMessageInfoModel, state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             addReceivedMessageCalled?(true)
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 
+import AzureCommunicationCommon
 import XCTest
 import Combine
 @testable import AzureCommunicationUIChat
@@ -46,6 +47,17 @@ class ChatActionHandlerTests: XCTestCase {
 
         XCTAssertTrue(mockChatService.getInitialMessagesCalled)
     }
+
+    func test_chatActionHandler_sendMessage_then_getInitialMessagesCalled() async {
+        let sut = makeSUT()
+        await sut.sendMessage(
+            internalId: "internalId",
+            content: "content",
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
+
+        XCTAssertTrue(mockChatService.sendMessageCalled)
+    }
 }
 
 extension ChatActionHandlerTests {
@@ -57,7 +69,11 @@ extension ChatActionHandlerTests {
     }
 
     private func getEmptyState() -> AppState {
-        return AppState()
+        let localUser = ParticipantInfoModel(
+            identifier: CommunicationUserIdentifier("identifier"),
+            displayName: "displayName")
+        let chatState = ChatState(localUser: localUser)
+        return AppState(chatState: chatState)
     }
 
     private func getEmptyDispatch() -> ActionDispatch {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
@@ -56,6 +56,19 @@ class ChatMiddlewareTests: XCTestCase {
         middlewareDispatch(getEmptyDispatch())(.repositoryAction(.fetchInitialMessagesTriggered))
         wait(for: [expectation], timeout: 1)
     }
+
+    func test_chatMiddleware_apply_when_sendMessageTriggeredRepositoryAction_then_handlerSendMessageCalledBeingCalled() {
+
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "sendMessageCalled")
+        mockChatActionHandler.sendMessageCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+
+        middlewareDispatch(getEmptyDispatch())(.repositoryAction(.sendMessageTriggered(internalId: "internalId", content: "content")))
+        wait(for: [expectation], timeout: 1)
+    }
 }
 
 extension ChatMiddlewareTests {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareHandlerTests.swift
@@ -3,10 +3,10 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
-
-import XCTest
+import AzureCommunicationCommon
 import Combine
+import Foundation
+import XCTest
 @testable import AzureCommunicationUIChat
 
 class RepositoryMiddlewareHandlerTests: XCTestCase {
@@ -32,13 +32,37 @@ class RepositoryMiddlewareHandlerTests: XCTestCase {
     }
 
     func test_repositoryMiddlewareHandler_loadInitialMessages_then_addInitialMessagesCalled() async {
-        await repositoryMiddlewareHandler.loadInitialMessages(messages: []).value
+        await repositoryMiddlewareHandler.loadInitialMessages(
+            messages: [],
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
         XCTAssertTrue(mockMessageRepositoryManager.addInitialMessagesCalled)
+    }
+
+    func test_repositoryMiddlewareHandler_addNewSentMessage_then_addNewSentMessageCalled() async {
+        await repositoryMiddlewareHandler.addNewSentMessage(
+            internalId: "internalId",
+            content: "content",
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
+        XCTAssertTrue(mockMessageRepositoryManager.addNewSentMessageCalled)
+    }
+
+    func test_repositoryMiddlewareHandler_updateSentMessageId_then_replaceMessageIdCalled() async {
+        await repositoryMiddlewareHandler.updateSentMessageId(
+            internalId: "internalId",
+            actualId: "actualId",
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
+        XCTAssertTrue(mockMessageRepositoryManager.replaceMessageIdCalled)
     }
 
     func test_repositoryMiddlewareHandler_addReceivedMessage_then_addReceivedMessageCalled() async {
         let message = ChatMessageInfoModel()
-        await repositoryMiddlewareHandler.addReceivedMessage(message: message).value
+        await repositoryMiddlewareHandler.addReceivedMessage(
+            message: message,
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
         XCTAssertTrue(mockMessageRepositoryManager.addReceivedMessageCalled)
     }
 }
@@ -46,7 +70,11 @@ class RepositoryMiddlewareHandlerTests: XCTestCase {
 extension RepositoryMiddlewareHandlerTests {
 
     private func getEmptyState() -> AppState {
-        return AppState()
+        let localUser = ParticipantInfoModel(
+            identifier: CommunicationUserIdentifier("identifier"),
+            displayName: "displayName")
+        let chatState = ChatState(localUser: localUser)
+        return AppState(chatState: chatState)
     }
 
     private func getEmptyDispatch() -> ActionDispatch {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareTests.swift
@@ -41,6 +41,36 @@ class RepositoryMiddlewareTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_repositoryMiddleware_apply_when_sendMessageTriggeredRepositoryAction_then_handlerLoadInitialMessagesCalledBeingCalled() {
+
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "addNewSentMessageCalled")
+        mockRepositoryHandler.addNewSentMessageCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+
+        middlewareDispatch(getEmptyDispatch())(.repositoryAction(.sendMessageTriggered(
+            internalId: "internalId",
+            content: "content")))
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_repositoryMiddleware_apply_when_sendMessageSuccessRepositoryAction_then_handlerLoadInitialMessagesCalledBeingCalled() {
+
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "updateSentMessageIdCalled")
+        mockRepositoryHandler.updateSentMessageIdCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+
+        middlewareDispatch(getEmptyDispatch())(.repositoryAction(.sendMessageSuccess(
+            internalId: "internalId",
+            actualId: "actualId")))
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_repositoryMiddleware_apply_when_chatMessageReceivedRepositoryAction_then_handleraddReceivedMessageBeingCalled() {
 
         let middlewareDispatch = getEmptyChatMiddlewareFunction()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Reducer/RepositoryReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Reducer/RepositoryReducerTests.swift
@@ -19,6 +19,30 @@ class RepositoryReducerTests: XCTestCase {
         XCTAssertTrue(resultState.lastUpdatedTimestamp > initialTimestamp)
     }
 
+    func test_repositoryReducer_reduce_when_sendMessageTriggeredAction_then_stateUpdated() {
+        let initialTimestamp = Date()
+        let state = RepositoryState(lastUpdatedTimestamp: initialTimestamp)
+        let action = Action.repositoryAction(.sendMessageTriggered(
+            internalId: "internalId",
+            content: "content"))
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        XCTAssertTrue(resultState.lastUpdatedTimestamp > initialTimestamp)
+    }
+
+    func test_repositoryReducer_reduce_when_sendMessageSuccess_then_stateUpdated() {
+        let initialTimestamp = Date()
+        let state = RepositoryState(lastUpdatedTimestamp: initialTimestamp)
+        let action = Action.repositoryAction(.sendMessageSuccess(
+            internalId: "internalId",
+            actualId: "actualId"))
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        XCTAssertTrue(resultState.lastUpdatedTimestamp > initialTimestamp)
+    }
+
     func test_repositoryReducer_reduce_when_chatMessageReceivedAction_then_stateUpdated() {
         let initialTimestamp = Date()
         let state = RepositoryState(lastUpdatedTimestamp: initialTimestamp)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
@@ -43,4 +43,10 @@ class ChatServiceTests: XCTestCase {
 
         XCTAssertTrue(chatSDKWrapper.getInitialMessagesCalled)
     }
+
+    func test_chatService_sendMessage_shouldCallchatSDKWrappersendMessage() async throws {
+        _ = try await chatService.sendMessage(content: "content", senderDisplayName: "displayName")
+
+        XCTAssertTrue(chatSDKWrapper.sendMessageCalled)
+    }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Implemented send message for chat composite for both service layer and redux layer
* Introduced internalId when sending message and update with actual messageId from ChatSDK response
  * When receive TrouterEvent for the local user's send message will replace the message with same id in message repository
* Filter logs by `*Message` when receiving and sending message to see the logs in console

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->