### PR TITLE
 [Calling][Bug] Fix VoiceOver announcements for remote camera state changes.

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
@@ -83,6 +83,7 @@
 "AzureCommunicationUICalling.CallingView.MutiplePeopleJoined"="%d participants joined the meeting";
 "AzureCommunicationUICalling.CallingView.OnePersonLeft"="%@ left the meeting";
 "AzureCommunicationUICalling.CallingView.MutiplePeopleLeft"="%d participants left the meeting";
+"AzureCommunicationUICalling.CallingView.ParticipantInformation.AccessibilityLabel" = "%@ %@ %@";
 "AzureCommunicationUICalling.CallingView.JoinedCall.AccessibilityLabel"="You have joined the call";
 "AzureCommunicationUICalling.CallingView.ScreenShareStart.AccessibilityLabel"="Content is being shared";
 "AzureCommunicationUICalling.CallingView.ScreenShareEnd.AccessibilityLabel"="Content sharing has ended";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -73,6 +73,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
         if self.participantName != participantModel.displayName ||
             self.isMuted != participantModel.isMuted ||
             self.isSpeaking != participantModel.isSpeaking ||
+            self.isCameraEnabled != participantModel.cameraVideoStreamModel?.videoStreamIdentifier.isEmpty ||
             self.isHold != (participantModel.status == .hold) {
             self.accessibilityLabel = getAccessibilityLabel(participantModel: participantModel)
         }
@@ -123,7 +124,11 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
         let status = participantModel.status == .hold ? getOnHoldString() :
         localizationProvider.getLocalizedString(participantModel.isSpeaking ? .speaking :
                                                     participantModel.isMuted ? .muted : .unmuted)
-        return "\(participantModel.displayName) \(status)"
+
+        let videoStatus = (videoViewModel?.videoStreamId?.isEmpty ?? true) ?
+        localizationProvider.getLocalizedString(.videoOff):
+        localizationProvider.getLocalizedString(.videoOn)
+        return "\(participantModel.displayName) \(status) \(videoStatus)"
     }
 
     private func getDisplayingVideoStreamModel(_ participantModel: ParticipantInfoModel)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -128,7 +128,8 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
         let videoStatus = (videoViewModel?.videoStreamId?.isEmpty ?? true) ?
         localizationProvider.getLocalizedString(.videoOff):
         localizationProvider.getLocalizedString(.videoOn)
-        return "\(participantModel.displayName) \(status) \(videoStatus)"
+        return localizationProvider.getLocalizedString(.participantInformationAccessibilityLable,
+                                                       participantModel.displayName, status, videoStatus)
     }
 
     private func getDisplayingVideoStreamModel(_ participantModel: ParticipantInfoModel)

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -101,6 +101,8 @@ enum LocalizationKey: String {
     case multiplePeopleJoined = "AzureCommunicationUICalling.CallingView.MutiplePeopleJoined"
     case onePersonLeft = "AzureCommunicationUICalling.CallingView.OnePersonLeft"
     case multiplePeopleLeft = "AzureCommunicationUICalling.CallingView.MutiplePeopleLeft"
+    case participantInformationAccessibilityLable =
+            "AzureCommunicationUICalling.CallingView.ParticipantInformation.AccessibilityLabel"
     case joinedCallAccessibilityLabel =
             "AzureCommunicationUICalling.CallingView.JoinedCall.AccessibilityLabel"
     case screenshareStartAccessibilityLabel =


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Voiceover doesn't announce any information regarding 'Video is On/Off' for participants who have joined the call. It announces 'Username, Muted/Unmuted' information only.
 
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
