### PR TITLE
[Bugfix] Fix crash on dispatch function of sendReadReceipt

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
@@ -121,8 +121,6 @@ class MessageListViewModel: ObservableObject {
         }
     }
 
-
-
     func update(chatState: ChatState, repositoryState: RepositoryState) {
         // Update messages
         if self.repositoryUpdatedTimestamp < repositoryState.lastUpdatedTimestamp {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/MessageListViewModel.swift
@@ -110,19 +110,18 @@ class MessageListViewModel: ObservableObject {
         didEndScrollingTimer = Timer.scheduledTimer(
             withTimeInterval: scrollEndsTolerance,
             repeats: false) { [weak self]_ in
-            self?.sendReadReceipt(messageId: self?.readReceiptToBeSentMessageId)
+                guard let messageId = self?.readReceiptToBeSentMessageId,
+                    let toBeSentReadReceiptTimestamp = messageId.convertEpochStringToTimestamp(),
+                    let lastSentReadReceiptTimestamp = self?.lastSentReadReceiptTimestamp,
+                    toBeSentReadReceiptTimestamp > lastSentReadReceiptTimestamp else {
+                    return
+                }
+                self?.dispatch(.participantsAction(.sendReadReceiptTriggered(messageId: messageId)))
+                self?.lastSentReadReceiptTimestamp = toBeSentReadReceiptTimestamp
         }
     }
 
-    func sendReadReceipt(messageId: String?) {
-        guard let messageId = messageId,
-            let toBeSentReadReceiptTimestamp = messageId.convertEpochStringToTimestamp(),
-            toBeSentReadReceiptTimestamp > lastSentReadReceiptTimestamp else {
-            return
-        }
-        dispatch(.participantsAction(.sendReadReceiptTriggered(messageId: messageId)))
-        lastSentReadReceiptTimestamp = toBeSentReadReceiptTimestamp
-    }
+
 
     func update(chatState: ChatState, repositoryState: RepositoryState) {
         // Update messages


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* According to the crash log:
  partial apply forwarder for generic specialization <AzureCommunicationUIChat.AppState> of closure 1 (AzureCommunicationUIChat.Action) -> () in closure 2 ((AzureCommunicationUIChat.Action) -> (), AzureCommunicationUIChat.Middleware<A>) -> (AzureCommunicationUIChat.Action) -> () in AzureCommunicationUIChat.Store.init(reducer: AzureCommunicationUIChat.Reducer<A, AzureCommunicationUIChat.Action>, middlewares: [AzureCommunicationUIChat.Middleware<A>], state: A) -> AzureCommunicationUIChat.Store<A> Store.swift:27
AzureCommunicationUIChat
$s24AzureCommunicationUIChat17ChatActionHandlerC017sendReadReceiptToD7Service...messageId8dispatch..._ ChatActionHandler.swift:157
* It seems to indicate there's some retain cycle related to the above function
* Marked variables with weak self might fix this.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update


## Other Information
<!-- Add any other helpful information that may be needed here. -->
