### PR TITLE
[BuildSystem] Enable code coverage / build quality check

### DIFF
--- a/eng/pipelines/jobs/CI-build-job.yml
+++ b/eng/pipelines/jobs/CI-build-job.yml
@@ -45,6 +45,6 @@ jobs:
         displayName: "Check build quality"
         inputs:
           checkCoverage: true
-          coverageThreshold: 50
+          coverageThreshold: 58
           coverageFailOption: fixed
           coverageType: lines

--- a/eng/pipelines/jobs/CI-build-job.yml
+++ b/eng/pipelines/jobs/CI-build-job.yml
@@ -43,8 +43,8 @@ jobs:
 
       - task: BuildQualityChecks@8
         displayName: "Check build quality"
-        enabled: false
         inputs:
           checkCoverage: true
+          coverageThreshold: 50
           coverageFailOption: fixed
           coverageType: lines


### PR DESCRIPTION
## Purpose
Re-enable the code coverage check, with 50% code coverage requirement.

We can increase this with more test coverage.