### PR TITLE
[BugFix] Update to fluent 0.10.0

### DIFF
--- a/AzureCommunicationUI/Podfile
+++ b/AzureCommunicationUI/Podfile
@@ -10,12 +10,12 @@ target 'AzureCommunicationUICalling' do
   project 'sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj'
   use_frameworks!
   pod 'AzureCommunicationCalling', '2.2.1'
-  pod 'MicrosoftFluentUI/Avatar_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/Button_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.8.9'
+  pod 'MicrosoftFluentUI/Avatar_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/Button_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.10.0'
   pod 'SwiftLint', '0.42.0'
 
   target 'AzureCommunicationUICallingTests' do
@@ -28,12 +28,12 @@ target 'AzureCommunicationUIChat' do
   project 'sdk/AzureCommunicationUIChat/AzureCommunicationUIChat.xcodeproj'
   use_frameworks!
   pod 'AzureCommunicationChat', '1.3.0'
-  pod 'MicrosoftFluentUI/Avatar_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/Button_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.8.9'
+  pod 'MicrosoftFluentUI/Avatar_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/Button_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.10.0'
   pod 'SwiftLint', '0.42.0'
 
   target 'AzureCommunicationUIChatTests' do
@@ -47,12 +47,12 @@ target 'AzureCommunicationUIDemoApp' do
   use_frameworks!
   pod 'AzureCommunicationCalling', '2.2.1'
   pod 'AzureCommunicationChat', '1.3.0'
-  pod 'MicrosoftFluentUI/Avatar_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/Button_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.8.9'
-  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.8.9'
+  pod 'MicrosoftFluentUI/Avatar_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/BottomSheet_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/Button_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/PopupMenu_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/ActivityIndicator_ios', '0.10.0'
+  pod 'MicrosoftFluentUI/AvatarGroup_ios', '0.10.0'
   pod 'SwiftLint', '0.42.0'
   pod 'AppCenter/Crashes', '4.4.1'
   

--- a/AzureCommunicationUI/Podfile.lock
+++ b/AzureCommunicationUI/Podfile.lock
@@ -10,40 +10,40 @@ PODS:
     - Trouter (= 0.1.0)
   - AzureCommunicationCommon (1.1.1)
   - AzureCore (1.0.0-beta.15)
-  - MicrosoftFluentUI/ActivityIndicator_ios (0.8.9):
+  - MicrosoftFluentUI/ActivityIndicator_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Avatar_ios (0.8.9):
+  - MicrosoftFluentUI/Avatar_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/AvatarGroup_ios (0.8.9):
+  - MicrosoftFluentUI/AvatarGroup_ios (0.10.0):
     - MicrosoftFluentUI/Avatar_ios
-  - MicrosoftFluentUI/BottomSheet_ios (0.8.9):
+  - MicrosoftFluentUI/BottomSheet_ios (0.10.0):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
-  - MicrosoftFluentUI/Button_ios (0.8.9):
+  - MicrosoftFluentUI/Button_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Core_ios (0.8.9)
-  - MicrosoftFluentUI/Drawer_ios (0.8.9):
+  - MicrosoftFluentUI/Core_ios (0.10.0)
+  - MicrosoftFluentUI/Drawer_ios (0.10.0):
     - MicrosoftFluentUI/Obscurable_ios
     - MicrosoftFluentUI/ResizingHandleView_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TouchForwardingView_ios
-  - MicrosoftFluentUI/Label_ios (0.8.9):
+  - MicrosoftFluentUI/Label_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Obscurable_ios (0.8.9):
+  - MicrosoftFluentUI/Obscurable_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/PopupMenu_ios (0.8.9):
+  - MicrosoftFluentUI/PopupMenu_ios (0.10.0):
     - MicrosoftFluentUI/Drawer_ios
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
     - MicrosoftFluentUI/TableView_ios
-  - MicrosoftFluentUI/ResizingHandleView_ios (0.8.9):
+  - MicrosoftFluentUI/ResizingHandleView_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/Separator_ios (0.8.9):
+  - MicrosoftFluentUI/Separator_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
-  - MicrosoftFluentUI/TableView_ios (0.8.9):
+  - MicrosoftFluentUI/TableView_ios (0.10.0):
     - MicrosoftFluentUI/Label_ios
     - MicrosoftFluentUI/Separator_ios
-  - MicrosoftFluentUI/TouchForwardingView_ios (0.8.9):
+  - MicrosoftFluentUI/TouchForwardingView_ios (0.10.0):
     - MicrosoftFluentUI/Core_ios
   - SwiftLint (0.42.0)
   - Trouter (0.1.0)
@@ -52,12 +52,12 @@ DEPENDENCIES:
   - AppCenter/Crashes (= 4.4.1)
   - AzureCommunicationCalling (= 2.2.1)
   - AzureCommunicationChat (= 1.3.0)
