### PR TITLE
[Calling][Bug] Update focus after device select list dismiss

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupView.swift
@@ -44,6 +44,7 @@ struct SetupView: View {
                             }
                             .background(Color(StyleProvider.color.surface))
                             .cornerRadius(4)
+                            .accessibilityElement(children: .contain)
                             joinCallView
                                 .padding(.bottom)
                         }
@@ -52,6 +53,7 @@ struct SetupView: View {
                             .padding(.bottom, setupViewVerticalPadding(parentSize: geometry.size))
                     }
                     .padding(.horizontal, setupViewHorizontalPadding(parentSize: geometry.size))
+                    .accessibilityElement(children: .contain)
                 }
             }
         }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/SetupControlBarView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Setup/SetupViewComponent/SetupControlBarView.swift
@@ -21,12 +21,12 @@ struct SetupControlBarView: View {
                 HStack(alignment: .center, spacing: layoutSpacing) {
                     if viewModel.isCameraDisplayed {
                         Spacer()
-                        cameraButton
+                        cameraButton.accessibility(sortPriority: 1)
                     }
                     Spacer()
-                    micButton
+                    micButton.accessibility(sortPriority: 0)
                     Spacer()
-                    audioDeviceButton
+                    audioDeviceButton.accessibility(sortPriority: 2)
                     Spacer()
                 }
                 .frame(width: getWidth(from: geometry),
@@ -34,6 +34,7 @@ struct SetupControlBarView: View {
                 .padding(.horizontal, getHorizontalPadding(from: geometry))
                 .padding(.vertical, verticalPadding)
                 .hidden(viewModel.isControlBarHidden())
+                .accessibilityElement(children: .contain)
             }
         }
         .modifier(PopupModalView(isPresented: viewModel.isAudioDeviceSelectionDisplayed) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Focus won't be back to device button because of the complex layout 
* Add the accessibilityElement(children: .contain) to let voiceover get the children layout element 
* Set the order to HStack, which will help to be back to deviceButton

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
