### PR TITLE
[Bugfix] Fix padding on typing participants

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatView.swift
@@ -6,12 +6,19 @@
 import SwiftUI
 
 struct ChatView: View {
+    private enum Constants {
+        static let messageListBottomPadding: CGFloat = 12
+        static let typingParticipantsBottomPadding: CGFloat = 12
+    }
+
     @StateObject var viewModel: ChatViewModel
 
     var body: some View {
         VStack(spacing: 0) {
             MessageListView(viewModel: viewModel.messageListViewModel)
+                .padding(.bottom, Constants.messageListBottomPadding )
             TypingParticipantsView(viewModel: viewModel.typingParticipantsViewModel)
+                .padding(.bottom, Constants.typingParticipantsBottomPadding)
             BottomBarView(viewModel: viewModel.bottomBarViewModel)
         }
         .onAppear {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/BottomBarView.swift
@@ -9,7 +9,6 @@ struct BottomBarView: View {
     private enum Constants {
         static let minimumHeight: CGFloat = 50
         static let focusDelay: CGFloat = 1.0
-        static let topPadding: CGFloat = 10
         static let padding: CGFloat = 12
     }
     @StateObject var viewModel: BottomBarViewModel
@@ -25,8 +24,7 @@ struct BottomBarView: View {
                 sendButton
             }
         }
-        .padding([.top], Constants.topPadding)
-        .padding([.leading, .trailing, .bottom], Constants.padding)
+        .padding([.leading, .trailing], Constants.padding)
     }
 
     var messageTextField: some View {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/TypingParticipantsView.swift
@@ -10,7 +10,7 @@ struct TypingParticipantsView: View {
     @StateObject var viewModel: TypingParticipantsViewModel
 
     private enum Constants {
-        static let padding: CGFloat = 37.0
+        static let leadingPadding: CGFloat = 37.0
         static let sectionHeight: CGFloat = 10.0
         static let avatarWidth: CGFloat = 16.0
         static let maxAvatarShown: Int = 3
@@ -37,7 +37,7 @@ struct TypingParticipantsView: View {
                 // give an explicit frame to constraint avatargroup layout
                 .frame(width: UIScreen.main.bounds.size.width,
                        height: Constants.sectionHeight)
-                .padding(.leading, Constants.padding)
+                .padding([.leading], Constants.leadingPadding)
             }
         }
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Resolves top and bottom padding for the typing indicator. We considered this a blocking issue, as it was overlapping the message input box.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
