### PR TITLE
[Task] Chat typing indicator sending - redux/service layer, PR #2 of 2

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Localization/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Localization/Localizable.strings
@@ -8,5 +8,7 @@
 "AzureCommunicationUIChat.ChatView.TopBarView.ChatWith1Person"="Chat with 1 person";
 "AzureCommunicationUIChat.ChatView.TopBarView.ChatWithNPeople"="Chat with %d people"; // %d is for number of people in call
 /* TypingParticipantsView */
-"AzureCommunicationUIChat.ChatView.TypingParticipantsView.AreTyping"="are typing...";
-"AzureCommunicationUIChat.ChatView.TypingParticipantsView.IsTyping"="is typing...";
+"AzureCommunicationUIChat.ChatView.TypingParticipantsView.oneParticipantIsTyping"="%@ is typing..."; // %@ is display name
+"AzureCommunicationUIChat.ChatView.TypingParticipantsView.twoParticipantsAreTyping"="%@ and %@ are typing...";
+"AzureCommunicationUIChat.ChatView.TypingParticipantsView.threeParticipantsAreTyping"="%@, %@ and 1 other are typing...";
+"AzureCommunicationUIChat.ChatView.TypingParticipantsView.multipleParticipantsAreTyping"="%@, %@ and %d others are typing..."; // %d is remaining number of participant typing

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Style/LocalizationProvider.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Style/LocalizationProvider.swift
@@ -9,6 +9,7 @@ import SwiftUI
 protocol LocalizationProviderProtocol {
     var isRightToLeft: Bool { get }
     func getLocalizedString(_ key: LocalizationKey) -> String
+    func getLocalizedString(_ key: LocalizationKey, _ args: CVarArg...) -> String
 }
 
 class LocalizationProvider: LocalizationProviderProtocol {
@@ -37,6 +38,11 @@ class LocalizationProvider: LocalizationProviderProtocol {
             }
         }
         return getPredefinedLocalizedString(key.rawValue)
