### PR TITLE
[Feature] Implemented chat message history pagination

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -11,6 +11,7 @@ protocol MessageRepositoryManagerProtocol {
 
     // MARK: sending local events
     func addInitialMessages(initialMessages: [ChatMessageInfoModel])
+    func addPreviousMessages(previousMessages: [ChatMessageInfoModel])
     func addNewSendingMessage(message: ChatMessageInfoModel)
     func replaceMessageId(internalId: String, actualId: String)
 
@@ -29,6 +30,26 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
 
     func addInitialMessages(initialMessages: [ChatMessageInfoModel]) {
         messages = initialMessages
+    }
+
+    func addPreviousMessages(previousMessages: [ChatMessageInfoModel]) {
+        // work around for duplicate message
+        // will use more efficient data structure in MessageRepo PR
+        for m in previousMessages {
+            if let index = messages.firstIndex(where: {
+                $0.id == m.id
+            }) {
+                messages[index] = m
+            } else {
+                messages.append(m)
+            }
+        }
+
+        messages.sort { lhs, rhs -> Bool in
+            // createdOn does not have milliseconds
+            return lhs.createdOn == rhs.createdOn ?
+            lhs.id < rhs.id : lhs.createdOn < rhs.createdOn
+        }
     }
 
     func addNewSendingMessage(message: ChatMessageInfoModel) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -33,8 +33,7 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
     }
 
     func addPreviousMessages(previousMessages: [ChatMessageInfoModel]) {
-        // work around for duplicate message
-        // will use more efficient data structure in MessageRepo PR
+        // Workaround: improve data structure in MessageRepo user story
         for m in previousMessages {
             if let index = messages.firstIndex(where: {
                 $0.id == m.id

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
@@ -36,7 +36,6 @@ class BottomBarViewModel: ObservableObject {
     func sendMessage() {
         // Added for testing to trigger action
         if message == "fetch" {
-            print("Fetching previous *Messages*")
             dispatch(.repositoryAction(.fetchPreviousMessagesTriggered))
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
@@ -34,6 +34,13 @@ class BottomBarViewModel: ObservableObject {
     @Published var hasFocus: Bool = true
 
     func sendMessage() {
+        // Added for testing to trigger action
+        if message == "fetch" {
+            print("Fetching previous *Messages*")
+            dispatch(.repositoryAction(.fetchPreviousMessagesTriggered))
+            return
+        }
+
         hasFocus = true
         guard !message.isEmpty else {
             return

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
@@ -27,7 +27,7 @@ class MessageListViewModel: ObservableObject {
             // for testing
             print("*Messages count: \(messageRepositoryManager.messages.count)")
             for m in messageRepositoryManager.messages {
-                print("--*Messages: \(m.id) \(m.content)")
+                print("--*Messages: \(m.id) \(m.createdOn.value) \(m.content)")
             }
 //            self.messages = messageRepositoryManager.messages.toMessageViewModel
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/RepositoryAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/RepositoryAction.swift
@@ -12,6 +12,10 @@ enum RepositoryAction: Equatable {
     case fetchInitialMessagesSuccess(messages: [ChatMessageInfoModel])
     case fetchInitialMessagesFailed(error: Error)
 
+    case fetchPreviousMessagesTriggered
+    case fetchPreviousMessagesSuccess(messages: [ChatMessageInfoModel])
+    case fetchPreviousMessagesFailed(error: Error)
+
     case sendMessageTriggered(internalId: String,
                               content: String)
     case sendMessageSuccess(internalId: String,
@@ -27,14 +31,17 @@ enum RepositoryAction: Equatable {
 
     static func == (lhs: RepositoryAction, rhs: RepositoryAction) -> Bool {
         switch (lhs, rhs) {
-        case let (.fetchInitialMessagesFailed(lErr), .fetchInitialMessagesFailed(rErr)):
+        case let (.fetchInitialMessagesFailed(lErr), .fetchInitialMessagesFailed(rErr)),
+            let (.fetchPreviousMessagesFailed(lErr), .fetchPreviousMessagesFailed(rErr)):
             return (lErr as NSError).code == (rErr as NSError).code
 
         case (.fetchInitialMessagesTriggered, .fetchInitialMessagesTriggered),
+            (.fetchPreviousMessagesTriggered, .fetchPreviousMessagesTriggered),
             (.repositoryUpdated, .repositoryUpdated):
             return true
 
-        case let (.fetchInitialMessagesSuccess(lMsgArr), .fetchInitialMessagesSuccess(rMsgArr)):
+        case let (.fetchInitialMessagesSuccess(lMsgArr), .fetchInitialMessagesSuccess(rMsgArr)),
+            let (.fetchPreviousMessagesSuccess(lMsgArr), .fetchPreviousMessagesSuccess(rMsgArr)):
             return lMsgArr == rMsgArr
 
         case let (.chatMessageReceived(lMsg), .chatMessageReceived(rMsg)),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
@@ -18,6 +18,8 @@ protocol ChatActionHandling {
     @discardableResult
     func getInitialMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never>
     @discardableResult
+    func getPreviousMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+    @discardableResult
     func sendMessage(internalId: String,
                      content: String,
                      state: AppState,
@@ -75,6 +77,22 @@ class ChatActionHandler: ChatActionHandling {
             } catch {
                 // dispatch error *not handled*
                 dispatch(.repositoryAction(.fetchInitialMessagesFailed(error: error)))
+            }
+        }
+    }
+
+    func getPreviousMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            do {
+                let previousMessages = try await chatService.getPreviousMessages()
+                print("!isEmpty previousMessage \(!previousMessages.isEmpty)")
+                if !previousMessages.isEmpty {
+                    print("isEmpty if statement being called")
+                    dispatch(.repositoryAction(.fetchPreviousMessagesSuccess(messages: previousMessages)))
+                }
+            } catch {
+                // dispatch error *not handled*
+                dispatch(.repositoryAction(.fetchPreviousMessagesFailed(error: error)))
             }
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatActionHandler.swift
@@ -85,9 +85,7 @@ class ChatActionHandler: ChatActionHandling {
         Task {
             do {
                 let previousMessages = try await chatService.getPreviousMessages()
-                print("!isEmpty previousMessage \(!previousMessages.isEmpty)")
                 if !previousMessages.isEmpty {
-                    print("isEmpty if statement being called")
                     dispatch(.repositoryAction(.fetchPreviousMessagesSuccess(messages: previousMessages)))
                 }
             } catch {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/ChatMiddleware.swift
@@ -75,6 +75,9 @@ private func handleRepositoryAction(_ action: RepositoryAction,
     case .fetchInitialMessagesTriggered:
         actionHandler.getInitialMessages(state: getState(),
                                          dispatch: dispatch)
+    case .fetchPreviousMessagesTriggered:
+        actionHandler.getPreviousMessages(state: getState(),
+                                          dispatch: dispatch)
     case .sendMessageTriggered(let internalId, let content):
         actionHandler.sendMessage(internalId: internalId,
                                   content: content,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
@@ -56,6 +56,10 @@ private func handleRepositoryAction(
             actionHandler.loadInitialMessages(messages: messages,
                                               state: getState(),
                                               dispatch: dispatch)
+        case .fetchPreviousMessagesSuccess(let messages):
+            actionHandler.addPreviousMessages(messages: messages,
+                                              state: getState(),
+                                              dispatch: dispatch)
         case .sendMessageTriggered(let internalId, let content):
             actionHandler.addNewSentMessage(internalId: internalId,
                                             content: content,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -13,6 +13,11 @@ protocol RepositoryMiddlewareHandling {
         state: AppState,
         dispatch: @escaping ActionDispatch) -> Task<Void, Never>
     @discardableResult
+    func addPreviousMessages(
+        messages: [ChatMessageInfoModel],
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+    @discardableResult
     func addNewSentMessage(
         internalId: String,
         content: String,
@@ -45,10 +50,21 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
         messages: [ChatMessageInfoModel],
         state: AppState,
         dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
-        Task {
-            messageRepository.addInitialMessages(initialMessages: messages)
+            Task {
+                messageRepository.addInitialMessages(initialMessages: messages)
+                dispatch(.repositoryAction(.repositoryUpdated))
+            }
         }
-    }
+
+    func addPreviousMessages(
+        messages: [ChatMessageInfoModel],
+        state: AppState,
+        dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+            Task {
+                messageRepository.addPreviousMessages(previousMessages: messages)
+                dispatch(.repositoryAction(.repositoryUpdated))
+            }
+        }
 
     func addNewSentMessage(
         internalId: String,
@@ -88,6 +104,7 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
         dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             messageRepository.addReceivedMessage(message: message)
+            dispatch(.repositoryAction(.repositoryUpdated))
         }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/RepositoryReducer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Reducer/RepositoryReducer.swift
@@ -12,7 +12,7 @@ extension Reducer where State == RepositoryState,
 
         switch action {
         case .repositoryAction(.repositoryUpdated):
-            print("RepositoryAction `repositoryUpdated` not implemented")
+            lastUpdated = Date()
         case .repositoryAction(.fetchInitialMessagesSuccess),
                 .repositoryAction(.sendMessageTriggered),
                 .repositoryAction(.sendMessageSuccess),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapper.swift
@@ -73,7 +73,6 @@ class ChatSDKWrapper: NSObject, ChatSDKWrapperProtocol {
     func getPreviousMessages() async throws -> [ChatMessageInfoModel] {
         do {
             guard let messagePagedCollection = self.pagedCollection else {
-                print("!!! pagedCollection is nil *Message")
                 return try await self.getInitialMessages()
             }
             return try await withCheckedThrowingContinuation { continuation in
@@ -83,9 +82,6 @@ class ChatSDKWrapper: NSObject, ChatSDKWrapperProtocol {
                         let previousMessages = messagesResult.map({
                             $0.toChatMessageInfoModel()
                         })
-                        for m in previousMessages {
-                            print("###*Messages Previous: \(m.id) \(m.createdOn.value) \(m.content)")
-                        }
                         continuation.resume(returning: previousMessages)
                     case .failure(let error):
                         self.logger.error("Failed to get previous messages")

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatSDKWrapperProtocol.swift
@@ -9,6 +9,7 @@ import Combine
 protocol ChatSDKWrapperProtocol {
     func initializeChat() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
+    func getPreviousMessages() async throws -> [ChatMessageInfoModel]
     func sendMessage(content: String, senderDisplayName: String) async throws -> String
 
     var chatEventsHandler: ChatSDKEventsHandling { get }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/ChatService.swift
@@ -9,6 +9,7 @@ import Foundation
 protocol ChatServiceProtocol {
     func initalize() async throws
     func getInitialMessages() async throws -> [ChatMessageInfoModel]
+    func getPreviousMessages() async throws -> [ChatMessageInfoModel]
     func sendMessage(content: String, senderDisplayName: String) async throws -> String
 
     var chatEventSubject: PassthroughSubject<ChatEventModel, Never> { get }
@@ -34,6 +35,10 @@ class ChatService: NSObject, ChatServiceProtocol {
 
     func getInitialMessages() async throws -> [ChatMessageInfoModel] {
         return try await chatSDKWrapper.getInitialMessages()
+    }
+
+    func getPreviousMessages() async throws -> [ChatMessageInfoModel] {
+        return try await chatSDKWrapper.getPreviousMessages()
     }
 
     func sendMessage(content: String, senderDisplayName: String) async throws -> String {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Manager/MessageRepositoryManagerTests.swift
@@ -37,6 +37,58 @@ class MessageRepositoryManagerTests: XCTestCase {
         XCTAssertEqual(sut.messages.count, initialMessages.count)
     }
 
+    func test_messageRepositoryManager_addPreviousMessages_with_nonEmptyPreviousMessages_then_messagesCountWillBeMatching() {
+        let initialMessages = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        let sut = makeSUT(messages: initialMessages)
+
+        let previousMessages1 = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        let previousMessages2 = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        sut.addPreviousMessages(previousMessages: previousMessages1)
+        XCTAssertEqual(sut.messages.count,
+                       initialMessages.count +
+                       previousMessages1.count)
+        sut.addPreviousMessages(previousMessages: previousMessages2)
+        XCTAssertEqual( sut.messages.count,
+                        initialMessages.count +
+                        previousMessages1.count +
+                        previousMessages2.count)
+    }
+
+    func test_messageRepositoryManager_addPreviousMessages_with_previousMessagesContainExistingMessage_then_messagesCountWillBeIgnoreExistingMessages() {
+        let initialMessages = [
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel(),
+            ChatMessageInfoModel()
+        ]
+        let messageId1 = initialMessages[0].id
+        let messageId2 = initialMessages[1].id
+        let duplicateCount = 2
+        let sut = makeSUT(messages: initialMessages)
+
+        let previousMessages1 = [
+            ChatMessageInfoModel(id: messageId1),
+            ChatMessageInfoModel(id: messageId2),
+            ChatMessageInfoModel()
+        ]
+
+        sut.addPreviousMessages(previousMessages: previousMessages1)
+        XCTAssertEqual(sut.messages.count,
+                       initialMessages.count +
+                       previousMessages1.count -
+                       duplicateCount)
+    }
+
     func test_messageRepositoryManager_addNewSentMessage_when_nonEmptyInitialMessages_then_messagesCountWillBeIncrementByOne() {
         let initialMessages = [
             ChatMessageInfoModel(),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatSDKWrapperMocking.swift
@@ -17,6 +17,7 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
 
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
+    var getPreviousMessagesCalled: Bool = false
     var sendMessageCalled: Bool = false
 
     func initializeChat() async throws {
@@ -26,6 +27,13 @@ class ChatSDKWrapperMocking: ChatSDKWrapperProtocol {
 
     func getInitialMessages() async throws -> [ChatMessageInfoModel] {
         getInitialMessagesCalled = true
+        return try await Task<[ChatMessageInfoModel], Error> {
+            []
+        }.value
+    }
+
+    func getPreviousMessages() async throws -> [ChatMessageInfoModel] {
+        getPreviousMessagesCalled = true
         return try await Task<[ChatMessageInfoModel], Error> {
             []
         }.value

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
@@ -42,7 +42,6 @@ class ChatServiceMocking: ChatServiceProtocol {
             if let error = self.error {
                 throw error
             }
-            print("----previousMessages count: \(previousMessages.count)")
             return previousMessages
         }
         return try await task.value

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/ChatServiceMocking.swift
@@ -13,9 +13,11 @@ class ChatServiceMocking: ChatServiceProtocol {
 
     var topic: String = "topic"
     var initialMessages: [ChatMessageInfoModel] = []
+    var previousMessages: [ChatMessageInfoModel] = []
 
     var initializeCalled: Bool = false
     var getInitialMessagesCalled: Bool = false
+    var getPreviousMessagesCalled: Bool = false
     var sendMessageCalled: Bool = false
 
     func initalize() async throws {
@@ -30,6 +32,18 @@ class ChatServiceMocking: ChatServiceProtocol {
                 throw error
             }
             return initialMessages
+        }
+        return try await task.value
+    }
+
+    func getPreviousMessages() async throws -> [ChatMessageInfoModel] {
+        getPreviousMessagesCalled = true
+        let task = Task<[ChatMessageInfoModel], Error> {
+            if let error = self.error {
+                throw error
+            }
+            print("----previousMessages count: \(previousMessages.count)")
+            return previousMessages
         }
         return try await task.value
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/MessageRepositoryManagerMocking.swift
@@ -10,6 +10,7 @@ class MessageRepositoryManagerMocking: MessageRepositoryManagerProtocol {
     var messages: [ChatMessageInfoModel] = []
 
     var addInitialMessagesCalled: Bool = false
+    var addPreviousMessagesCalled: Bool = false
     var addNewSentMessageCalled: Bool = false
     var replaceMessageIdCalled: Bool = false
     var addReceivedMessageCalled: Bool = false
@@ -17,6 +18,11 @@ class MessageRepositoryManagerMocking: MessageRepositoryManagerProtocol {
     func addInitialMessages(initialMessages: [ChatMessageInfoModel]) {
         addInitialMessagesCalled = true
         messages = initialMessages
+    }
+
+    func addPreviousMessages(previousMessages: [ChatMessageInfoModel]) {
+        addPreviousMessagesCalled = true
+        messages = previousMessages + messages
     }
 
     func addNewSendingMessage(message: ChatMessageInfoModel) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/ChatActionHandlerMocking.swift
@@ -11,6 +11,7 @@ class ChatActionHandlerMocking: ChatActionHandling {
     var enterForegroundCalled: ((Bool) -> Void)?
     var initializeCalled: ((Bool) -> Void)?
     var getInitialMessagesCalled: ((Bool) -> Void)?
+    var getPreviousMessagesCalled: ((Bool) -> Void)?
     var sendMessageCalled: ((Bool) -> Void)?
 
     func enterBackground(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
@@ -34,6 +35,12 @@ class ChatActionHandlerMocking: ChatActionHandling {
     func getInitialMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             getInitialMessagesCalled?(true)
+        }
+    }
+
+    func getPreviousMessages(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            getPreviousMessagesCalled?(true)
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/RepositoryHandlerMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Mocking/Redux/RepositoryHandlerMocking.swift
@@ -8,6 +8,7 @@ import Foundation
 
 class RepositoryHandlerMocking: RepositoryMiddlewareHandling {
     var loadInitialMessagesCalled: ((Bool) -> Void)?
+    var addPreviousMessagesCalled: ((Bool) -> Void)?
     var addNewSentMessageCalled: ((Bool) -> Void)?
     var updateSentMessageIdCalled: ((Bool) -> Void)?
     var addReceivedMessageCalled: ((Bool) -> Void)?
@@ -15,6 +16,12 @@ class RepositoryHandlerMocking: RepositoryMiddlewareHandling {
     func loadInitialMessages(messages: [ChatMessageInfoModel], state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
             loadInitialMessagesCalled?(true)
+        }
+    }
+
+    func addPreviousMessages(messages: [ChatMessageInfoModel], state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            addPreviousMessagesCalled?(true)
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatActionHandlerTests.swift
@@ -48,6 +48,35 @@ class ChatActionHandlerTests: XCTestCase {
         XCTAssertTrue(mockChatService.getInitialMessagesCalled)
     }
 
+    func test_chatActionHandler_getPreviousMessages_when_nonEmptyPreviousMessages_then_getPreviousMessagesCalled() async {
+        let expectation = XCTestExpectation(description: "Dispatch the new action")
+        let previousMessages = [ChatMessageInfoModel()]
+        func dispatch(action: Action) { XCTAssertTrue(mockChatService.getPreviousMessagesCalled)
+            XCTAssertTrue(action == Action.repositoryAction(.fetchPreviousMessagesSuccess(messages: previousMessages)))
+            expectation.fulfill()
+        }
+        let sut = makeSUT(previousMessages: previousMessages)
+        await sut.getPreviousMessages(
+            state: getEmptyState(),
+            dispatch: dispatch).value
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_chatActionHandler_getPreviousMessages_when_emptyPreviousMessages_then_getPreviousMessagesCalled() async {
+        let expectation = XCTestExpectation(description: "Not dispatch the new action")
+        expectation.isInverted = true
+        func dispatch(action: Action) {
+            XCTFail("Should not call this")
+        }
+        let sut = makeSUT(previousMessages: [])
+        await sut.getPreviousMessages(
+            state: getEmptyState(),
+            dispatch: dispatch).value
+        XCTAssertTrue(mockChatService.getPreviousMessagesCalled)
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_chatActionHandler_sendMessage_then_getInitialMessagesCalled() async {
         let sut = makeSUT()
         await sut.sendMessage(
@@ -62,7 +91,15 @@ class ChatActionHandlerTests: XCTestCase {
 
 extension ChatActionHandlerTests {
 
-    func makeSUT() -> ChatActionHandler {
+    func makeSUT(initialMessages: [ChatMessageInfoModel]? = nil,
+                 previousMessages: [ChatMessageInfoModel]? = nil) -> ChatActionHandler {
+        if let initialMsg = initialMessages {
+            mockChatService.initialMessages = initialMsg
+        }
+        if let previousMsg = previousMessages {
+            mockChatService.previousMessages = previousMsg
+        }
+
         return ChatActionHandler(
             chatService: mockChatService,
             logger: mockLogger)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/ChatMiddlewareTests.swift
@@ -57,6 +57,19 @@ class ChatMiddlewareTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_chatMiddleware_apply_when_sendMessageTriggeredRepositoryAction_then_handlerGetPreviousMessagesBeingCalled() {
+
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "getPreviousMessagesWasCalled")
+        mockChatActionHandler.getPreviousMessagesCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+
+        middlewareDispatch(getEmptyDispatch())(.repositoryAction(.fetchPreviousMessagesTriggered))
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_chatMiddleware_apply_when_sendMessageTriggeredRepositoryAction_then_handlerSendMessageCalledBeingCalled() {
 
         let middlewareDispatch = getEmptyChatMiddlewareFunction()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareHandlerTests.swift
@@ -39,6 +39,14 @@ class RepositoryMiddlewareHandlerTests: XCTestCase {
         XCTAssertTrue(mockMessageRepositoryManager.addInitialMessagesCalled)
     }
 
+    func test_repositoryMiddlewareHandler_addPreviousMessages_then_addPreviousMessagesCalled() async {
+        await repositoryMiddlewareHandler.addPreviousMessages(
+            messages: [ChatMessageInfoModel()],
+            state: getEmptyState(),
+            dispatch: getEmptyDispatch()).value
+        XCTAssertTrue(mockMessageRepositoryManager.addPreviousMessagesCalled)
+    }
+
     func test_repositoryMiddlewareHandler_addNewSentMessage_then_addNewSentMessageCalled() async {
         await repositoryMiddlewareHandler.addNewSentMessage(
             internalId: "internalId",

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Middleware/RepositoryMiddlewareTests.swift
@@ -41,6 +41,20 @@ class RepositoryMiddlewareTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_repositoryMiddleware_apply_when_fetchPreviousMessagesSuccessRepositoryAction_then_handlerAddPreviousCalledMessagesCalled() {
+
+        let middlewareDispatch = getEmptyChatMiddlewareFunction()
+        let expectation = expectation(description: "loadInitialMessagesCalled")
+        mockRepositoryHandler.addPreviousMessagesCalled = { value in
+            XCTAssertTrue(value)
+            expectation.fulfill()
+        }
+
+        let messages: [ChatMessageInfoModel] = []
+        middlewareDispatch(getEmptyDispatch())(.repositoryAction(.fetchPreviousMessagesSuccess(messages: messages)))
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_repositoryMiddleware_apply_when_sendMessageTriggeredRepositoryAction_then_handlerLoadInitialMessagesCalledBeingCalled() {
 
         let middlewareDispatch = getEmptyChatMiddlewareFunction()

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Reducer/RepositoryReducerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Redux/Reducer/RepositoryReducerTests.swift
@@ -9,6 +9,16 @@ import XCTest
 
 class RepositoryReducerTests: XCTestCase {
 
+    func test_repositoryReducer_reduce_when_repositoryUpdatedAction_then_stateUpdated() {
+        let initialTimestamp = Date()
+        let state = RepositoryState(lastUpdatedTimestamp: initialTimestamp)
+        let action = Action.repositoryAction(.repositoryUpdated)
+        let sut = getSUT()
+        let resultState = sut.reduce(state, action)
+
+        XCTAssertTrue(resultState.lastUpdatedTimestamp > initialTimestamp)
+    }
+
     func test_repositoryReducer_reduce_when_fetchInitialMessagesSuccessAction_then_stateUpdated() {
         let initialTimestamp = Date()
         let state = RepositoryState(lastUpdatedTimestamp: initialTimestamp)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Tests/Service/ChatServiceTests.swift
@@ -44,6 +44,12 @@ class ChatServiceTests: XCTestCase {
         XCTAssertTrue(chatSDKWrapper.getInitialMessagesCalled)
     }
 
+    func test_chatService_getPreviousMessages_shouldCallchatSDKWrapperGetPreviousMessages() async throws {
+        _ = try await chatService.getPreviousMessages()
+
+        XCTAssertTrue(chatSDKWrapper.getPreviousMessagesCalled)
+    }
+
     func test_chatService_sendMessage_shouldCallchatSDKWrappersendMessage() async throws {
         _ = try await chatService.sendMessage(content: "content", senderDisplayName: "displayName")
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Implement chat message history pagination for service and redux layer
* Because UI is not implemented, so added a chat command to fetch previous message and see result in console if the text equals to `fetch` and send using the UI
* Note currently the behaviour maxPagesize is `5` for testing, when page backward will also include recent sent/received message since previous pageNext (should not be an issue when have page size of 50 or 200). Recent/duplicate message will be filtered/ignored by message repository

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->