### PR TITLE
[Task] handle local user removal in presentation layer, PR 2 of 3

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
@@ -12,6 +12,7 @@ enum MessageType: Equatable {
     case topicUpdated
     case participantsAdded
     case participantsRemoved
+    case localUserRemoved
 }
 
 struct ChatMessageInfoModel: BaseInfoModel, Identifiable, Equatable, Hashable {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -14,6 +14,7 @@ protocol MessageRepositoryManagerProtocol {
     func addPreviousMessages(previousMessages: [ChatMessageInfoModel])
     func addNewSendingMessage(message: ChatMessageInfoModel)
     func replaceMessageId(internalId: String, actualId: String)
+    func addLocalUserRemovedMessage()
 
     // MARK: participant events
     func addParticipantAdded(message: ChatMessageInfoModel)
@@ -88,6 +89,14 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
             type: .topicUpdated,
             content: topic,
             createdOn: chatThreadInfo.receivedOn
+        )
+        messages.append(topicUpdatedSystemMessage)
+    }
+
+    func addLocalUserRemovedMessage() {
+        let topicUpdatedSystemMessage = ChatMessageInfoModel(
+            type: .localUserRemoved,
+            createdOn: Iso8601Date()
         )
         messages.append(topicUpdatedSystemMessage)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -94,11 +94,11 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
     }
 
     func addLocalUserRemovedMessage() {
-        let topicUpdatedSystemMessage = ChatMessageInfoModel(
+        let localUserRemovedSystemMessage = ChatMessageInfoModel(
             type: .localUserRemoved,
             createdOn: Iso8601Date()
         )
-        messages.append(topicUpdatedSystemMessage)
+        messages.append(localUserRemovedSystemMessage)
     }
 
     func addReceivedMessage(message: ChatMessageInfoModel) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
@@ -19,8 +19,14 @@ struct BottomBarView: View {
 
     var body: some View {
         HStack {
-            messageTextField
-            sendButton
+            Group {
+                if viewModel.localParticipantStatus == .removed {
+                    localParticipantInfoBanner
+                } else {
+                    messageTextField
+                    sendButton
+                }
+            }
         }
         .frame(minHeight: Constants.minimumHeight)
         .padding(.leading, Constants.padding)
@@ -54,5 +60,9 @@ struct BottomBarView: View {
     var sendButton: some View {
         IconButton(viewModel: viewModel.sendButtonViewModel)
             .flipsForRightToLeftLayoutDirection(true)
+    }
+
+    var localParticipantInfoBanner: some View {
+        Text("You're no longer a participant")
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
@@ -64,5 +64,6 @@ struct BottomBarView: View {
 
     var localParticipantInfoBanner: some View {
         Text("You're no longer a participant")
+            .foregroundColor(Color(StyleProvider.color.textSecondary))
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarViewModel.swift
@@ -15,6 +15,8 @@ class BottomBarViewModel: ObservableObject {
     private var lastTypingIndicatorSendTimestamp = Date()
     private let typingIndicatorDelay: TimeInterval = 8.0
 
+    @Published var localParticipantStatus: LocalParticipantStatus = .joined
+
     @Published var message: String = ""
     @Published var hasFocus: Bool = false
 
@@ -53,5 +55,9 @@ class BottomBarViewModel: ObservableObject {
             dispatch(.chatAction(.sendTypingIndicatorTriggered))
             lastTypingIndicatorSendTimestamp = Date()
         }
+    }
+
+    func update(participantsState: ParticipantsState) {
+        localParticipantStatus = participantsState.localParticipantStatus
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/Message/SystemMessageViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/Message/SystemMessageViewModel.swift
@@ -13,7 +13,9 @@ class SystemMessageViewModel: MessageViewModel {
         case .participantsRemoved:
             return "\(participants) left the chat" // Localization
         case .topicUpdated:
-            return "Topic updated \(message.content ?? "")" // Localization 
+            return "Topic updated \(message.content ?? "")" // Localization
+        case .localUserRemoved:
+            return "You were removed from the chat" // todo: Localization
         default:
             return "System Message"
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
@@ -178,7 +178,7 @@ class MessageListViewModel: ObservableObject {
                                         showTime: showTime,
                                         isLocalUser: isLocalUser,
                                         isConsecutive: isConsecutive)
-        case .participantsAdded, .participantsRemoved, .topicUpdated:
+        case .participantsAdded, .participantsRemoved, .topicUpdated, .localUserRemoved:
             return SystemMessageViewModel(message: message,
                                           showDateHeader: showDateHeader,
                                           isConsecutive: false)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewModel.swift
@@ -48,5 +48,6 @@ class ChatViewModel: ObservableObject {
         messageListViewModel.update(chatState: state.chatState, repositoryState: state.repositoryState)
         typingParticipantsViewModel.update(participantsState: state.participantsState)
         topBarViewModel.update(participantsState: state.participantsState)
+        bottomBarViewModel.update(participantsState: state.participantsState)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
@@ -15,6 +15,7 @@ enum ChatAction: Equatable {
     case realTimeNotificationDisconnected
     case chatThreadDeleted
     case chatTopicUpdated(threadInfo: ChatThreadInfoModel)
+    case chatLocalUserRemoved
 
     case sendTypingIndicatorTriggered
     case sendTypingIndicatorSuccess

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Action/ChatAction.swift
@@ -15,7 +15,7 @@ enum ChatAction: Equatable {
     case realTimeNotificationDisconnected
     case chatThreadDeleted
     case chatTopicUpdated(threadInfo: ChatThreadInfoModel)
-    case chatLocalUserRemoved
+    case chatMessageLocalUserRemoved
 
     case sendTypingIndicatorTriggered
     case sendTypingIndicatorSuccess

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
@@ -44,7 +44,9 @@ private func handleChatAction(
             actionHandler.addTopicUpdatedMessage(threadInfo: threadInfo,
                                                  state: getState(),
                                                  dispatch: dispatch)
-
+        case .chatLocalUserRemoved:
+            actionHandler.addLocalUserRemovedMessage(state: getState(),
+                                                     dispatch: dispatch)
         default:
             break
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddleware.swift
@@ -44,7 +44,7 @@ private func handleChatAction(
             actionHandler.addTopicUpdatedMessage(threadInfo: threadInfo,
                                                  state: getState(),
                                                  dispatch: dispatch)
-        case .chatLocalUserRemoved:
+        case .chatMessageLocalUserRemoved:
             actionHandler.addLocalUserRemovedMessage(state: getState(),
                                                      dispatch: dispatch)
         default:

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -44,6 +44,9 @@ protocol RepositoryMiddlewareHandling {
                                    localUser: ParticipantInfoModel,
                                    dispatch: @escaping ActionDispatch) -> Task<Void, Never>
     @discardableResult
+    func addLocalUserRemovedMessage(state: AppState,
+                                    dispatch: @escaping ActionDispatch) -> Task<Void, Never>
+    @discardableResult
     func addReceivedMessage(
         message: ChatMessageInfoModel,
         state: AppState,
@@ -130,7 +133,15 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
                 messageRepository.addTopicUpdatedMessage(chatThreadInfo: threadInfo)
                 dispatch(.repositoryAction(.repositoryUpdated))
             }
+    }
+
+    func addLocalUserRemovedMessage(state: AppState,
+                                    dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
+        Task {
+            messageRepository.addLocalUserRemovedMessage()
+            dispatch(.repositoryAction(.repositoryUpdated))
         }
+    }
 
     func participantAddedMessage(participants: [ParticipantInfoModel],
                                  dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
@@ -150,6 +161,7 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
         Task {
             if participants.contains(where: { $0.id == localUser.id }) {
                 dispatch(.participantsAction(.localParticipantRemoved))
+                dispatch(.chatAction(.chatLocalUserRemoved))
                 return
             }
             let message = ChatMessageInfoModel(

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Redux/Middleware/RepositoryMiddlewareHandler.swift
@@ -161,7 +161,7 @@ class RepositoryMiddlewareHandler: RepositoryMiddlewareHandling {
         Task {
             if participants.contains(where: { $0.id == localUser.id }) {
                 dispatch(.participantsAction(.localParticipantRemoved))
-                dispatch(.chatAction(.chatLocalUserRemoved))
+                dispatch(.chatAction(.chatMessageLocalUserRemoved))
                 return
             }
             let message = ChatMessageInfoModel(


### PR DESCRIPTION
## Purpose
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/109105353/201740374-e5db575c-d8a5-4f6a-91e7-4cd016e7eeb5.png">


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [X] View Data Injection
- [X] Demo App UI/UX update

## How to Test
since there's no way to remove a participant currently from neither web/mobile, you need to hard code the following in ```ChatServiceEventHandler``` to simulate an event from SDK:

```
        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: {
            let id = "YOU_LOCAL_PARTICIPANT_ID_HERE"
            let participants = [ParticipantInfoModel(identifier: CommunicationUserIdentifier(id),
                                                     displayName: "")]
            dispatch(.participantsAction(.participantsRemoved(participants: participants)))
        })
```

## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->

https://user-images.githubusercontent.com/109105353/201750680-7d5338b5-fe79-4398-a04a-e20c57fb2101.mov


