### PR TITLE
[Call][Bug] Accessibility join call disabled

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "AzureCommunicationUICalling.SetupView.Button.Dismiss.AccessibilityLabel"="Back";
 "AzureCommunicationUICalling.SetupView.Button.JoinCall"="Join call";
 "AzureCommunicationUICalling.SetupView.Button.JoiningCall"="Joining call…";
+"AzureCommunicationUICalling.SetupView.Button.JoinCall.DisableState.AccessibilityLabel" = "Join Call Disabled";
 "AzureCommunicationUICalling.SetupView.Button.VideoOff"="Video off";
 "AzureCommunicationUICalling.SetupView.Button.VideoOff.AccessibilityLabel"="Video On";
 "AzureCommunicationUICalling.SetupView.Button.VideoOn"="Video on";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewModel.swift
@@ -72,8 +72,7 @@ class SetupViewModel: ObservableObject {
                 }
                 self.joinCallButtonTapped()
         }
-        joinCallButtonViewModel.update(accessibilityLabel: self.localizationProvider.getLocalizedString(.joinCall))
-
+        updateAccessibilityLabel()
         dismissButtonViewModel = compositeViewModelFactory.makeIconButtonViewModel(
             iconName: .leftArrow,
             buttonType: .controlButton,
@@ -99,6 +98,17 @@ class SetupViewModel: ObservableObject {
         $isJoinRequested.sink { [weak self] value in
             self?.setupControlBarViewModel.update(isJoinRequested: value)
         }.store(in: &cancellables)
+    }
+
+    func updateAccessibilityLabel() {
+        if joinCallButtonViewModel.isDisabled {
+            // Update the accessibility label for the disabled state
+            joinCallButtonViewModel.update(accessibilityLabel:
+            self.localizationProvider.getLocalizedString(.joinCallDiableStateAccessibilityLabel))
+        } else {
+            // Update the accessibility label for the normal state
+            joinCallButtonViewModel.update(accessibilityLabel: self.localizationProvider.getLocalizedString(.joinCall))
+        }
     }
 
     deinit {
@@ -142,6 +152,7 @@ class SetupViewModel: ObservableObject {
                                         permissionState: permissionState,
                                         callingState: callingState)
         joinCallButtonViewModel.update(isDisabled: permissionState.audioPermission == .denied)
+        updateAccessibilityLabel()
         errorInfoViewModel.update(errorState: state.errorState)
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -29,6 +29,8 @@ enum LocalizationKey: String {
     case micOnAccessibilityLabel = "AzureCommunicationUICalling.SetupView.Button.MicOn.AccessibilityLabel"
     case device = "AzureCommunicationUICalling.SetupView.Button.Device"
     case deviceAccesibiiltyLabel = "AzureCommunicationUICalling.SetupView.Button.Device.AccessibilityLabel"
+    case joinCallDiableStateAccessibilityLabel =
+            "AzureCommunicationUICalling.SetupView.Button.JoinCall.DisableState.AccessibilityLabel"
     case goToSettings = "AzureCommunicationUICalling.SetupView.Button.GoToSettings"
     case cameraDisabled = "AzureCommunicationUICalling.SetupView.PreviewArea.AudioGrantedCameraDisabled"
     case audioAndCameraDisabled = "AzureCommunicationUICalling.SetupView.PreviewArea.AudioDisabledCameraDenied"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Voiceover should announce 'dimmed' state information for the 'Disabled Join Call' button.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
