### PR TITLE
[Bugfix] Chat duplicate system message

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Model/ChatMessageInfoModel.swift
@@ -12,6 +12,17 @@ enum MessageType: Equatable {
     case topicUpdated
     case participantsAdded
     case participantsRemoved
+
+    var isSystemMessage: Bool {
+        switch self {
+        case .topicUpdated,
+                .participantsAdded,
+                .participantsRemoved:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 enum MessageSendStatus: Equatable {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/Manager/MessageRepositoryManager.swift
@@ -35,6 +35,7 @@ protocol MessageRepositoryManagerProtocol {
 
 class MessageRepositoryManager: MessageRepositoryManagerProtocol {
     var messages: [ChatMessageInfoModel] = []
+    var initialFetchTimestamp = Iso8601Date()
 
     private let eventsHandler: ChatAdapter.Events
 
@@ -53,6 +54,7 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
         if let index = messages.lastIndex(where: {$0.isLocalUser}) {
             messages[index].update(sendStatus: .seen)
         }
+        initialFetchTimestamp = Iso8601Date()
     }
 
     func addPreviousMessages(previousMessages: [ChatMessageInfoModel]) {
@@ -62,7 +64,11 @@ class MessageRepositoryManager: MessageRepositoryManagerProtocol {
                 $0.id == m.id
             }) {
                 messages[index] = m
-            } else {
+            } else if m.createdOn < initialFetchTimestamp {
+                // Add all previous message
+                messages.append(m)
+            } else if !m.type.isSystemMessage {
+                // Workaround: for system message, use trouter msg, drop new fetched message after initialFetchTimestamp
                 messages.append(m)
             }
         }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix duplicate system message
  * Root cause: receiving trouter event for system message will not contain messageId (we generate random messageId), and not able to find the system message by matching messageId
  * Workaround: Ignore system message in the fetched previous message list if it happens after initial message fetch timestamp
    * Regular message will always be added/replaced
    * System message after initial fetch will depend on Trouter event messages

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