+    }
+
+    func getLocalizedString(_ key: LocalizationKey, _ args: CVarArg...) -> String {
+        let stringFormat = getLocalizedString(key)
+        return String(format: stringFormat, arguments: args)
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
@@ -37,6 +37,12 @@ struct BottomBarView: View {
         .onChange(of: hasFocus) {
             viewModel.hasFocus = $0
         }
+        .onChange(of: viewModel.message) { newValue in
+            guard !newValue.isEmpty else {
+                return
+            }
+            viewModel.sendTypingIndicator()
+        }
         .onAppear {
            self.hasFocus = viewModel.hasFocus
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
@@ -11,6 +11,10 @@ class BottomBarViewModel: ObservableObject {
 
     var sendButtonViewModel: IconButtonViewModel!
 
+    // MARK: Typing Indicators
+    private var lastTypingIndicatorSendTimestamp = Date()
+    private let typingIndicatorDelay: TimeInterval = 8.0
+
     init(compositeViewModelFactory: CompositeViewModelFactory,
          logger: Logger,
          dispatch: @escaping ActionDispatch) {
@@ -42,5 +46,12 @@ class BottomBarViewModel: ObservableObject {
             internalId: UUID().uuidString,
             content: message)))
         message = ""
+    }
+
+    func sendTypingIndicator() {
+        if lastTypingIndicatorSendTimestamp < Date() - typingIndicatorDelay {
+            dispatch(.chatAction(.sendTypingIndicatorTriggered))
+            lastTypingIndicatorSendTimestamp = Date()
+        }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsView.swift
@@ -13,25 +13,31 @@ struct TypingParticipantsView: View {
         static let padding: CGFloat = 20.0
         static let sectionHeight: CGFloat = 10.0
         static let avatarWidth: CGFloat = 16.0
+        static let maxAvatarShown: Int = 3
     }
 
     var body: some View {
-        Spacer()
-        HStack {
-            VStack(spacing: 0) {
+        Group {
+            if viewModel.shouldShowIndicator {
                 Spacer()
-                TypingParticipantAvatarGroupContainer(participantList: viewModel.participants)
-                    .frame(width: CGFloat(viewModel.participants.count) * Constants.avatarWidth,
-                           alignment: .leading)
+                HStack {
+                    VStack(spacing: 0) {
+                        Spacer()
+                        TypingParticipantAvatarGroupContainer(participantList: viewModel.participants)
+                            .frame(width: CGFloat(min(Constants.maxAvatarShown,
+                                                      viewModel.participants.count)) * Constants.avatarWidth,
+                                   alignment: .leading)
+                        Spacer()
+                    }
+                    Text(viewModel.typingIndicatorLabel ?? "")
+                        .font(.caption)
+                    Spacer()
+                }
+                .frame(width: UIScreen.main.bounds.size.width,
+                       height: Constants.sectionHeight)
+                .padding(.leading, Constants.padding)
                 Spacer()
             }
-            Text(viewModel.typingParticipants)
-                .fontWeight(.light)
-            Spacer()
         }
-        .frame(width: UIScreen.main.bounds.size.width,
-               height: Constants.sectionHeight)
-        .padding(.leading, Constants.padding)
-        Spacer()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
@@ -14,11 +14,10 @@ class TypingParticipantsViewModel: ObservableObject {
     private var typingIndicatorLastUpdatedTimestamp = Date()
     var participants: [ParticipantInfoModel] = []
 
-    @Published var typingParticipants: String = Constants.defaultParticipant
+    @Published var typingIndicatorLabel: String?
+    var shouldShowIndicator: Bool = false
 
     private enum Constants {
-        static let defaultParticipant: String = ""
-        static let participantSeparator: String = ", "
         static let defaultTimeInterval: TimeInterval = 8.0
     }
 
@@ -52,16 +51,17 @@ class TypingParticipantsViewModel: ObservableObject {
 
     private func displayWithTimer(latestTypingTimestamp: Date,
                                   participants: [ParticipantInfoModel]) {
-        if participants.isEmpty {
-            hideTypingIndicator()
-        } else {
-            typingParticipants = getLocalizedTypingIndicatorText(participants: participants)
-            resetTimer(timeInterval: Date().timeIntervalSince(latestTypingTimestamp))
+        guard !participants.isEmpty else {
+            return
         }
+        shouldShowIndicator = true
+        typingIndicatorLabel = getLocalizedTypingIndicatorText(participants: participants)
+        resetTimer(timeInterval: Date().timeIntervalSince(latestTypingTimestamp))
     }
 
     @objc private func hideTypingIndicator() {
-        typingParticipants = Constants.defaultParticipant
+        shouldShowIndicator = false
+        typingIndicatorLabel = nil
         typingIndicatorTimer?.invalidate()
     }
 
@@ -72,17 +72,17 @@ class TypingParticipantsViewModel: ObservableObject {
                                                            participants[0].displayName)
         // X and Y are typing
         } else if participants.count == 2 {
-            return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+            return localizationProvider.getLocalizedString(.twoParticipantsAreTyping,
                                                            participants[0].displayName,
                                                            participants[1].displayName)
         // X, Y and 1 other are typing
         } else if participants.count == 3 {
-                return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+                return localizationProvider.getLocalizedString(.threeParticipantsAreTyping,
                                                                participants[0].displayName,
                                                                participants[1].displayName)
         // X, Y and Z others are typing
         } else if participants.count > 3 {
-            return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+            return localizationProvider.getLocalizedString(.multipleParticipantsAreTyping,
                                                            participants[0].displayName,
                                                            participants[1].displayName,
                                                            participants.count - 2)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
@@ -60,11 +60,12 @@ class TypingParticipantsViewModel: ObservableObject {
 
     private func displayWithTimer(latestTypingTimestamp: Date,
                                   participants: [ParticipantInfoModel]) {
-        guard !participants.isEmpty else {
+        guard !participants.isEmpty,
+              let label = getLocalizedTypingIndicatorText(participants: participants) else {
             return
         }
         shouldShowIndicator = true
-        typingIndicatorLabel = getLocalizedTypingIndicatorText(participants: participants)
+        typingIndicatorLabel = label
         resetTimer(timeInterval: Date().timeIntervalSince(latestTypingTimestamp))
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsViewModel.swift
@@ -55,12 +55,7 @@ class TypingParticipantsViewModel: ObservableObject {
         if participants.isEmpty {
             hideTypingIndicator()
         } else {
-            typingParticipants = participants.compactMap { p in
-                p.displayName
-            }.joined(separator: Constants.participantSeparator)
-            typingParticipants += participants.count == 1 ?
-            localizationProvider.getLocalizedString(.participantIsTyping):
-            localizationProvider.getLocalizedString(.participantsAreTyping)
+            typingParticipants = getLocalizedTypingIndicatorText(participants: participants)
             resetTimer(timeInterval: Date().timeIntervalSince(latestTypingTimestamp))
         }
     }
@@ -68,6 +63,32 @@ class TypingParticipantsViewModel: ObservableObject {
     @objc private func hideTypingIndicator() {
         typingParticipants = Constants.defaultParticipant
         typingIndicatorTimer?.invalidate()
+    }
+
+    private func getLocalizedTypingIndicatorText(participants: [ParticipantInfoModel]) -> String {
+        // X is typing
+        if participants.count == 1 {
+            return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+                                                           participants[0].displayName)
+        // X and Y are typing
+        } else if participants.count == 2 {
+            return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+                                                           participants[0].displayName,
+                                                           participants[1].displayName)
+        // X, Y and 1 other are typing
+        } else if participants.count == 3 {
+                return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+                                                               participants[0].displayName,
+                                                               participants[1].displayName)
+        // X, Y and Z others are typing
+        } else if participants.count > 3 {
+            return localizationProvider.getLocalizedString(.oneParticipantIsTyping,
+                                                           participants[0].displayName,
+                                                           participants[1].displayName,
+                                                           participants.count - 2)
+        } else {
+            return ""
+        }
     }
 
     private func resetTimer(timeInterval: TimeInterval = Constants.defaultTimeInterval) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
@@ -15,7 +15,6 @@ enum ChatAction: Equatable {
     case realTimeNotificationDisconnected
     case chatThreadDeleted
     case chatTopicUpdated(topic: String)
-    case messageReceived(message: ChatMessageInfoModel)
 
     case sendTypingIndicatorTriggered
     case sendTypingIndicatorSuccess

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
@@ -17,12 +17,19 @@ enum ChatAction: Equatable {
     case chatTopicUpdated(topic: String)
     case messageReceived(message: ChatMessageInfoModel)
 
+    case sendTypingIndicatorTriggered
+    case sendTypingIndicatorSuccess
+    case sendTypingIndicatorFailed(error: Error)
+
     static func == (lhs: ChatAction, rhs: ChatAction) -> Bool {
         switch (lhs, rhs) {
-        case let (.initializeChatFailed(lErr), .initializeChatFailed(rErr)):
+        case let (.initializeChatFailed(lErr), .initializeChatFailed(rErr)),
+            let (.sendTypingIndicatorFailed(lErr), .sendTypingIndicatorFailed(rErr)):
             return (lErr as NSError).code == (rErr as NSError).code
 
-        case (.initializeChatTriggered, .initializeChatTriggered):
+        case (.initializeChatTriggered, .initializeChatTriggered),
+            (.sendTypingIndicatorTriggered, .sendTypingIndicatorTriggered),
+            (.sendTypingIndicatorSuccess, .sendTypingIndicatorSuccess):
             return true
 
         case let (.topicRetrieved(lStr), .topicRetrieved(rStr)):

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
@@ -71,7 +71,6 @@ class ChatActionHandler: ChatActionHandling {
             do {
                 try await chatService.sendTypingIndicator()
                 dispatch(.chatAction(.sendTypingIndicatorSuccess))
-                logger.error("ChatActionHandler sendTypingIndicator success")
             } catch {
                 logger.error("ChatActionHandler sendTypingIndicator failed: \(error)")
                 dispatch(.chatAction(.sendTypingIndicatorFailed(error: error)))

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
@@ -22,9 +22,12 @@ protocol ChatActionHandling {
                      content: String,
                      state: AppState,
                      dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+    @discardableResult
+    func sendTypingIndicator(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never>
 }
 
 class ChatActionHandler: ChatActionHandling {
+
     private let chatService: ChatServiceProtocol
     private let logger: Logger
 
@@ -63,6 +66,18 @@ class ChatActionHandler: ChatActionHandling {
     }
 
     // MARK: Chat Handler
+    func sendTypingIndicator(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            do {
+                try await chatService.sendTypingIndicator()
+                dispatch(.chatAction(.sendTypingIndicatorSuccess))
+                logger.error("ChatActionHandler sendTypingIndicator success")
+            } catch {
+                logger.error("ChatActionHandler sendTypingIndicator failed: \(error)")
+                dispatch(.chatAction(.sendTypingIndicatorFailed(error: error)))
+            }
+        }
+    }
 
     // MARK: Participants Handler
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
@@ -55,6 +55,9 @@ private func handleChatAction(_ action: ChatAction,
         actionHandler.initialize(state: getState(),
                                  dispatch: dispatch,
                                  serviceListener: serviceListener)
+    case .sendTypingIndicatorTriggered:
+        actionHandler.sendTypingIndicator(state: getState(),
+                                          dispatch: dispatch)
     default:
         break
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/ParticipantsReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/ParticipantsReducer.swift
@@ -37,8 +37,8 @@ extension Reducer where State == ParticipantsState,
             if typingIndicatorTimestamp < typingExpiringTimestamp {
                 typingIndicatorTimestamp = typingExpiringTimestamp
             }
-        case .chatAction(.messageReceived(let message)):
-            if let participantId = message.senderId, message.type == .text {
+        case .repositoryAction(.chatMessageReceived(let message)):
+            if let participantId = message.senderId {
                 typingIndicatorMap.removeValue(forKey: participantId)
                 typingIndicatorTimestamp = currentTimestamp
             }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
@@ -150,6 +150,25 @@ class ChatSDKWrapper: NSObject, ChatSDKWrapperProtocol {
         }
     }
 
+    func sendTypingIndicator() async throws {
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                self.chatThreadClient?.sendTypingNotification(from: self.chatConfiguration.displayName) { result, _ in
+                    switch result {
+                    case .success:
+                        continuation.resume(returning: Void())
+                    case .failure(let error):
+                        self.logger.error("Send Typing Indicator failed: \(error)")
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        } catch {
+            self.logger.error("Send Typing Indicator failed: \(error)")
+            throw error
+        }
+    }
+
     private func registerEvents() {
         guard let client = self.chatClient else {
                      return

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
@@ -10,6 +10,7 @@ protocol ChatSDKWrapperProtocol {
     func initializeChat() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
     func sendMessage(content: String, senderDisplayName: String) async throws -> String
+    func sendTypingIndicator() async throws
 
     var chatEventsHandler: ChatSDKEventsHandling { get }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
@@ -10,6 +10,7 @@ protocol ChatServiceProtocol {
     func initalize() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
     func sendMessage(content: String, senderDisplayName: String) async throws -> String
+    func sendTypingIndicator() async throws
 
     var chatEventSubject: PassthroughSubject<ChatEventModel, Never> { get }
 }
@@ -38,5 +39,9 @@ class ChatService: NSObject, ChatServiceProtocol {
 
     func sendMessage(content: String, senderDisplayName: String) async throws -> String {
         return try await chatSDKWrapper.sendMessage(content: content, senderDisplayName: senderDisplayName)
+    }
+
+    func sendTypingIndicator() async throws {
+        try await chatSDKWrapper.sendTypingIndicator()
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Utilities/LocalizationKey.swift
@@ -13,6 +13,12 @@ enum LocalizationKey: String {
     case chatWithNPerson = "AzureCommunicationUIChat.ChatView.TopBarView.CallWithNPeople"
 
     /* TypingParticipantsView */
-    case participantsAreTyping = "AzureCommunicationUIChat.ChatView.TypingParticipantsView.AreTyping"
-    case participantIsTyping = "AzureCommunicationUIChat.ChatView.TypingParticipantsView.IsTyping"
+    case oneParticipantIsTyping =
+            "AzureCommunicationUIChat.ChatView.TypingParticipantsView.oneParticipantIsTyping"
+    case twoParticipantsAreTyping =
+            "AzureCommunicationUIChat.ChatView.TypingParticipantsView.twoParticipantsAreTyping"
+    case threeParticipantsAreTyping =
+            "AzureCommunicationUIChat.ChatView.TypingParticipantsView.threeParticipantsAreTyping"
+    case multipleParticipantsAreTyping =
+            "AzureCommunicationUIChat.ChatView.TypingParticipantsView.multipleParticipantsAreTyping"
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
@@ -18,6 +18,7 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
     var sendMessageCalled: Bool = false
+    var sendTypingIndicatorCalled: Bool = false
 
     func initializeChat() async throws {
         initializeCalled = true
@@ -36,5 +37,10 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
         return try await Task<String, Error> {
             "messageId"
         }.value
+    }
+
+    func sendTypingIndicator() async throws {
+        sendTypingIndicatorCalled = true
+        try await Task<Void, Error> {}.value
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
@@ -8,7 +8,6 @@ import Combine
 @testable import AzureCommunicationUIChat
 
 class ChatServiceMocking: ChatServiceProtocol {
-    
     var error: Error?
     var chatEventSubject = PassthroughSubject<ChatEventModel, Never>()
 
@@ -18,6 +17,7 @@ class ChatServiceMocking: ChatServiceProtocol {
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
     var sendMessageCalled: Bool = false
+    var sendTypingIndicatorCalled: Bool = false
 
     func initalize() async throws {
         initializeCalled = true
@@ -56,6 +56,7 @@ class ChatServiceMocking: ChatServiceProtocol {
     }
 
     func sendTypingIndicator() async throws {
+        sendTypingIndicatorCalled = true
         Task<Void, Error> {
             if let error = self.error {
                 throw error

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
@@ -8,6 +8,7 @@ import Combine
 @testable import AzureCommunicationUIChat
 
 class ChatServiceMocking: ChatServiceProtocol {
+    
     var error: Error?
     var chatEventSubject = PassthroughSubject<ChatEventModel, Never>()
 
@@ -47,6 +48,14 @@ class ChatServiceMocking: ChatServiceProtocol {
 
     // for future void functions
     private func possibleErrorTask() throws -> Task<Void, Error> {
+        Task<Void, Error> {
+            if let error = self.error {
+                throw error
+            }
+        }
+    }
+
+    func sendTypingIndicator() async throws {
         Task<Void, Error> {
             if let error = self.error {
                 throw error

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/LocalizationProviderMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/LocalizationProviderMocking.swift
@@ -3,4 +3,23 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
+@testable import AzureCommunicationUIChat
+
+class LocalizationProviderMocking: LocalizationProviderProtocol {
+    var isGetLocalizedStringCalled: Bool = false
+    var isGetLocalizedStringWithArgsCalled: Bool = false
+
+    var isRightToLeft: Bool {
+        return false
+    }
+
+    func getLocalizedString(_ key: LocalizationKey) -> String {
+        isGetLocalizedStringCalled = true
+        return key.rawValue
+    }
+
+    func getLocalizedString(_ key: LocalizationKey, _ args: CVarArg...) -> String {
+        isGetLocalizedStringWithArgsCalled = true
+        return key.rawValue
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
@@ -7,11 +7,13 @@ import Foundation
 @testable import AzureCommunicationUIChat
 
 class ChatActionHandlerMocking: ChatActionHandling {
+    
     var enterBackgroundCalled: ((Bool) -> Void)?
     var enterForegroundCalled: ((Bool) -> Void)?
     var initializeCalled: ((Bool) -> Void)?
     var getInitialMessagesCalled: ((Bool) -> Void)?
     var sendMessageCalled: ((Bool) -> Void)?
+    var sendTypingIndicatorCalled: ((Bool) -> Void)?
 
     func enterBackground(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
@@ -40,6 +42,13 @@ class ChatActionHandlerMocking: ChatActionHandling {
     func sendMessage(internalId: String, content: String, state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             sendMessageCalled?(true)
+        }
+    }
+
+    func sendTypingIndicator(state: AzureCommunicationUIChat.AppState,
+                             dispatch: @escaping AzureCommunicationUIChat.ActionDispatch) -> Task<Void, Never> {
+        Task {
+            sendTypingIndicatorCalled?(true)
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
@@ -7,7 +7,7 @@ import Foundation
 @testable import AzureCommunicationUIChat
 
 class ChatActionHandlerMocking: ChatActionHandling {
-    
+
     var enterBackgroundCalled: ((Bool) -> Void)?
     var enterForegroundCalled: ((Bool) -> Void)?
     var initializeCalled: ((Bool) -> Void)?

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
@@ -58,6 +58,25 @@ class ChatActionHandlerTests: XCTestCase {
 
         XCTAssertTrue(mockChatService.sendMessageCalled)
     }
+
+    func test_chatActionHandler_sendTypingIndicator_then_sendTypingIndicatorCalled() async {
+        let sut = makeSUT()
+        await sut.sendTypingIndicator(state: getEmptyState(),
+                                      dispatch: getEmptyDispatch()).value
+        XCTAssertTrue(mockChatService.sendTypingIndicatorCalled)
+    }
+
+    func test_chatActionHandler_sendTypingIndicator_then_sendTypingIndicatorDispatched() async {
+        let expectation = XCTestExpectation(description: "Dispatch Send Typing Indicator Success")
+        func dispatch(action: Action) {
+            XCTAssertTrue(action == Action.chatAction(.sendTypingIndicatorSuccess))
+            expectation.fulfill()
+        }
+        let sut = makeSUT()
+        await sut.sendTypingIndicator(state: getEmptyState(),
+                                      dispatch: dispatch).value
+        wait(for: [expectation], timeout: 1)
+    }
 }
 
 extension ChatActionHandlerTests {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
@@ -69,6 +69,17 @@ class ChatMiddlewareTests: XCTestCase {
         middlewareDispatch(getEmptyDispatch())(.repositoryAction(.sendMessageTriggered(internalId: "internalId", content: "content")))
         wait(for: [expectation], timeout: 1)
     }
+
+    func test_chatMiddleware_apply_when_sendTypingIndicatorTriggered_then_handlerSendTypingIndicatorCalled() {
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "sendTypingIndicatorCalled")
+        mockChatActionHandler.sendTypingIndicatorCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+        middlewareDispatch(getEmptyDispatch())(.chatAction(.sendTypingIndicatorTriggered))
+        wait(for: [expectation], timeout: 1)
+    }
 }
 
 extension ChatMiddlewareTests {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
@@ -49,4 +49,9 @@ class ChatServiceTests: XCTestCase {
 
         XCTAssertTrue(chatSDKWrapper.sendMessageCalled)
     }
+
+    func test_chatService_sendTypingIndicator_shouldCallchatSDKWrapperSendTypingIndicator() async throws {
+        _ = try await chatService.sendTypingIndicator()
+        XCTAssertTrue(chatSDKWrapper.sendTypingIndicatorCalled)
+    }
 }


### PR DESCRIPTION
## Purpose
typing indicator logic is currently as the following:

for 1 person typing, it would be "X is typing..."
for 2 people: "X and Y are typing..."
for 3 and more: "X, Y and Z other(s) are typing...

maximum avatar is currently being capped at 2, will confirm with UI team later when they are back.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
Minor style update to the UI: 

![image](https://user-images.githubusercontent.com/109105353/196559961-d2062f91-5bd2-4728-a85f-d543180d4e1a.png)
