### PR TITLE
[Bugfix] Fix scroll to bottom

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListView.swift
@@ -56,7 +56,7 @@ struct MessageListView: View {
                         ForEach(Array(viewModel.messages.enumerated()), id: \.element) { index, message in
                             let messageViewModel = viewModel.createViewModel(index: index)
                             MessageView(viewModel: messageViewModel)
-                                .id(UUID())
+                                .id(message.id)
                                 .padding(getEdgeInsets(message: messageViewModel))
                                 .onAppear {
                                     if index == viewModel.minFetchIndex {
@@ -93,7 +93,11 @@ struct MessageListView: View {
 
     private func scrollToBottom(proxy: ScrollViewProxy) {
         let scrollIndex = viewModel.messages.count - 1
-        proxy.scrollTo(scrollIndex, anchor: .bottom)
+        guard scrollIndex >= 0 else {
+            return
+        }
+        let messageId = viewModel.messages[scrollIndex].id
+        proxy.scrollTo(messageId, anchor: .bottom)
     }
 
     private func getEdgeInsets(message: MessageViewModel) -> EdgeInsets {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Use message id as MessageView's id and scrollTo's id

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open a chat thread
* Send a message from another user
* Tap on New message button
* It should scroll to the bottom

## Other Information
<!-- Add any other helpful information that may be needed here. -->
N/A
