### PR TITLE
[Bug] Fix Thread Warnings

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/FluentUI/Wrapper/TypingParticipantAvatarGroupContainer.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/FluentUI/Wrapper/TypingParticipantAvatarGroupContainer.swift
@@ -16,6 +16,8 @@ struct TypingParticipantAvatarGroupContainer: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: TypingParticipantAvatarGroup, context: Context) {
-        avatarGroup.setAvatars(to: participantList)
+        Task { @MainActor in
+            avatarGroup.setAvatars(to: participantList)
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Previously the UI was updated in background thread causing Xcode to have those warnings:

solution is to update UI on main thread

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
1. join a call with multiple participant, ask each one to start typing
2. check Xcode to see if there's any warning 

## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | ![image](https://user-images.githubusercontent.com/109105353/204894683-0778e1ba-1905-4e05-822e-f87f2248fe16.png) |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
