### PR TITLE
[Bug] Fix Theming Override Not Working

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/DrawerContainerViewController.swift
@@ -113,6 +113,7 @@ class DrawerContainerViewController<T: Equatable>: UIViewController,
         controller.backgroundColor = backgroundColor
 
         self.controller = controller
+        controller.overrideUserInterfaceStyle = StyleProvider.color.colorSchemeOverride
         resizeDrawer()
         self.controller?.contentView?.semanticContentAttribute = self.isRightToLeft ?
                                                             .forceRightToLeft : .forceLeftToRight


### PR DESCRIPTION
## Purpose
This PR fixes the issue where theming override not working as expected. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [x] Color Theming
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
1. open the app
2. go to setting, set theming to light
3. set os to dark mode
4. join a call 

## What to Check
1. participant list, audio list, call id and end call.
2. make sure all of them have correct background colour

<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|

![image](https://user-images.githubusercontent.com/109105353/204919749-bae02839-6ec8-4485-824c-fd5e246ae10c.png)

## Other Information
<!-- Add any other helpful information that may be needed here. -->
