### PR TITLE
[UFD][1.5.0] Fixes a few small issues related to accessibility on diagnostic banners

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -200,6 +200,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
 
     func makeCallDiagnosticsViewModel(dispatchAction: @escaping ActionDispatch) -> CallDiagnosticsViewModel {
         CallDiagnosticsViewModel(localizationProvider: localizationProvider,
+                                 accessibilityProvider: accessibilityProvider,
                                  dispatchAction: dispatchAction)
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/BottomToastDiagnosticView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/BottomToastDiagnosticView.swift
@@ -24,6 +24,7 @@ struct BottomToastDiagnosticView: View {
                         EdgeInsets(
                             top: 0, leading: horizontalPadding, bottom: 0, trailing: 0)
                     )
+                    .accessibilityHidden(true)
             }
             Text(viewModel.text)
                 .font(Fonts.caption1.font)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/BottomToastDiagnosticViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/BottomToastDiagnosticViewModel.swift
@@ -8,13 +8,14 @@ import Foundation
 
 final class BottomToastDiagnosticViewModel: ObservableObject, Identifiable {
     // The time a bottom toast diagnostic should be presented for before
-    // automatically beging dismissed.
+    // automatically being dismissed.
     static let bottomToastBannerDismissInterval: TimeInterval = 4.0
 
     @Published private(set) var text: String = ""
     @Published private(set) var icon: CompositeIcon?
 
     private let localizationProvider: LocalizationProviderProtocol
+    private let accessibilityProvider: AccessibilityProviderProtocol
 
     private(set) var networkDiagnostic: NetworkCallDiagnostic?
     private(set) var networkQualityDiagnostic: NetworkQualityCallDiagnostic?
@@ -27,22 +28,28 @@ final class BottomToastDiagnosticViewModel: ObservableObject, Identifiable {
     ]
 
     init(localizationProvider: LocalizationProviderProtocol,
+         accessibilityProvider: AccessibilityProviderProtocol,
          mediaDiagnostic: MediaCallDiagnostic) {
         self.localizationProvider = localizationProvider
+        self.accessibilityProvider = accessibilityProvider
         self.mediaDiagnostic = mediaDiagnostic
         self.updateTextAndIcon()
     }
 
     init(localizationProvider: LocalizationProviderProtocol,
+         accessibilityProvider: AccessibilityProviderProtocol,
          networkDiagnostic: NetworkCallDiagnostic) {
         self.localizationProvider = localizationProvider
+        self.accessibilityProvider = accessibilityProvider
         self.networkDiagnostic = networkDiagnostic
         self.updateTextAndIcon()
     }
 
     init(localizationProvider: LocalizationProviderProtocol,
+         accessibilityProvider: AccessibilityProviderProtocol,
          networkQualityDiagnostic: NetworkQualityCallDiagnostic) {
         self.localizationProvider = localizationProvider
+        self.accessibilityProvider = accessibilityProvider
         self.networkQualityDiagnostic = networkQualityDiagnostic
         self.updateTextAndIcon()
     }
@@ -55,6 +62,9 @@ final class BottomToastDiagnosticViewModel: ObservableObject, Identifiable {
         } else if let networkQualityDiagnostic = networkQualityDiagnostic {
             updateTextAndIcon(for: networkQualityDiagnostic)
         }
+
+        // Announce accessibility text when toast appear.
+        accessibilityProvider.postQueuedAnnouncement(text)
     }
 
     private func updateTextAndIcon(for mediaDiagnostics: MediaCallDiagnostic) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/CallDiagnosticsViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/CallDiagnosticsViewModel.swift
