### PR TITLE
[Calling][Bug] Make no-network internal error propagate out

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -160,7 +160,7 @@ class SetupViewModel: ObservableObject {
     }
 
     private func handleOffline() {
-        store.dispatch(action: .errorAction(.statusErrorAndCallReset(internalError: .connectionFailed,
+        store.dispatch(action: .errorAction(.statusErrorAndCallReset(internalError: .callJoinConnectionFailed,
                                                                      error: nil)))
         // only show banner again when user taps on button explicitly
         // banner would not reappear when other events^1 send identical error state again

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Error/ErrorInfoViewModel.swift
@@ -69,7 +69,7 @@ class ErrorInfoViewModel: ObservableObject {
             title = localizationProvider.getLocalizedString(.snackBarErrorCallDenied)
         case .cameraOnFailed:
             title = localizationProvider.getLocalizedString(.snackBarErrorCameraOnFailed)
-        case .connectionFailed:
+        case .callJoinConnectionFailed:
             title = localizationProvider.getLocalizedString(.snackBarErrorConnectionError)
         default:
             title = localizationProvider.getLocalizedString(.snackBarError)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
@@ -7,7 +7,7 @@ import Foundation
 
 enum CallCompositeInternalError: Error, Equatable {
     case deviceManagerFailed(Error?)
-    case connectionFailed
+    case callJoinConnectionFailed
     case callTokenFailed
     case callJoinFailed
     case callEndFailed
@@ -26,7 +26,7 @@ enum CallCompositeInternalError: Error, Equatable {
             return CallCompositeErrorCode.cameraFailure
         case .callTokenFailed:
             return CallCompositeErrorCode.tokenExpired
-        case .callJoinFailed:
+        case .callJoinFailed, .callJoinConnectionFailed:
             return CallCompositeErrorCode.callJoin
         case .callEndFailed:
             return CallCompositeErrorCode.callEnd
@@ -34,8 +34,7 @@ enum CallCompositeInternalError: Error, Equatable {
             return CallCompositeErrorCode.cameraFailure
         case .callJoinFailedByMicPermission:
             return CallCompositeErrorCode.microphonePermissionNotGranted
-        case .networkConnectionNotAvailable,
-                .connectionFailed:
+        case .networkConnectionNotAvailable:
             return CallCompositeErrorCode.networkConnectionNotAvailable
         case .callHoldFailed,
                 .callResumeFailed,
@@ -61,7 +60,7 @@ enum CallCompositeInternalError: Error, Equatable {
                 .callDenied,
                 .cameraSwitchFailed,
                 .cameraOnFailed,
-                .connectionFailed:
+                .callJoinConnectionFailed:
             return false
         }
     }
@@ -71,7 +70,7 @@ extension CallCompositeInternalError {
     static func == (lhs: CallCompositeInternalError, rhs: CallCompositeInternalError) -> Bool {
         switch(lhs, rhs) {
         case (.deviceManagerFailed, .deviceManagerFailed),
-            (.connectionFailed, .connectionFailed),
+            (.callJoinConnectionFailed, .callJoinConnectionFailed),
             (.callTokenFailed, .callTokenFailed),
             (.callJoinFailed, .callJoinFailed),
             (.callEndFailed, .callEndFailed),

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/CallCompositeInternalError.swift
@@ -34,14 +34,14 @@ enum CallCompositeInternalError: Error, Equatable {
             return CallCompositeErrorCode.cameraFailure
         case .callJoinFailedByMicPermission:
             return CallCompositeErrorCode.microphonePermissionNotGranted
-        case .networkConnectionNotAvailable:
+        case .networkConnectionNotAvailable,
+                .connectionFailed:
             return CallCompositeErrorCode.networkConnectionNotAvailable
         case .callHoldFailed,
                 .callResumeFailed,
                 .callEvicted,
                 .callDenied,
-                .cameraSwitchFailed,
-                .connectionFailed:
+                .cameraSwitchFailed:
             return nil
         }
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Setup/ErrorInfoViewModelTests.swift
@@ -85,7 +85,7 @@ class ErrorInfoViewModelTests: XCTestCase {
 
     func test_errorInfoViewModel_update_when_errorStateConnectionFailed_then_snackBarErrorConnectionErrorDisplayed() {
         let sut = makeSUT()
-        let state = ErrorState(internalError: .connectionFailed,
+        let state = ErrorState(internalError: .callJoinConnectionFailed,
                                error: nil,
                                errorCategory: .none)
         sut.update(errorState: state)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Redux/Middleware/CallingMiddlewareHandlerTests.swift
@@ -566,7 +566,7 @@ class CallingMiddlewareHandlerTests: XCTestCase {
                                                            cameraStatus: .off,
                                                            cameraDeviceStatus: .front,
                                                            cameraPermission: .granted,
-                                                           internalError: .connectionFailed),
+                                                           internalError: .callJoinConnectionFailed),
                             dispatch: dispatch).value
     }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* On setup screen, when network error is detected, it is an internel "connectFailed" event that did not have a mapping. I added a mapping to the public noNetworkConnection error.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
