### PR TITLE
[Bug] Scroll to Bottom When Keyboard Shows Up

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/ChatDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/ChatDemoView.swift
@@ -238,6 +238,8 @@ extension ChatDemoView {
         print("::::SwiftUIChatDemoView::showError \(error)")
         print("::::SwiftUIChatDemoView error.code \(error.code)")
         print("Error - \(error.code): \(error.error?.localizedDescription ?? error.localizedDescription)")
+        // cases are hard coded for now
+        // since ChatCompositeErrorCode is internal
         switch error.code {
         case "connectFailed":
             errorMessage = "Connection Failed"

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListView.swift
@@ -82,11 +82,15 @@ struct MessageListView: View {
             .environment(\.defaultMinListRowHeight, Constants.defaultMinListRowHeight)
             .onChange(of: viewModel.shouldScrollToBottom) { _ in
                 if viewModel.shouldScrollToBottom {
-                    let lastIndex = viewModel.messages.count - 1 > 0 ? viewModel.messages.count - 1 : 0
-                    scrollProxy.scrollTo(lastIndex, anchor: .bottom)
-                    viewModel.shouldScrollToBottom = false
+                    withAnimation(.linear(duration: 0.1)) {
+                        let lastIndex = viewModel.messages.count - 1 > 0 ? viewModel.messages.count - 1 : 0
+                        scrollProxy.scrollTo(lastIndex, anchor: .bottom)
+                        viewModel.shouldScrollToBottom = false
+                    }
                 }
             }
+        }.onReceive(keyboardWillShow) { _ in
+            viewModel.shouldScrollToBottom = true
         }
     }
 

--- a/AzureCommunicationUI/sdk/common/BaseComposite/Sources/Presentation/SwiftUI/Utilities/ViewExtension.swift
+++ b/AzureCommunicationUI/sdk/common/BaseComposite/Sources/Presentation/SwiftUI/Utilities/ViewExtension.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import Combine
 
 extension View {
     @ViewBuilder func hidden(_ shouldHide: Bool) -> some View {
@@ -31,5 +32,13 @@ extension View {
 
     func onRotate(perform action: @escaping (UIDeviceOrientation) -> Void) -> some View {
         self.modifier(DeviceRotationViewModifier(action: action))
+    }
+
+    var keyboardWillShow: AnyPublisher<Void, Never> {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification).map { _ in }
+        // 0.5 delay added to allow Bottom Bar View to finish updating its position
+        // so scroll view can move up by (keyboard height + Bottom Bar View height)
+        .debounce(for: .seconds(0.5), scheduler: RunLoop.main)
+        .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## Purpose

1. scroll message list to the button when keyboard shows up
2. added scrolling animation

https://user-images.githubusercontent.com/109105353/208504688-18097ae5-90ac-4588-a3e9-b2d5b7b167c9.mov

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