@@ -7,16 +7,19 @@ import Combine
 import Foundation
 
 final class CallDiagnosticsViewModel: ObservableObject {
-    private var bottomToastDimissTimer: Timer!
+    private var bottomToastDismissTimer: Timer!
     private let localizationProvider: LocalizationProviderProtocol
+    private let accessibilityProvider: AccessibilityProviderProtocol
     private let dispatch: ActionDispatch
 
     @Published var currentBottomToastDiagnostic: BottomToastDiagnosticViewModel?
     @Published var messageBarStack: [MessageBarDiagnosticViewModel] = []
 
     init(localizationProvider: LocalizationProviderProtocol,
+         accessibilityProvider: AccessibilityProviderProtocol,
          dispatchAction: @escaping ActionDispatch) {
         self.localizationProvider = localizationProvider
+        self.accessibilityProvider = accessibilityProvider
         self.dispatch = dispatchAction
         initializeMessageBarListModel()
     }
@@ -27,6 +30,7 @@ final class CallDiagnosticsViewModel: ObservableObject {
                 .map { diagnostic in
                     return MessageBarDiagnosticViewModel(
                         localizationProvider: localizationProvider,
+                        accessibilityProvider: accessibilityProvider,
                         callDiagnosticViewModel: self,
                         mediaDiagnostic: diagnostic
                     )
@@ -47,6 +51,7 @@ final class CallDiagnosticsViewModel: ObservableObject {
         updateBottomToast(isBadState: diagnosticModel.value,
                           viewModel: BottomToastDiagnosticViewModel(
                                         localizationProvider: localizationProvider,
+                                        accessibilityProvider: accessibilityProvider,
                                         networkDiagnostic: diagnosticModel.diagnostic),
                           dismissAfterInterval: true,
                           where: { $0.networkDiagnostic == diagnosticModel.diagnostic })
@@ -59,6 +64,7 @@ final class CallDiagnosticsViewModel: ObservableObject {
         updateBottomToast(isBadState: diagnosticModel.value == .bad || diagnosticModel.value == .poor,
                           viewModel: BottomToastDiagnosticViewModel(
                                         localizationProvider: localizationProvider,
+                                        accessibilityProvider: accessibilityProvider,
                                         networkQualityDiagnostic: diagnosticModel.diagnostic),
                           dismissAfterInterval: dismissAfterInterval,
                           where: { $0.networkQualityDiagnostic == diagnosticModel.diagnostic })
@@ -69,6 +75,7 @@ final class CallDiagnosticsViewModel: ObservableObject {
             updateBottomToast(isBadState: diagnosticModel.value,
                               viewModel: BottomToastDiagnosticViewModel(
                                             localizationProvider: localizationProvider,
+                                            accessibilityProvider: accessibilityProvider,
                                             mediaDiagnostic: diagnosticModel.diagnostic),
                               dismissAfterInterval: true,
                               where: { $0.mediaDiagnostic == diagnosticModel.diagnostic })
@@ -109,7 +116,7 @@ final class CallDiagnosticsViewModel: ObservableObject {
 
             // Restart timer for interval dismiss.
             if dismissAfterInterval {
-                bottomToastDimissTimer =
+                bottomToastDismissTimer =
                     Timer.scheduledTimer(withTimeInterval:
                                             BottomToastDiagnosticViewModel.bottomToastBannerDismissInterval,
                                          repeats: false) { [weak self] _ in
@@ -135,8 +142,8 @@ final class CallDiagnosticsViewModel: ObservableObject {
     }
 
     private func invalidateTimer() {
-        bottomToastDimissTimer?.invalidate()
-        bottomToastDimissTimer = nil
+        bottomToastDismissTimer?.invalidate()
+        bottomToastDismissTimer = nil
     }
 
     private func dispatchBottomToastDismissAction() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/MessageBarDiagnosticView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/MessageBarDiagnosticView.swift
@@ -25,6 +25,7 @@ struct MessageBarDiagnosticView: View {
                             EdgeInsets(
                                 top: 0, leading: horizontalPadding, bottom: 0, trailing: 0)
                         )
+                        .accessibilityHidden(true)
                 }
                 Text(viewModel.text)
                     .font(Fonts.footnote.font)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/MessageBarDiagnosticViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/Diagnostics/MessageBarDiagnosticViewModel.swift
@@ -11,6 +11,7 @@ final class MessageBarDiagnosticViewModel: ObservableObject, Identifiable {
     @Published private(set) var isDisplayed: Bool = false
 
     private let localizationProvider: LocalizationProviderProtocol
+    private let accessibilityProvider: AccessibilityProviderProtocol
 
     private(set) var mediaDiagnostic: MediaCallDiagnostic
     private(set) weak var callDiagnosticViewModel: CallDiagnosticsViewModel?
@@ -31,9 +32,11 @@ final class MessageBarDiagnosticViewModel: ObservableObject, Identifiable {
     ]
 
     init(localizationProvider: LocalizationProviderProtocol,
+         accessibilityProvider: AccessibilityProviderProtocol,
          callDiagnosticViewModel: CallDiagnosticsViewModel,
          mediaDiagnostic: MediaCallDiagnostic) {
         self.localizationProvider = localizationProvider
+        self.accessibilityProvider = accessibilityProvider
         self.callDiagnosticViewModel = callDiagnosticViewModel
         self.mediaDiagnostic = mediaDiagnostic
         self.updateTextAndIcon(for: mediaDiagnostic)
@@ -68,6 +71,9 @@ final class MessageBarDiagnosticViewModel: ObservableObject, Identifiable {
 
     func show() {
         isDisplayed = true
+
+        // Announce accessibility text when displayed.
+        accessibilityProvider.postQueuedAnnouncement(text)
     }
 }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -141,7 +141,7 @@ enum LocalizationKey: String {
     case callDiagnosticsSpeakerMuted = "AzureCommunicationUICalling.Diagnostics.Text.SpeakerMuted"
 
     case callDiagnosticsDismissAccessibilityLabel =
-            "AzureCommunicationUICalling.Diagnostics.Text.Dismiss.AccessibilityLabel"
+            "AzureCommunicationUICalling.Diagnostics.Button.Dismiss.AccessibilityLabel"
     case callDiagnosticsDismissAccessibilityHint =
-            "AzureCommunicationUICalling.Diagnostics.Text.Dismiss.AccessibilityHint"
+            "AzureCommunicationUICalling.Diagnostics.Button.Dismiss.AccessibilityHint"
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/CompositeViewModelFactoryMocking.swift
@@ -151,7 +151,9 @@ struct CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
     }
 
     func makeCallDiagnosticsViewModel(dispatchAction: @escaping ActionDispatch) -> CallDiagnosticsViewModel {
-        return callDiagnosticsViewModel ?? CallDiagnosticsViewModel(localizationProvider: localizationProvider, dispatchAction: dispatchAction)
+        return callDiagnosticsViewModel ?? CallDiagnosticsViewModel(localizationProvider: localizationProvider,
+                                                                    accessibilityProvider: accessibilityProvider,
+                                                                    dispatchAction: dispatchAction)
     }
 
     func makeSelectableDrawerListItemViewModel(icon: CompositeIcon,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/BottomToastDiagnosticViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/BottomToastDiagnosticViewModelTests.swift
@@ -91,21 +91,27 @@ extension BottomToastDiagnosticViewModelTests {
     func makeSUT(mediaDiagnostic: MediaCallDiagnostic,
                  localizationProvider: LocalizationProviderMocking? = nil) -> BottomToastDiagnosticViewModel {
         let localizationProviderValue: LocalizationProviderProtocol = localizationProvider ?? LocalizationProvider(logger: LoggerMocking())
+        let accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()
         return BottomToastDiagnosticViewModel(localizationProvider: localizationProviderValue,
+                                              accessibilityProvider: accessibilityProvider,
                                               mediaDiagnostic: mediaDiagnostic)
     }
 
     func makeSUT(networkDiagnostic: NetworkCallDiagnostic,
                  localizationProvider: LocalizationProviderMocking? = nil) -> BottomToastDiagnosticViewModel {
         let localizationProviderValue: LocalizationProviderProtocol = localizationProvider ?? LocalizationProvider(logger: LoggerMocking())
+        let accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()
         return BottomToastDiagnosticViewModel(localizationProvider: localizationProviderValue,
+                                              accessibilityProvider: accessibilityProvider,
                                               networkDiagnostic: networkDiagnostic)
     }
 
     func makeSUT(networkQualityDiagnostic: NetworkQualityCallDiagnostic,
                  localizationProvider: LocalizationProviderMocking? = nil) -> BottomToastDiagnosticViewModel {
         let localizationProviderValue: LocalizationProviderProtocol = localizationProvider ?? LocalizationProvider(logger: LoggerMocking())
+        let accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()
         return BottomToastDiagnosticViewModel(localizationProvider: localizationProviderValue,
+                                              accessibilityProvider: accessibilityProvider,
                                               networkQualityDiagnostic: networkQualityDiagnostic)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/CallDiagnosticsViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/CallDiagnosticsViewModelTests.swift
@@ -212,8 +212,9 @@ class CallDiagnosticsViewModelTests: XCTestCase {
 
 extension CallDiagnosticsViewModelTests {
     func makeSUT(dispatchAction: @escaping ActionDispatch, localizationProvider: LocalizationProviderMocking? = nil) -> CallDiagnosticsViewModel {
+        let accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()
         return CallDiagnosticsViewModel(
-            localizationProvider: localizationProvider ?? LocalizationProvider(logger: LoggerMocking()), dispatchAction: dispatchAction
+            localizationProvider: localizationProvider ?? LocalizationProvider(logger: LoggerMocking()), accessibilityProvider: accessibilityProvider, dispatchAction: dispatchAction
         )
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/MessageBarDiagnosticViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/MessageBarDiagnosticViewModelTests.swift
@@ -61,8 +61,12 @@ extension MessageBarDiagnosticViewModelTests {
     func makeSUT(mediaDiagnostic: MediaCallDiagnostic,
                  localizationProvider: LocalizationProviderMocking? = nil) -> MessageBarDiagnosticViewModel {
         let localizationProviderValue: LocalizationProviderProtocol = localizationProvider ?? LocalizationProvider(logger: LoggerMocking())
-        let callDiagnosticsViewModel = CallDiagnosticsViewModel(localizationProvider: localizationProviderValue, dispatchAction: { _ in })
+        let accessibilityProvider: AccessibilityProviderProtocol = AccessibilityProviderMocking()
+        let callDiagnosticsViewModel = CallDiagnosticsViewModel(localizationProvider: localizationProviderValue,
+                                                                accessibilityProvider: accessibilityProvider,
+                                                                dispatchAction: { _ in })
         return MessageBarDiagnosticViewModel(localizationProvider: localizationProviderValue,
+                                             accessibilityProvider: accessibilityProvider,
                                              callDiagnosticViewModel: callDiagnosticsViewModel,
                                              mediaDiagnostic: mediaDiagnostic)
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Ensure that voice over announces message banner and bottom toast banners.
Ensure that icons don't participate in accessibility.
Fix accessibility label and hint localized key.
Fixed few typos.

Cherry-pick of https://github.com/Azure/communication-ui-library-ios/pull/769
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

Scenarios described on:
https://dev.azure.com/skype/SPOOL/_workitems/edit/3502660
https://dev.azure.com/skype/SPOOL/_workitems/edit/3502538

## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