-  - MicrosoftFluentUI/ActivityIndicator_ios (= 0.8.9)
-  - MicrosoftFluentUI/Avatar_ios (= 0.8.9)
-  - MicrosoftFluentUI/AvatarGroup_ios (= 0.8.9)
-  - MicrosoftFluentUI/BottomSheet_ios (= 0.8.9)
-  - MicrosoftFluentUI/Button_ios (= 0.8.9)
-  - MicrosoftFluentUI/PopupMenu_ios (= 0.8.9)
+  - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
+  - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
+  - MicrosoftFluentUI/AvatarGroup_ios (= 0.10.0)
+  - MicrosoftFluentUI/BottomSheet_ios (= 0.10.0)
+  - MicrosoftFluentUI/Button_ios (= 0.10.0)
+  - MicrosoftFluentUI/PopupMenu_ios (= 0.10.0)
   - SwiftLint (= 0.42.0)
 
 SPEC REPOS:
@@ -77,10 +77,10 @@ SPEC CHECKSUMS:
   AzureCommunicationChat: c3a67d67e85daba4d9d81874e50187c91f556f2d
   AzureCommunicationCommon: cc520a89f3f8db6d58de42ec4a70cfb79a1b76a3
   AzureCore: ebbf7cf4dfe72afc7584088c38d1c99f5a35d647
-  MicrosoftFluentUI: a204df7fac4bf62b608ad0f9683a5ca64faec2be
+  MicrosoftFluentUI: f6db695718efb93f4ca9bdc366c00b80a1f91dba
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Trouter: 62f6db5519829c0897832d404338c3b78ea64fa2
 
-PODFILE CHECKSUM: dba06e7567902f624b6be4dac963332e701eb372
+PODFILE CHECKSUM: 16c83386b7b70e9388c4af3908bcb766565fea05
 
 COCOAPODS: 1.11.3

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeAvatar.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeAvatar.swift
@@ -11,7 +11,7 @@ struct CompositeAvatar: View {
     @Binding var displayName: String?
     @Binding var avatarImage: UIImage?
     var isSpeaking: Bool
-    var avatarSize: MSFAvatarSize = .xxlarge
+    var avatarSize: MSFAvatarSize = .size72
     var body: some View {
         let isNameEmpty = displayName == nil
         || displayName?.trimmingCharacters(in: .whitespaces).isEmpty == true

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeParticipantsListCell.swift
@@ -18,7 +18,7 @@ class CompositeParticipantsListCell: TableViewCell {
         let avatarParticipantName = viewModel.getParticipantName(with: participantViewData)
         let isNameEmpty = avatarParticipantName.trimmingCharacters(in: .whitespaces).isEmpty
 
-        let avatar = MSFAvatar(style: isNameEmpty ? .outlined : .accent, size: .medium)
+        let avatar = MSFAvatar(style: isNameEmpty ? .outlined : .accent, size: .size32)
         avatar.state.primaryText = !isNameEmpty ? avatarParticipantName : nil
         avatar.state.image = participantViewData?.avatarImage
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/VideoView/LocalVideoView.swift
@@ -26,9 +26,9 @@ enum LocalVideoViewType {
         switch self {
         case .localVideofull,
              .preview:
-            return .xxlarge
+            return .size72
         case .localVideoPip:
-            return .large
+            return .size40
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/FluentUI/Wrapper/TypingParticipantAvatarGroup.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/FluentUI/Wrapper/TypingParticipantAvatarGroup.swift
@@ -31,7 +31,7 @@ class TypingParticipantAvatarGroup: UIView {
 
 extension TypingParticipantAvatarGroup {
     private func initAvatarGroup() {
-        group = MSFAvatarGroup(style: .stack, size: .xsmall)
+        group = MSFAvatarGroup(style: .stack, size: .size16)
         guard let group = group else {
             return
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/Message/TextMessageView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUIChat/Sources/Presentation/SwiftUI/Chat/ChatViewComponents/Message/TextMessageView.swift
@@ -39,7 +39,7 @@ struct TextMessageView: View {
     var avatar: some View {
         VStack() {
             if showUsername {
-                Avatar(style: .outlinedPrimary, size: .small, primaryText: messageModel.senderDisplayName)
+                Avatar(style: .outlinedPrimary, size: .size24, primaryText: messageModel.senderDisplayName)
                 Spacer()
             }
         }


### PR DESCRIPTION
## Purpose
We've seen mid-cycle view updates from the components in fluent, which were fixed in https://github.com/microsoft/fluentui-apple/pull/1450

This PR bumps the fluent version to the first post-PR release.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
Translation of the avatar sizes: 
https://github.com/microsoft/fluentui-apple/blob/main_0.8/ios/FluentUI/Avatar/AvatarTokenSet.swift#L200
