### PR TITLE
[Bugfix] Chat View Margin Fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatView.swift
@@ -10,9 +10,6 @@ struct ChatView: View {
 
     var body: some View {
         VStack {
-//            TopBarView(viewModel: viewModel.topBarViewModel)
-            Divider()
-            Spacer()
             MessageListView(viewModel: viewModel.messageListViewModel)
             TypingParticipantsView(viewModel: viewModel.typingParticipantsViewModel)
             messageInput


### PR DESCRIPTION
## Purpose
removed the extra margin in chat view so the message won't appear to be cut off.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------| 
| ![image](https://user-images.githubusercontent.com/109105353/210636726-560f5b33-f3ea-4306-a560-9e261c24ede8.png) | ![image](https://user-images.githubusercontent.com/109105353/210636514-21d6505e-20c7-46c4-9b9b-3fdc059dddfb.png) |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
