### PR TITLE
[Calling] Filter our InLobby and Disconnected users from UI

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Azure Communication UI Calling Release History
 
+## Upcoming
+
+### Bug Fixes
+- Hide lobby users in GridView and Participant List
+
 ## 1.4.0 (2023-08-30)
 
 ### Features

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/InfoHeaderViewModel.swift
@@ -83,8 +83,14 @@ class InfoHeaderViewModel: ObservableObject {
         if isVoiceOverEnabled && newDisplayInfoHeaderValue != shouldDisplayInfoHeaderValue {
             updateInfoHeaderAvailability()
         }
-        if participantsCount != remoteParticipantsState.participantInfoList.count {
-            participantsCount = remoteParticipantsState.participantInfoList.count
+
+        let updatedRemoteparticipantCount = remoteParticipantsState.participantInfoList
+            .filter({ participantInfoModel in
+                participantInfoModel.status != .inLobby && participantInfoModel.status != .disconnected
+            })
+            .count
+        if participantsCount != updatedRemoteparticipantCount {
+            participantsCount = updatedRemoteparticipantCount
             updateInfoLabel()
         }
         participantsListViewModel.update(localUserState: localUserState,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ParticipantsListViewModel.swift
@@ -30,9 +30,13 @@ class ParticipantsListViewModel: ObservableObject {
 
         if lastUpdateTimeStamp != remoteParticipantsState.lastUpdateTimeStamp {
             lastUpdateTimeStamp = remoteParticipantsState.lastUpdateTimeStamp
-            participantsList = remoteParticipantsState.participantInfoList.map {
-                compositeViewModelFactory.makeParticipantsListCellViewModel(participantInfoModel: $0)
-            }
+            participantsList = remoteParticipantsState.participantInfoList
+                .filter({ participant in
+                    participant.status != .inLobby && participant.status != .disconnected
+                })
+                .map {
+                    compositeViewModelFactory.makeParticipantsListCellViewModel(participantInfoModel: $0)
+                }
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridViewModel.swift
@@ -43,6 +43,9 @@ class ParticipantGridViewModel: ObservableObject {
         lastDominantSpeakersUpdatedTimestamp = remoteParticipantsState.dominantSpeakersModifiedTimestamp
 
         let remoteParticipants = remoteParticipantsState.participantInfoList
+            .filter { participanInfoModel in
+                participanInfoModel.status != .inLobby && participanInfoModel.status != .disconnected
+            }
         let dominantSpeakers = remoteParticipantsState.dominantSpeakers
         let newDisplayedInfoModelArr = getDisplayedInfoViewModels(remoteParticipants, dominantSpeakers)
         let removedModels = getRemovedInfoModels(for: newDisplayedInfoModelArr)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Builder/ParticipantInfoModelBuilder.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Builder/ParticipantInfoModelBuilder.swift
@@ -12,7 +12,8 @@ struct ParticipantInfoModelBuilder {
                     screenShareStreamId: String? = nil,
                     displayName: String = "displayName",
                     isSpeaking: Bool = false,
-                    isMuted: Bool = true) -> ParticipantInfoModel {
+                    isMuted: Bool = true,
+                    status: ParticipantStatus = .idle) -> ParticipantInfoModel {
         var videoStreamInfoModel: VideoStreamInfoModel?
         var screenShareIdInfoModel: VideoStreamInfoModel?
         if let screenShareId = screenShareStreamId {
@@ -30,7 +31,7 @@ struct ParticipantInfoModelBuilder {
                                     isMuted: isMuted,
                                     isRemoteUser: true,
                                     userIdentifier: participantIdentifier,
-                                    status: .idle,
+                                    status: status,
                                     screenShareVideoStreamModel: screenShareIdInfoModel,
                                     cameraVideoStreamModel: videoStreamInfoModel)
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/InfoHeaderViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/InfoHeaderViewModelTests.swift
@@ -133,6 +133,62 @@ class InfoHeaderViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_infoHeaderViewModel_update_when_multipleParticipantInfoListCountChanged_then_shouldBePublishedWithoutInLobbyNorDisconnected() {
+        let sut = makeSUT()
+        let expectation = XCTestExpectation(description: "Should publish infoLabel")
+        sut.$infoLabel
+            .dropFirst()
+            .sink(receiveValue: { infoLabel in
+                XCTAssertEqual(infoLabel, "Call with 1 person")
+                expectation.fulfill()
+            }).store(in: cancellable)
+
+        var participantList: [ParticipantInfoModel] = []
+        let participant1 = ParticipantInfoModel(
+            displayName: "Participant 1",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier1",
+            status: .idle,
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        participantList.append(participant1)
+
+        let participant2 = ParticipantInfoModel(
+            displayName: "Participant 2",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier2",
+            status: .inLobby,
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        participantList.append(participant2)
+
+        let participant3 = ParticipantInfoModel(
+            displayName: "Participant 3",
+            isSpeaking: false,
+            isMuted: false,
+            isRemoteUser: true,
+            userIdentifier: "testUserIdentifier3",
+            status: .disconnected,
+            screenShareVideoStreamModel: nil,
+            cameraVideoStreamModel: nil)
+        participantList.append(participant3)
+
+        let remoteParticipantsState = RemoteParticipantsState(
+            participantInfoList: participantList, lastUpdateTimeStamp: Date())
+
+        XCTAssertEqual(sut.infoLabel, "Waiting for others to join")
+        sut.update(localUserState: storeFactory.store.state.localUserState,
+                   remoteParticipantsState: remoteParticipantsState,
+                   callingState: CallingState())
+        XCTAssertEqual(sut.infoLabel, "Call with 1 person")
+
+        wait(for: [expectation], timeout: 1)
+    }
+
     func test_infoHeaderViewModel_update_when_statesUpdated_then_participantsListViewModelUpdated() {
         let expectation = XCTestExpectation(description: "Should update participantsListViewModel")
         let participantList = ParticipantInfoModelBuilder.getArray(count: 2)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantGridsViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantGridsViewModelTests.swift
@@ -139,6 +139,24 @@ class ParticipantGridViewModelTests: XCTestCase {
         XCTAssertEqual(sut.displayedParticipantInfoModelArr.first!.screenShareVideoStreamModel?.videoStreamIdentifier, expectedVideoStreamId)
     }
 
+    func test_participantGridsViewModel_updateParticipantsState_when_someParticipantsInLobby_then_lobbyNotDisconnecteParticipantsNotDisplaydInGrid() {
+        let uuid1 = UUID().uuidString
+        let uuid2 = UUID().uuidString
+        let uuid3 = UUID().uuidString
+
+        let infoModel1 = ParticipantInfoModelBuilder.get(participantIdentifier: uuid1, screenShareStreamId: nil)
+        let infoModel2 = ParticipantInfoModelBuilder.get(participantIdentifier: uuid2, screenShareStreamId: nil, status: .inLobby)
+        let infoModel3 = ParticipantInfoModelBuilder.get(participantIdentifier: uuid3, screenShareStreamId: nil, status: .disconnected)
+
+        let state = RemoteParticipantsState(participantInfoList: [infoModel1, infoModel2, infoModel3],
+                                            lastUpdateTimeStamp: Date())
+        let sut = makeSUT()
+        sut.update(callingState: CallingState(),
+                   remoteParticipantsState: state)
+        XCTAssertEqual(sut.displayedParticipantInfoModelArr.count, 1)
+        XCTAssertEqual(sut.displayedParticipantInfoModelArr.first!.userIdentifier, uuid1)
+    }
+
     // MARK: Updating participants list
     func test_participantGridsViewModel_updateParticipantsState_when_participantViewModelStateChanges_then_participantViewModelUpdated() {
         let date = Calendar.current.date(

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -261,7 +261,6 @@ class ParticipantsListViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-
     func test_participantsListViewModel_update_when_lastUpdateTimeStampNotChanged_then_shouldNotBePublished() {
         let sut = makeSUT()
         let expectation = XCTestExpectation(description: "Should not publish participantsList")

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantsListViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ParticipantsListViewModelTests.swift
@@ -197,6 +197,71 @@ class ParticipantsListViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    func test_participantsListViewModel_update_when_remoteParticipantInLobby_then_lobbyNorDisconnectedParticipantShouldNotBeDispalyed() {
+        let avatarViewManager = AvatarViewManager(store: storeFactory.store,
+                                                  localParticipantViewData: nil)
+        let sut = makeSUT()
+        let expectation = XCTestExpectation(description: "Should publish localParticipantsListCellViewModel")
+        sut.$participantsList
+            .dropFirst()
+            .sink(receiveValue: { participantsList in
+                XCTAssertEqual(participantsList.count, 1)
+                expectation.fulfill()
+            }).store(in: cancellable)
+
+        let audioStateOff = LocalUserState.AudioState(operation: .off,
+                                                      device: .receiverSelected)
+        let timestamp = Date()
+        let localUserState = LocalUserState(audioState: audioStateOff)
+        let participantInfoModel: [ParticipantInfoModel] = [
+            ParticipantInfoModel(displayName: "User Name1",
+                                 isSpeaking: false,
+                                 isMuted: false,
+                                 isRemoteUser: false,
+                                 userIdentifier: "MockUUID1",
+                                 status: .idle,
+                                 screenShareVideoStreamModel: nil,
+                                 cameraVideoStreamModel: nil),
+            ParticipantInfoModel(displayName: "User Name 2",
+                                 isSpeaking: false,
+                                 isMuted: false,
+                                 isRemoteUser: false,
+                                 userIdentifier: "MockUUID2",
+                                 status: .inLobby,
+                                 screenShareVideoStreamModel: nil,
+                                 cameraVideoStreamModel: nil),
+            ParticipantInfoModel(displayName: "User Name 3",
+                                 isSpeaking: false,
+                                 isMuted: false,
+                                 isRemoteUser: false,
+                                 userIdentifier: "MockUUID3",
+                                 status: .disconnected,
+                                 screenShareVideoStreamModel: nil,
+                                 cameraVideoStreamModel: nil)
+        ]
+        let remoteParticipantsState = RemoteParticipantsState(
+            participantInfoList: participantInfoModel, lastUpdateTimeStamp: timestamp.addingTimeInterval(1))
+
+        let audioStateOn = LocalUserState.AudioState(operation: .on,
+                                                     device: .receiverSelected)
+        sut.lastUpdateTimeStamp = timestamp
+        let localParticipant = ParticipantsListCellViewModel(
+            localUserState: LocalUserState(audioState: audioStateOn),
+            localizationProvider: localizationProvider)
+        sut.localParticipantsListCellViewModel = localParticipant
+        XCTAssertEqual(sut.participantsList.count, 0)
+        sut.update(localUserState: localUserState,
+                                         remoteParticipantsState: remoteParticipantsState)
+        XCTAssertEqual(sut.participantsList.count, 1)
+        XCTAssertEqual(localParticipant.getParticipantName(with: nil), "")
+        XCTAssertEqual(localParticipant.isLocalParticipant, true)
+        let sortedParticipants = sut.sortedParticipants(with: avatarViewManager)
+        XCTAssertEqual(sortedParticipants.first?.getParticipantName(with: nil), localParticipant.getParticipantName(with: nil))
+        XCTAssertEqual(sortedParticipants.last?.getParticipantName(with: nil), remoteParticipantsState.participantInfoList.first!.displayName)
+        wait(for: [expectation], timeout: 1)
+    }
+
+
     func test_participantsListViewModel_update_when_lastUpdateTimeStampNotChanged_then_shouldNotBePublished() {
         let sut = makeSUT()
         let expectation = XCTestExpectation(description: "Should not publish participantsList")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Filter our InLobby and Disconnected users from UI. We should not display users in the grid nor in participant list until they are admitted to the Team meeting call. Also, when user is rejected, we first receive Disconnected status followed by Participant list updated event when participant is removed. The time gap is about 1 sec. To avoid user be displayed for a second, also filter out Disconnected.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
