### PR TITLE
[Feature] Foreground/Background Action Handling

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/DI/DependencyContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/DI/DependencyContainer.swift
@@ -66,7 +66,8 @@ final class DependencyContainer {
         register(ErrorManager(store: resolve(),
                               chatCompositeEventsHandler: chatCompositeEventsHandler) as ErrorManagerProtocol)
         register(UIKitAppLifeCycleManager(store: resolve(),
-                                          logger: resolve()) as LifeCycleManagerProtocol)
+                                          logger: resolve(),
+                                          viewModelFactory: resolve()) as LifeCycleManagerProtocol)
 
         register(CompositeManager(store: resolve(),
                                   logger: resolve()) as CompositeManagerProtocol)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewFactory.swift
@@ -7,7 +7,7 @@ import Foundation
 
 protocol CompositeViewFactoryProtocol {
     func makeChatView() -> ChatView
-    func enter(status: AppStatus)
+    func enter(_ status: AppStatus)
 }
 
 struct CompositeViewFactory: CompositeViewFactoryProtocol {
@@ -24,7 +24,7 @@ struct CompositeViewFactory: CompositeViewFactoryProtocol {
         return ChatView(viewModel: compositeViewModelFactory.getChatViewModel())
     }
 
-    func enter(status: AppStatus) {
-        compositeViewModelFactory.handleAppStatusChange(status)
+    func enter(_ newStatus: AppStatus) {
+        compositeViewModelFactory.handleAppStatusChange(newStatus)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewFactory.swift
@@ -7,6 +7,7 @@ import Foundation
 
 protocol CompositeViewFactoryProtocol {
     func makeChatView() -> ChatView
+    func enter(status: AppStatus)
 }
 
 struct CompositeViewFactory: CompositeViewFactoryProtocol {
@@ -21,5 +22,9 @@ struct CompositeViewFactory: CompositeViewFactoryProtocol {
 
     func makeChatView() -> ChatView {
         return ChatView(viewModel: compositeViewModelFactory.getChatViewModel())
+    }
+
+    func enter(status: AppStatus) {
+        compositeViewModelFactory.handleAppStatusChange(status)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -8,6 +8,7 @@ import FluentUI
 
 protocol CompositeViewModelFactoryProtocol {
     // MARK: CompositeViewModels
+    @discardableResult
     func getChatViewModel() -> ChatViewModel
 
     // MARK: ComponentViewModels
@@ -23,6 +24,8 @@ protocol CompositeViewModelFactoryProtocol {
                                   chatState: ChatState) -> MessageListViewModel
     func makeBottomBarViewModel(dispatch: @escaping ActionDispatch) -> BottomBarViewModel
     func makeTypingParticipantsViewModel() -> TypingParticipantsViewModel
+    func handleAppStatusChange(_ status: AppStatus)
+    func destroyChatViewModel()
 }
 
 class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
@@ -49,6 +52,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     }
 
     // MARK: CompositeViewModels
+    @discardableResult
     func getChatViewModel() -> ChatViewModel {
         guard let viewModel = self.chatViewModel else {
             let viewModel = ChatViewModel(compositeViewModelFactory: self,
@@ -97,5 +101,15 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     func makeTypingParticipantsViewModel() -> TypingParticipantsViewModel {
         TypingParticipantsViewModel(logger: logger,
                                     localizationProvider: localizationProvider)
+    }
+
+    // MARK: View Model Life Cycle Handling
+    func destroyChatViewModel() {
+        chatViewModel = nil
+    }
+
+    func handleAppStatusChange(_ status: AppStatus) {
+        store.dispatch(action: .lifecycleAction(status == .background ?
+            .backgroundEntered : .foregroundEntered))
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -52,7 +52,6 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     }
 
     // MARK: CompositeViewModels
-    @discardableResult
     func getChatViewModel() -> ChatViewModel {
         guard let viewModel = self.chatViewModel else {
             let viewModel = ChatViewModel(compositeViewModelFactory: self,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Container/ContainerView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Container/ContainerView.swift
@@ -21,8 +21,8 @@ struct ContainerView: View {
             }
         }
         .environment(\.layoutDirection, isRightToLeft ? .rightToLeft : .leftToRight)
-        .onAppear { viewFactory.enter(status: .foreground) }
-        .onDisappear { viewFactory.enter(status: .background) }
+        .onAppear { viewFactory.enter(.foreground) }
+        .onDisappear { viewFactory.enter(.background) }
     }
 
     var chatView: ChatView {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Container/ContainerView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Container/ContainerView.swift
@@ -21,6 +21,8 @@ struct ContainerView: View {
             }
         }
         .environment(\.layoutDirection, isRightToLeft ? .rightToLeft : .leftToRight)
+        .onAppear { viewFactory.enter(status: .foreground) }
+        .onDisappear { viewFactory.enter(status: .background) }
     }
 
     var chatView: ChatView {


### PR DESCRIPTION
## Purpose
PR on Android side: https://github.com/Azure/communication-ui-library-android/pull/486

basically the parity between both platform is to:
- use container view's lifecycle to decide foreground/background
- clean up view model when app goes to background

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
N/A
testing not available until headless mode is supported

## What to Check
N/A
no unit tests available because the trigger point is from view init/deinit.

## Other Information
N/A