### PR TITLE
[HotFix] Make ThemeOptions internal access only

### DIFF
--- a/AzureCommunicationUI/sdk/common/Core/Sources/CompositeOptions/ThemeOptions.swift
+++ b/AzureCommunicationUI/sdk/common/Core/Sources/CompositeOptions/ThemeOptions.swift
@@ -14,7 +14,7 @@ import FluentUI
 /// Join Call Button - Border - Normal - Light/Dark Mode - Tint10
 /// Join Call Button - Border - Highlighted - Light/Dark Mode - Tint30
 ///
-public protocol ThemeOptions {
+protocol ThemeOptions {
     /// Provide a getter to force color scheme to be light or dark.
     var colorSchemeOverride: UIUserInterfaceStyle { get }
 
@@ -31,7 +31,7 @@ public protocol ThemeOptions {
     var primaryColorTint30: UIColor { get }
 }
 
-public extension ThemeOptions {
+extension ThemeOptions {
     var colorSchemeOverride: UIUserInterfaceStyle {
         return .unspecified
     }


### PR DESCRIPTION
## Purpose
The ThemeOptions class from calling was copied into Chat and retained public accessibility.  This is not needed at the current time.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist
