### PR TITLE
[Bug] Added Default Display Name

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/Extension/ChatParticipantExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Service/Chat/Extension/ChatParticipantExtension.swift
@@ -11,7 +11,7 @@ extension ChatParticipant {
     func toParticipantInfoModel(_ localParticipantId: String) -> ParticipantInfoModel {
         return ParticipantInfoModel(
             identifier: self.id,
-            displayName: self.displayName ?? "",
+            displayName: self.displayName ?? "Unknown user",
             isLocalParticipant: id.stringValue == localParticipantId,
             sharedHistoryTime: self.shareHistoryTime ?? Iso8601Date())
     }
@@ -21,7 +21,7 @@ extension SignalingChatParticipant {
     func toParticipantInfoModel(_ localParticipantId: String) -> ParticipantInfoModel {
         return ParticipantInfoModel(
             identifier: self.id!,
-            displayName: self.displayName ?? "",
+            displayName: self.displayName ?? "Unknown user",
             isLocalParticipant: id?.rawId == localParticipantId,
             sharedHistoryTime: self.shareHistoryTime ?? Iso8601Date())
     }


### PR DESCRIPTION
## Purpose
participant info model does not have a default display name. This would cause the typing indicator shown blank user typing in Teams interop cases.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test

1. start a teams call
2. deep link to chat
3. ask other participants to type in teams call


## What to Check
1. check if display is shown as "Unknown user"

<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![IMG_0132](https://user-images.githubusercontent.com/109105353/208198611-cbbb9475-9158-4da2-9ddb-2d1331a20629.PNG)  |  ![IMG_0131](https://user-images.githubusercontent.com/109105353/208198658-caa7cb52-fd56-4fec-b016-30833dc06853.PNG) |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
