### PR TITLE
[BugFix] Ensure title and subtitle on setup screen can be overridden.

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
@@ -175,7 +175,8 @@ public class CallComposite {
                 networkManager: NetworkManager(),
                 localizationProvider: localizationProvider,
                 accessibilityProvider: accessibilityProvider,
-                debugInfoManager: debugInfoManager
+                debugInfoManager: debugInfoManager,
+                localOptions: localOptions
             )
         )
     }


### PR DESCRIPTION
## Purpose
During our bug bash, custom title and subtitle were not working. This PR fixes that.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
Run the demo app, set a custom title for the setup screen

## What to Check
Verify the screen title and subtitle are as expected