### PR TITLE
[Bugfix] Work around for failure to grab ownership of microphone on first try.

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
@@ -108,6 +108,9 @@ class AudioSessionManager: AudioSessionManagerProtocol {
                                                            .allowBluetoothA2DP]
             try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: options)
             try audioSession.setActive(true)
+            // Work around for failure to grab ownership of microphone on first try.
+            // Reproduced on phone 11/13/14. iOS 14, 15, 16
+            try audioSession.setActive(true)
         } catch let error {
             logger.error("Failed to set audio session category:\(error.localizedDescription)")
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
@@ -110,6 +110,7 @@ class AudioSessionManager: AudioSessionManagerProtocol {
             try audioSession.setActive(true)
             // Work around for failure to grab ownership of microphone on first try.
             // Reproduced on phone 11/13/14. iOS 14, 15, 16
+            try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: options)
             try audioSession.setActive(true)
         } catch let error {
             logger.error("Failed to set audio session category:\(error.localizedDescription)")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Work around for failure to grab ownership of microphone on the first try.

Open ACS UI Lib Demo and join a group call, end the call successfully
Open a music/podcast/audio app and play something
Stop playing the audio
Open the composite again
Join call
The microphone will not work despite being unmuted

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->