### PR TITLE
[Calling][Bugfix] Keyboard watcher state was resetting with Views/Viewmodels

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
@@ -6,10 +6,12 @@ import Foundation
 import SwiftUI
 import UIKit
 
-/*
- Prepares offsets for views impacted by the keyboard, specifically in Landscape mode
- */
 class LandscapeAwareKeyboardWatcher: ObservableObject {
+<<<<<<< Updated upstream
+=======
+    static let shared = LandscapeAwareKeyboardWatcher()
+
+>>>>>>> Stashed changes
     @Published var activeHeight: CGFloat = 0
 
     private var keyboardHeight: CGFloat = 0
@@ -76,6 +78,10 @@ class LandscapeAwareKeyboardWatcher: ObservableObject {
     private func updateOrientationStatus() {
         let currentOrientation = UIDevice.current.orientation
         isLandscape = currentOrientation == .landscapeLeft || currentOrientation == .landscapeRight
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
     }
 
     private func updateActiveHeight() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
@@ -6,7 +6,7 @@ import Foundation
 import SwiftUI
 import UIKit
 
-class LandscapeAwareKeyboardWatcher: ObservableObject {
+internal class LandscapeAwareKeyboardWatcher: ObservableObject {
     static let shared = LandscapeAwareKeyboardWatcher()
     @Published var activeHeight: CGFloat = 0
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Utilities/LandscapeAwareKeyboardWatcher.swift
@@ -7,11 +7,7 @@ import SwiftUI
 import UIKit
 
 class LandscapeAwareKeyboardWatcher: ObservableObject {
-<<<<<<< Updated upstream
-=======
     static let shared = LandscapeAwareKeyboardWatcher()
-
->>>>>>> Stashed changes
     @Published var activeHeight: CGFloat = 0
 
     private var keyboardHeight: CGFloat = 0
@@ -78,10 +74,6 @@ class LandscapeAwareKeyboardWatcher: ObservableObject {
     private func updateOrientationStatus() {
         let currentOrientation = UIDevice.current.orientation
         isLandscape = currentOrientation == .landscapeLeft || currentOrientation == .landscapeRight
-<<<<<<< Updated upstream
-=======
-
->>>>>>> Stashed changes
     }
 
     private func updateActiveHeight() {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/SupportForm/SupportFormView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/ViewComponents/SupportForm/SupportFormView.swift
@@ -9,7 +9,8 @@ import FluentUI
 
 internal struct SupportFormView: View {
     @ObservedObject var viewModel: SupportFormViewModel
-    @ObservedObject var landscapeKeyboardWatcher = LandscapeAwareKeyboardWatcher()
+    @ObservedObject var landscapeKeyboardWatcher: LandscapeAwareKeyboardWatcher
+        = LandscapeAwareKeyboardWatcher.shared
 
     let screenHeight: CGFloat = UIScreen.main.bounds.height
     let otherControlsHeightEstimate: CGFloat = 104


### PR DESCRIPTION
Fix the keyboard handler. Was in the View and recreation was setting the offset to 0, causing the form to jump back down.
Migrated to singleton which works reliably (no recreation, no resetting to 0, no jumping).

Weighed singleton decision against alternatives (DI, Redux) but this seems like safest/lowest impact approach for the moment.

DI: Would require changes to the interface of the watcher, as well as propagating to VM's (estimated +20-50 lines, +3 files at least)
Redux: Would require changes to the interface to be more of a "manager" + redux state + propagating to VM's. (estimated +40-80 lines, +5-10 files changed)
vs
Singleton: One global keyboard, everyone can use the same instance in their view, quick and easy. Very little tracked in static state. (2 files changed, +2 lines).

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
