### PR TITLE
[Calling][Bug] Leave call button accessibility

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
@@ -46,7 +46,6 @@ extension LeaveCallConfirmationListViewController: UITableViewDataSource, UITabl
         label.frame = headerView.frame
         label.text = headerName
         label.textAlignment = .center
-        label.font = .systemFont(ofSize: 17, weight: .semibold)
         label.font = .preferredFont(forTextStyle: .headline)
         label.textColor = StyleProvider.color.onSurface
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/LeaveCallConfirmationListViewController.swift
@@ -47,6 +47,7 @@ extension LeaveCallConfirmationListViewController: UITableViewDataSource, UITabl
         label.text = headerName
         label.textAlignment = .center
         label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.font = .preferredFont(forTextStyle: .headline)
         label.textColor = StyleProvider.color.onSurface
         label.translatesAutoresizingMaskIntoConstraints = false
         headerView.addSubview(label)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* 'Leave call' heading should be adopting a larger text setting. Text size should be increased according to resize settings.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
|<img width="1272" alt="Textual information like 'Leave call' heading does not adopt larger text settings" src="https://github.com/Azure/communication-ui-library-ios/assets/93549644/fab99498-1411-49ae-9155-079b09fe913e">|![IMG_7943](https://github.com/Azure/communication-ui-library-ios/assets/93549644/b74016aa-86c9-464c-865f-9f6a002158f3)|


## Other Information
<!-- Add any other helpful information that may be needed here. -->
