### PR TITLE
[Calling][Bugfix] Start a call with video ON fix

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Service/Calling/AzureCommunicationCalling/CallingSDKWrapper.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Service/Calling/AzureCommunicationCalling/CallingSDKWrapper.swift
@@ -66,8 +66,9 @@ class CallingSDKWrapper: NSObject, CallingSDKWrapperProtocol {
         if isCameraPreferred,
            let localVideoStream = localVideoStream {
             let localVideoStreamArray = [localVideoStream]
-            _ = [localVideoStream]
+
             let videoOptions = OutgoingVideoOptions()
+            videoOptions.streams = localVideoStreamArray
             joinCallOptions.outgoingVideoOptions = videoOptions
         }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Start a call with video ON fix

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Launch CallComposite
* turn camera ON in the Setup screen
* Join a call



## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Observe that on the remote device another participant can see our outgoing video | Screenshot or description with this change | Before it did not go out and remote user did not see vidoe.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
