### PR TITLE
[Calling][iOS][Bugfix] Switch camera off when user opens AppCenter or user Locks screen

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AppLifeCycleManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AppLifeCycleManager.swift
@@ -44,6 +44,16 @@ class UIKitAppLifeCycleManager: LifeCycleManagerProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(willTerminate),
                                                name: UIApplication.willTerminateNotification,
                                                object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(willDeactivate),
+                                               name: UIScene.didEnterBackgroundNotification,
+                                               object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didActivate),
+                                               name: UIScene.willEnterForegroundNotification,
+                                               object: nil)
     }
 
     private func receive(state: AppState) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Middleware/CallingMiddlewareHandler.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Middleware/CallingMiddlewareHandler.swift
@@ -149,7 +149,8 @@ class CallingMiddlewareHandler: CallingMiddlewareHandling {
 
     func enterForeground(state: AppState, dispatch: @escaping ActionDispatch) -> Task<Void, Never> {
         Task {
-            guard state.callingState.status == .connected,
+            guard state.lifeCycleState.currentStatus == .background,
+                  state.callingState.status == .connected,
                   state.localUserState.cameraState.operation == .paused else {
                 return
             }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Switch camera off when user opens AppCenter or user locks screen

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
