### PR TITLE
[Calling][Bug] iOS15 remote participant video event not received

### DIFF
--- a/AzureCommunicationUI/Podfile
+++ b/AzureCommunicationUI/Podfile
@@ -9,7 +9,7 @@ project 'AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp.xcodeproj'
 target 'AzureCommunicationUICalling' do
   project 'sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj'
   use_frameworks!
-  pod 'AzureCommunicationCalling', '2.3.0'
+  pod 'AzureCommunicationCalling', '2.4.1'
   pod 'MicrosoftFluentUI/Avatar_ios', '0.10.0'
   pod 'MicrosoftFluentUI/BottomSheet_ios', '0.10.0'
   pod 'MicrosoftFluentUI/Button_ios', '0.10.0'
@@ -45,7 +45,7 @@ end
 target 'AzureCommunicationUIDemoApp' do
   project 'AzureCommunicationUIDemoApp/AzureCommunicationUIDemoApp.xcodeproj'
   use_frameworks!
-  pod 'AzureCommunicationCalling', '2.3.0'
+  pod 'AzureCommunicationCalling', '2.4.1'
   pod 'AzureCommunicationChat', '1.3.1'
   pod 'MicrosoftFluentUI/Avatar_ios', '0.10.0'
   pod 'MicrosoftFluentUI/BottomSheet_ios', '0.10.0'

--- a/AzureCommunicationUI/Podfile.lock
+++ b/AzureCommunicationUI/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - AppCenter/Core (4.4.1)
   - AppCenter/Crashes (4.4.1):
     - AppCenter/Core
-  - AzureCommunicationCalling (2.3.0):
+  - AzureCommunicationCalling (2.4.1):
     - AzureCommunicationCommon (~> 1.0)
   - AzureCommunicationChat (1.3.1):
     - AzureCommunicationCommon (~> 1.0)
@@ -50,7 +50,7 @@ PODS:
 
 DEPENDENCIES:
   - AppCenter/Crashes (= 4.4.1)
-  - AzureCommunicationCalling (= 2.3.0)
+  - AzureCommunicationCalling (= 2.4.1)
   - AzureCommunicationChat (= 1.3.1)
   - MicrosoftFluentUI/ActivityIndicator_ios (= 0.10.0)
   - MicrosoftFluentUI/Avatar_ios (= 0.10.0)
@@ -73,7 +73,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AppCenter: b0b6f1190215b5f983c42934db718f3b46fff3c0
-  AzureCommunicationCalling: 7c19a3a41e6043cb2a50ebda864044333632ed55
+  AzureCommunicationCalling: 5a71fcf4988e8dc59b7a08640defb5d3edfeb324
   AzureCommunicationChat: 9be8209d32c2fc6259095ff9838ad30dcfc44f80
   AzureCommunicationCommon: cc520a89f3f8db6d58de42ec4a70cfb79a1b76a3
   AzureCore: ebbf7cf4dfe72afc7584088c38d1c99f5a35d647
@@ -81,6 +81,6 @@ SPEC CHECKSUMS:
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   Trouter: 7eab36954ad740e32db3ff9f6025b0dff92193d7
 
-PODFILE CHECKSUM: 0f386a7f3fd3e10920b9694aca0534e50b300562
+PODFILE CHECKSUM: 582b1bf1b10b1a2141a8c5b964d49b493bc14bf9
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Service/Calling/AzureCommunicationCalling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Service/Calling/AzureCommunicationCalling/CallingSDKWrapper.swift
@@ -57,6 +57,12 @@ class CallingSDKWrapper: NSObject, CallingSDKWrapperProtocol {
         logger.debug( "Joining call")
         let joinCallOptions = JoinCallOptions()
 
+        // to fix iOS 15 issue
+        // by default on iOS 15 calling SDK incoming type is raw video
+        // because of this on iOS 15 remote video start event is not received
+        let incomingVideoOptions = IncomingVideoOptions()
+        incomingVideoOptions.streamType = .remoteIncoming
+
         if isCameraPreferred,
            let localVideoStream = localVideoStream {
             let localVideoStreamArray = [localVideoStream]
@@ -66,6 +72,7 @@ class CallingSDKWrapper: NSObject, CallingSDKWrapperProtocol {
 
         joinCallOptions.audioOptions = AudioOptions()
         joinCallOptions.audioOptions?.muted = !isAudioPreferred
+        joinCallOptions.incomingVideoOptions = incomingVideoOptions
 
         var joinLocator: JoinMeetingLocator
         if callConfiguration.compositeCallType == .groupCall,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Making code changes as per latest SDK to fix issue where only on iOS 15 we need to set default video type to not raw (works fine on iOS 16)
* With fix iOS 15 will see remote participant video

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
