### PR TITLE
[Calling][Bug] Update resume button label

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en-GB.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en-GB.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 /* OnHoldView */
 "AzureCommunicationUICalling.OnHoldView.Text.OnHold"="You're on hold";
 "AzureCommunicationUICalling.OnHoldView.Button.Resume"="Resume";
+"AzureCommunicationUICalling.OnHoldView.Button.Resume.AccessibilityLabel" = "Resume";
 
 /* CallingView */
 "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"="Waiting for others to join";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en-US.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en-US.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 /* OnHoldView */
 "AzureCommunicationUICalling.OnHoldView.Text.OnHold"="You're on hold";
 "AzureCommunicationUICalling.OnHoldView.Button.Resume"="Resume";
+"AzureCommunicationUICalling.OnHoldView.Button.Resume.AccessibilityLabel" = "Resume";
 
 /* CallingView */
 "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"="Waiting for others to join";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
@@ -38,6 +38,7 @@
 /* OnHoldView */
 "AzureCommunicationUICalling.OnHoldView.Text.OnHold"="You're on hold";
 "AzureCommunicationUICalling.OnHoldView.Button.Resume"="Resume";
+"AzureCommunicationUICalling.OnHoldView.Button.Resume.AccessibilityLabel" = "Resume";
 
 /* CallingView */
 "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"="Waiting for others to join";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/Overlay/OnHoldOverlayViewModel.swift
@@ -59,7 +59,7 @@ class OnHoldOverlayViewModel: OverlayViewModelProtocol, ObservableObject {
                 }
         }
         self.actionButtonViewModel?
-            .update(accessibilityLabel: AccessibilityIdentifier.callResumeAccessibilityID.rawValue)
+            .update(accessibilityLabel: self.localizationProvider.getLocalizedString(.resumeAccessibilityLabel))
     }
 
     func update(callingStatus: CallingStatus,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -41,6 +41,7 @@ enum LocalizationKey: String {
     /* OnHoldView */
     case onHoldMessage = "AzureCommunicationUICalling.OnHoldView.Text.OnHold"
     case resume = "AzureCommunicationUICalling.OnHoldView.Button.Resume"
+    case resumeAccessibilityLabel = "AzureCommunicationUICalling.OnHoldView.Button.Resume.AccessibilityLabel"
 
     /* CallingView */
     case callWith0Person = "AzureCommunicationUICalling.CallingView.InfoHeader.WaitingForOthersToJoin"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Proper Name should be defined for 'Resume' button. Voiceover should announce something like 'Resume' button.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
