### PR TITLE
[Bugfix] Fix for background color of the share diagnostic info cell

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/MoreCallOptionsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/MoreCallOptionsListCell.swift
@@ -15,6 +15,10 @@ class MoreCallOptionsListCell: TableViewCell {
         let iconImageView = UIImageView(image: iconImage)
 
         selectionStyle = .none
+        backgroundStyleType = .custom
+        backgroundColor = UIDevice.current.userInterfaceIdiom == .pad
+            ? StyleProvider.color.popoverColor
+            : StyleProvider.color.drawerColor
         setup(title: viewModel.title,
               customView: iconImageView)
         bottomSeparatorType = .none


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix background color for Share diagnostic info cell in dark mode

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [x] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Join a call
* Open more menu
* Check that the background is consistent for light/dark mode on iPhone and iPad
