### PR TITLE
[BuildSystem] [Bugfix] Always run nightly pipeline

### DIFF
--- a/eng/pipelines/nightly.yml
+++ b/eng/pipelines/nightly.yml
@@ -12,13 +12,15 @@ schedules:
       include:
         - develop
         - main
+    always: true
 
   - cron: "0 */2 * * *" # Check the AppCenter build schedule every 2 hours
     displayName: "AppCenter UI Test Run Trigger"
     branches:
       include:
         - develop
-
+    always: true
+    
 variables:
   AppCenterDevicesOverride: ''  # This should be in the form 'Azure-Communication-Services/<your_device_set_name>'
   buildHourOfDayUtc: $[format('{0:H}', pipeline.startTime)]


### PR DESCRIPTION
## Purpose
By default, scheduled triggers only run if there has been a code change. We want the trigger to fire always.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No


