### PR TITLE
[Calling][Feature] Leave call confirmation mode

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
@@ -63,6 +63,7 @@ class EnvConfigSubject: ObservableObject {
     @Published var cameraOn: Bool = false
     @Published var audioOnly: Bool = false
     @Published var skipSetupScreen: Bool = false
+    @Published var displayLeaveCallConfirmation: Bool = true
     @Published var useCustomColors: Bool = false
     @Published var useCustomRemoteParticipantViewData: Bool = false
     @Published var useMockCallingSDKHandler: Bool = false

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Utilities/AccessibilityId.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Utilities/AccessibilityId.swift
@@ -34,4 +34,6 @@ enum AccessibilityId: String {
             "AzureCommunicationUICalling.SettingsView.useRelaunchOnDismissed.AccessibilityID"
     case toggleAudioOnlyModeAccessibilityID = "AzureCommunicationUICalling.SettingsView.AudioOnly.AccessibilityID"
     case userReportedIssueAccessibilityID = "AzureCommunicationUICalling.Launcher.UserFeedback"
+    case leaveCallConfirmationDisplayAccessibilityID =
+            "AzureCommunicationUICalling.SettingsView.leaveCallConfirmationDisplay.AccessibilityID"
 }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
@@ -250,6 +250,10 @@ extension CallingDemoView {
 
         var localizationConfig: LocalizationOptions?
         let layoutDirection: LayoutDirection = envConfigSubject.isRightToLeft ? .rightToLeft : .leftToRight
+        let barOptions = CallScreenControlBarOptions(leaveCallConfirmationMode:
+                                                        envConfigSubject.displayLeaveCallConfirmation ?
+            .alwaysEnabled : .alwaysDisabled)
+        var callScreenOptions = CallScreenOptions(controlBarOptions: barOptions)
         if !envConfigSubject.localeIdentifier.isEmpty {
             let locale = Locale(identifier: envConfigSubject.localeIdentifier)
             localizationConfig = LocalizationOptions(locale: locale,
@@ -270,7 +274,8 @@ extension CallingDemoView {
             setupScreenOrientation: setupViewOrientation,
             callingScreenOrientation: callingViewOrientation,
             enableMultitasking: envConfigSubject.enableMultitasking,
-            enableSystemPictureInPictureWhenMultitasking: envConfigSubject.enablePipWhenMultitasking)
+            enableSystemPictureInPictureWhenMultitasking: envConfigSubject.enablePipWhenMultitasking,
+            callScreenOptions: callScreenOptions)
         #if DEBUG
         let useMockCallingSDKHandler = envConfigSubject.useMockCallingSDKHandler
         let callComposite = useMockCallingSDKHandler ?

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoViewController.swift
@@ -211,7 +211,10 @@ class CallingDemoViewController: UIViewController {
                 locale: envConfigSubject.locale,
                 layoutDirection: layoutDirection)
         }
-
+        let barOptions = CallScreenControlBarOptions(leaveCallConfirmationMode:
+                                                        envConfigSubject.displayLeaveCallConfirmation ?
+            .alwaysEnabled : .alwaysDisabled)
+        var callScreenOptions = CallScreenOptions(controlBarOptions: barOptions)
         let setupViewOrientation = envConfigSubject.setupViewOrientation
         let callingViewOrientation = envConfigSubject.callingViewOrientation
         let callCompositeOptions = CallCompositeOptions(
@@ -222,7 +225,8 @@ class CallingDemoViewController: UIViewController {
             setupScreenOrientation: setupViewOrientation,
             callingScreenOrientation: callingViewOrientation,
             enableMultitasking: envConfigSubject.enableMultitasking,
-            enableSystemPictureInPictureWhenMultitasking: envConfigSubject.enablePipWhenMultitasking)
+            enableSystemPictureInPictureWhenMultitasking: envConfigSubject.enablePipWhenMultitasking,
+            callScreenOptions: callScreenOptions)
         #if DEBUG
         let callComposite = envConfigSubject.useMockCallingSDKHandler ?
             CallComposite(withOptions: callCompositeOptions,

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -67,7 +67,6 @@ struct SettingsView: View {
             Group {
                 localizationSettings
                 skipSetupScreenSettings
-                displayLeaveCallConfirmationSettings
                 micSettings
                 localParticipantSettings
                 avatarSettings
@@ -77,6 +76,7 @@ struct SettingsView: View {
                 themeSettings
                 multitaskingSettings
             }
+            displayLeaveCallConfirmationSettings
             exitCompositeSettings
         }
     }

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -52,7 +52,7 @@ struct SettingsView: View {
     }
 
     var displayLeaveCallConfirmationSettings: some View {
-        Section(header: Text("Display leave call confirmation")) {
+        Section(header: Text("Call screen settings")) {
             Toggle("Display leave call confirmation", isOn: $envConfigSubject.displayLeaveCallConfirmation)
                 .onTapGesture {
                     envConfigSubject.displayLeaveCallConfirmation = !envConfigSubject.displayLeaveCallConfirmation

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/SettingsView.swift
@@ -51,12 +51,23 @@ struct SettingsView: View {
         .accessibilityIdentifier(AccessibilityId.settingsCloseButtonAccessibilityID.rawValue)
     }
 
+    var displayLeaveCallConfirmationSettings: some View {
+        Section(header: Text("Display leave call confirmation")) {
+            Toggle("Display leave call confirmation", isOn: $envConfigSubject.displayLeaveCallConfirmation)
+                .onTapGesture {
+                    envConfigSubject.displayLeaveCallConfirmation = !envConfigSubject.displayLeaveCallConfirmation
+                }
+                .accessibilityIdentifier(AccessibilityId.leaveCallConfirmationDisplayAccessibilityID.rawValue)
+        }
+    }
+
     var settingsForm: some View {
         Form {
             orientationOptions
             Group {
                 localizationSettings
                 skipSetupScreenSettings
+                displayLeaveCallConfirmationSettings
                 micSettings
                 localParticipantSettings
                 avatarSettings

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Tests/AzureCommunicationUIDemoAppE2ETests.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Tests/AzureCommunicationUIDemoAppE2ETests.swift
@@ -31,6 +31,14 @@ class AzureCommunicationUIDemoAppE2ETests: XCUITestBase {
         e2eTest()
     }
 
+    func testWhenLeaveCallConfirmationDisabled() {
+        tapInterfaceFor(.callUIKit)
+        tapMeetingType(.teamsCall)
+        disableLeaveCallConfirmationToggle()
+        joinCall()
+        leaveCallWithoutConfirmation()
+    }
+
     // MARK: Private / helper functions
 
     /// Toggles the leave call overlay  in the calling screen and triggers call end
@@ -38,6 +46,12 @@ class AzureCommunicationUIDemoAppE2ETests: XCUITestBase {
         tapButton(accessibilityIdentifier: AccessibilityIdentifier.hangupAccessibilityID.rawValue,
                   shouldWait: true)
         tapCell(accessibilityIdentifier: AccessibilityIdentifier.leaveCallAccessibilityID.rawValue)
+        wait(for: app.buttons[AccessibilityId.startExperienceAccessibilityID.rawValue])
+    }
+
+    private func leaveCallWithoutConfirmation() {
+        tapButton(accessibilityIdentifier: AccessibilityIdentifier.hangupAccessibilityID.rawValue,
+                  shouldWait: true)
         wait(for: app.buttons[AccessibilityId.startExperienceAccessibilityID.rawValue])
     }
 

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Tests/Utilities/XCUITestBase.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Tests/Utilities/XCUITestBase.swift
@@ -207,6 +207,28 @@ extension XCUITestBase {
                          shouldWait: true)
     }
 
+    func disableLeaveCallConfirmationToggle(useCallingSDKMock: Bool = true) {
+        tapButton(accessibilityIdentifier: AccessibilityId.settingsButtonAccessibilityID.rawValue)
+        let leaveToggle = app.switches[AccessibilityId.leaveCallConfirmationDisplayAccessibilityID.rawValue]
+        wait(for: leaveToggle)
+        leaveToggle.tap()
+        XCTAssertEqual(leaveToggle.isOn, false)
+        if #unavailable(iOS 16) {
+            // for <iOS 16, the table is shown
+            app.tables.firstMatch.swipeUp()
+        } else {
+            // for iOS 16, the collection is shown
+            app.collectionViews.firstMatch.swipeUp()
+        }
+        let toggle = app.switches[AccessibilityId.useMockCallingSDKHandlerToggleAccessibilityID.rawValue]
+        wait(for: toggle)
+        toggle.tap()
+        XCTAssertEqual(toggle.isOn, true)
+        closeDemoAppSettingsPage()
+        tapEnabledButton(accessibilityIdentifier: AccessibilityId.startExperienceAccessibilityID.rawValue,
+                         shouldWait: true)
+    }
+
     func closeDemoAppSettingsPage() {
         if #unavailable(iOS 15) {
             // Close button in toolbar is unavailable for iOS 14 because of how Forms handles events

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/AzureCommunicationUICalling.xcodeproj/project.pbxproj
@@ -159,6 +159,10 @@
 		534B2CF42B575CFB00D52D02 /* CallCompositeAudioVideoMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534B2CF32B575CFB00D52D02 /* CallCompositeAudioVideoMode.swift */; };
 		538016522B900C690093AC4D /* LandscapeAwareKeyboardWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538016512B900C690093AC4D /* LandscapeAwareKeyboardWatcher.swift */; };
 		53B6C33C2B58BA03000EFE19 /* CompositeViewModelFactoryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B6C33B2B58BA03000EFE19 /* CompositeViewModelFactoryProtocols.swift */; };
+		5A1F4BCD2BD9756D00EA7B2D /* LeaveCallConfirmationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F4BCA2BD9756C00EA7B2D /* LeaveCallConfirmationMode.swift */; };
+		5A1F4BCE2BD9756D00EA7B2D /* CallScreenOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F4BCB2BD9756C00EA7B2D /* CallScreenOptions.swift */; };
+		5A1F4BCF2BD9756D00EA7B2D /* CallScreenControlBarOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F4BCC2BD9756C00EA7B2D /* CallScreenControlBarOptions.swift */; };
+		5A1F4BD12BDA08D200EA7B2D /* ControlBarViewModelExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F4BD02BDA08D200EA7B2D /* ControlBarViewModelExtension.swift */; };
 		5A314059D7E61D1083A8C473 /* LocalVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A314A985811198B09DA2688 /* LocalVideoView.swift */; };
 		5A3140EA80ACDCB14140A060 /* CompositeViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3145FC912A71B20D5ECBF6 /* CompositeViewFactory.swift */; };
 		5A3142646DD55C66CF290F7A /* LocalVideoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A314317E4A1B700E6BE5E2E /* LocalVideoViewModel.swift */; };
@@ -515,6 +519,10 @@
 		534B2CF32B575CFB00D52D02 /* CallCompositeAudioVideoMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallCompositeAudioVideoMode.swift; sourceTree = "<group>"; };
 		538016512B900C690093AC4D /* LandscapeAwareKeyboardWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandscapeAwareKeyboardWatcher.swift; sourceTree = "<group>"; };
 		53B6C33B2B58BA03000EFE19 /* CompositeViewModelFactoryProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositeViewModelFactoryProtocols.swift; sourceTree = "<group>"; };
+		5A1F4BCA2BD9756C00EA7B2D /* LeaveCallConfirmationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeaveCallConfirmationMode.swift; sourceTree = "<group>"; };
+		5A1F4BCB2BD9756C00EA7B2D /* CallScreenOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallScreenOptions.swift; sourceTree = "<group>"; };
+		5A1F4BCC2BD9756C00EA7B2D /* CallScreenControlBarOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallScreenControlBarOptions.swift; sourceTree = "<group>"; };
+		5A1F4BD02BDA08D200EA7B2D /* ControlBarViewModelExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBarViewModelExtension.swift; sourceTree = "<group>"; };
 		5A3141390FEFB58AD2A2E22F /* LocalVideoViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalVideoViewModelTests.swift; sourceTree = "<group>"; };
 		5A314317E4A1B700E6BE5E2E /* LocalVideoViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalVideoViewModel.swift; sourceTree = "<group>"; };
 		5A31447C18BC49B691800C9D /* ACSCameraFacingExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ACSCameraFacingExtension.swift; sourceTree = "<group>"; };
@@ -1104,6 +1112,7 @@
 				50FA460D26829345001844AC /* InfoHeaderViewModel.swift */,
 				50FA45F4267D3BD3001844AC /* ControlBarView.swift */,
 				50FA460F26829B7A001844AC /* ControlBarViewModel.swift */,
+				5A1F4BD02BDA08D200EA7B2D /* ControlBarViewModelExtension.swift */,
 				50E2D69426EACB74006B0EF4 /* ParticipantsListViewModel.swift */,
 				50E2D69826F4FA05006B0EF4 /* ParticipantsListCellViewModel.swift */,
 				1BAD44BB283DAF2100C9E6A9 /* DraggableLocalVideoView.swift */,
@@ -1320,6 +1329,9 @@
 				1F94DAF42677D48400691D1E /* CallCompositeError.swift */,
 				A464810329F3353B001B80A3 /* CallCompositeCallState.swift */,
 				A8373993261F9D7600D46787 /* CallCompositeOptions.swift */,
+				5A1F4BCC2BD9756C00EA7B2D /* CallScreenControlBarOptions.swift */,
+				5A1F4BCB2BD9756C00EA7B2D /* CallScreenOptions.swift */,
+				5A1F4BCA2BD9756C00EA7B2D /* LeaveCallConfirmationMode.swift */,
 				A810038A26A0C1740015C26E /* CallConfiguration.swift */,
 				FA538277292FE86200963FFC /* DebugInfo.swift */,
 				1F48B400274879F000B6E5F9 /* DiagnosticConfig.swift */,
@@ -1879,6 +1891,7 @@
 				1B79BD50273F2D87002D5A36 /* UIViewControllerExtension.swift in Sources */,
 				503F4B692704EDD100C17DA6 /* BannerViewModel.swift in Sources */,
 				982C2835267D15AF00427246 /* CompositeAvatar.swift in Sources */,
+				5A1F4BCE2BD9756D00EA7B2D /* CallScreenOptions.swift in Sources */,
 				FAD20A8D292834500063D8A9 /* CancelBag.swift in Sources */,
 				50FA460C26829162001844AC /* IconWithLabelButton.swift in Sources */,
 				756F596E2965F8EA00BAFBF7 /* Store.swift in Sources */,
@@ -2000,6 +2013,7 @@
 				1FBCB6B9264BA90000F57EEA /* ParticipantGridCellVideoView.swift in Sources */,
 				1F48B401274879F000B6E5F9 /* DiagnosticConfig.swift in Sources */,
 				05C1C828297F4830006EDD0D /* CallHistoryRecord.swift in Sources */,
+				5A1F4BD12BDA08D200EA7B2D /* ControlBarViewModelExtension.swift in Sources */,
 				9823AB4926A13F220006266D /* PreviewAreaView.swift in Sources */,
 				50FA46212698EA7A001844AC /* IconWithLabelButtonViewModel.swift in Sources */,
 				11159FFE2A1D3F4200C0E3B8 /* OrientationOptions.swift in Sources */,
@@ -2031,6 +2045,7 @@
 				756F59782966020800BAFBF7 /* AccessibilityProviderProtocol.swift in Sources */,
 				988799912745EABE00AA3759 /* SourceViewSpace.swift in Sources */,
 				1FBCB6B12649EB1200F57EEA /* RemoteParticipantExtension.swift in Sources */,
+				5A1F4BCF2BD9756D00EA7B2D /* CallScreenControlBarOptions.swift in Sources */,
 				FA6B61A1290C89EC004B8188 /* DrawerViewControllerProtocol.swift in Sources */,
 				88F6EE1C2735F8E8001AD3E9 /* ErrorState.swift in Sources */,
 				1F48CF1F283447F400A44D58 /* CallingSDKWrapperProtocol.swift in Sources */,
@@ -2043,6 +2058,7 @@
 				500C0F1F2847DE18000BA2DC /* RemoteOptions.swift in Sources */,
 				759BDEFF28FF0B0B002B6853 /* LocalizationProvider.swift in Sources */,
 				1F13D36C26A8B83300E31666 /* RemoteParticipantsState.swift in Sources */,
+				5A1F4BCD2BD9756D00EA7B2D /* LeaveCallConfirmationMode.swift in Sources */,
 				1FFEA01426A68D0D00E90816 /* FontExtension.swift in Sources */,
 				1FBCB666264519DA00F57EEA /* VideoViewManager.swift in Sources */,
 				051EE22B2AB9106200A94632 /* LobbyWaitingHeaderViewModel.swift in Sources */,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
@@ -62,6 +62,7 @@ public class CallComposite {
     private var callHistoryService: CallHistoryService?
     private lazy var callHistoryRepository = CallHistoryRepository(logger: logger,
         userDefaults: UserDefaults.standard)
+    private var leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled
 
     private var viewFactory: CompositeViewFactoryProtocol?
     private var viewController: UIViewController?
@@ -91,6 +92,8 @@ public class CallComposite {
         setupViewOrientationOptions = options?.setupScreenOrientation
         callingViewOrientationOptions = options?.callingScreenOrientation
         orientationProvider = OrientationProvider()
+        leaveCallConfirmationMode =
+               options?.callScreenOptions?.controlBarOptions?.leaveCallConfirmationMode ?? .alwaysEnabled
     }
 
     /// Dismiss call composite. If call is in progress, user will leave a call.
@@ -293,7 +296,8 @@ public class CallComposite {
                 enableMultitasking: enableMultitasking,
                 enableSystemPipWhenMultitasking: enableSystemPipWhenMultitasking,
                 eventsHandler: events,
-                retrieveLogFiles: callingSdkWrapper.getLogFiles
+                retrieveLogFiles: callingSdkWrapper.getLogFiles,
+                leaveCallConfirmationMode: leaveCallConfirmationMode
             )
         )
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallComposite.swift
@@ -300,8 +300,8 @@ public class CallComposite {
                 enableMultitasking: enableMultitasking,
                 enableSystemPipWhenMultitasking: enableSystemPipWhenMultitasking,
                 eventsHandler: events,
-                retrieveLogFiles: callingSdkWrapper.getLogFiles,
-                leaveCallConfirmationMode: leaveCallConfirmationMode
+                leaveCallConfirmationMode: leaveCallConfirmationMode,
+                retrieveLogFiles: callingSdkWrapper.getLogFiles
             )
         )
     }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallCompositeOptions.swift
@@ -14,7 +14,7 @@ public struct CallCompositeOptions {
     private(set) var enableSystemPipWhenMultitasking: Bool = false
     private(set) var setupScreenOrientation: OrientationOptions?
     private(set) var callingScreenOrientation: OrientationOptions?
-
+    private(set) var callScreenOptions: CallScreenOptions?
     /// Creates an instance of CallCompositeOptions with related options.
     /// - Parameter theme: ThemeOptions for changing color pattern.
     ///  Default value is `nil`.
@@ -33,12 +33,14 @@ public struct CallCompositeOptions {
                 setupScreenOrientation: OrientationOptions? = nil,
                 callingScreenOrientation: OrientationOptions? = nil,
                 enableMultitasking: Bool = false,
-                enableSystemPictureInPictureWhenMultitasking: Bool = false) {
+                enableSystemPictureInPictureWhenMultitasking: Bool = false,
+                callScreenOptions: CallScreenOptions? = nil) {
         self.themeOptions = theme
         self.localizationOptions = localization
         self.setupScreenOrientation = setupScreenOrientation
         self.callingScreenOrientation = callingScreenOrientation
         self.enableMultitasking = enableMultitasking
         self.enableSystemPipWhenMultitasking = enableSystemPictureInPictureWhenMultitasking
+        self.callScreenOptions = callScreenOptions
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenControlBarOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenControlBarOptions.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// Configuration options for customizing the call screen control bar.
+public struct CallScreenControlBarOptions {
+    /// Determines whether to display leave call confirmation. Default is enabled.
+    public let leaveCallConfirmationMode: LeaveCallConfirmationMode
+
+    /// Initializes an instance of CallScreenControlBarOptions.
+    /// - Parameter leaveCallConfirmationMode: Whether to enable or disable the leave call confirmation.
+    ///                                           Default is enabled.
+    init(leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled) {
+        self.leaveCallConfirmationMode = leaveCallConfirmationMode
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenControlBarOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenControlBarOptions.swift
@@ -13,7 +13,7 @@ public struct CallScreenControlBarOptions {
     /// Initializes an instance of CallScreenControlBarOptions.
     /// - Parameter leaveCallConfirmationMode: Whether to enable or disable the leave call confirmation.
     ///                                           Default is enabled.
-    init(leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled) {
+    public init(leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled) {
         self.leaveCallConfirmationMode = leaveCallConfirmationMode
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenOptions.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// User-configurable options for creating CallScreen.
+public struct CallScreenOptions {
+    /// CallScreenControlBarOptions for specifying CallScreenControlBar customization.
+    let controlBarOptions: CallScreenControlBarOptions?
+
+    /// Creates an instance of CallScreenOptions with related options.
+    /// - Parameter controlBarOptions: CallScreenControlBarOptions for specifying CallScreenControlBar customization.
+    public init(controlBarOptions: CallScreenControlBarOptions? = nil) {
+        self.controlBarOptions = controlBarOptions
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenOptions.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/CallScreenOptions.swift
@@ -8,7 +8,7 @@ import Foundation
 /// User-configurable options for creating CallScreen.
 public struct CallScreenOptions {
     /// CallScreenControlBarOptions for specifying CallScreenControlBar customization.
-    let controlBarOptions: CallScreenControlBarOptions?
+    public let controlBarOptions: CallScreenControlBarOptions?
 
     /// Creates an instance of CallScreenOptions with related options.
     /// - Parameter controlBarOptions: CallScreenControlBarOptions for specifying CallScreenControlBar customization.

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LeaveCallConfirmationMode.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LeaveCallConfirmationMode.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// Enum defining options for leaving a call confirmation.
+public enum LeaveCallConfirmationMode {
+    /// Enables the leave call confirmation.
+    case alwaysEnabled
+    /// Disables the leave call confirmation.
+    case alwaysDisabled
+
+    /// Provides a `String` representation of the mode.
+    /// - For `.always_enabled`, returns "always_enabled".
+    /// - For `.always_disabled`, returns "always_disabled".
+    var rawValue: String {
+        switch self {
+        case .alwaysEnabled:
+            return "always_enabled"
+        case .alwaysDisabled:
+            return "always_disabled"
+        }
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LeaveCallConfirmationMode.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/CallCompositeOptions/LeaveCallConfirmationMode.swift
@@ -4,23 +4,54 @@
 //
 
 import Foundation
+import AzureCore
 
 /// Enum defining options for leaving a call confirmation.
-public enum LeaveCallConfirmationMode {
-    /// Enables the leave call confirmation.
-    case alwaysEnabled
-    /// Disables the leave call confirmation.
-    case alwaysDisabled
+public struct LeaveCallConfirmationMode: Equatable, RequestStringConvertible {
+    internal enum  LeaveCallConfirmationModeKV {
+        case alwaysEnabled
+        case alwaysDisabled
+        case unknown(String)
 
-    /// Provides a `String` representation of the mode.
-    /// - For `.always_enabled`, returns "always_enabled".
-    /// - For `.always_disabled`, returns "always_disabled".
-    var rawValue: String {
-        switch self {
-        case .alwaysEnabled:
-            return "always_enabled"
-        case .alwaysDisabled:
-            return "always_disabled"
+        var rawValue: String {
+            switch self {
+            case .alwaysEnabled:
+                return "always_enabled"
+            case .alwaysDisabled:
+                return "always_disabled"
+            case .unknown(let value):
+                return value
+            }
+        }
+        init(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "always_enabled":
+                self = .alwaysEnabled
+            case "always_disabled":
+                self = .alwaysDisabled
+            default:
+                self = .unknown(rawValue.lowercased())
+            }
         }
     }
+
+    private let value: LeaveCallConfirmationModeKV
+
+    public var requestString: String {
+        return value.rawValue
+    }
+
+    private init(rawValue: String) {
+        self.value = LeaveCallConfirmationModeKV(rawValue: rawValue)
+    }
+
+    public static func == (lhs: LeaveCallConfirmationMode, rhs: LeaveCallConfirmationMode) -> Bool {
+        return lhs.requestString == rhs.requestString
+    }
+
+    /// Enables the leave call confirmation.
+    public static let alwaysEnabled: LeaveCallConfirmationMode = .init(rawValue: "always_enabled")
+
+    /// Disables the leave call confirmation.
+    public static let alwaysDisabled: LeaveCallConfirmationMode = .init(rawValue: "always_disabled")
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -22,6 +22,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
     private let retrieveLogFiles: () -> [URL]
     private weak var setupViewModel: SetupViewModel?
     private weak var callingViewModel: CallingViewModel?
+    private var leaveCallConfirmationMode: LeaveCallConfirmationMode?
 
     init(logger: Logger,
          store: Store<AppState, Action>,
@@ -34,7 +35,8 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
          enableMultitasking: Bool,
          enableSystemPipWhenMultitasking: Bool,
          eventsHandler: CallComposite.Events,
-         retrieveLogFiles: @escaping () -> [URL]
+         retrieveLogFiles: @escaping () -> [URL],
+         leaveCallConfirmationMode: LeaveCallConfirmationMode
          ) {
         self.logger = logger
         self.store = store
@@ -48,6 +50,7 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
         self.enableMultitasking = enableMultitasking
         self.enableSystemPipWhenMultitasking = enableSystemPipWhenMultitasking
         self.retrieveLogFiles = retrieveLogFiles
+        self.leaveCallConfirmationMode = leaveCallConfirmationMode
     }
 
     func makeSupportFormViewModel() -> SupportFormViewModel {
@@ -83,7 +86,8 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
                                              accessibilityProvider: accessibilityProvider,
                                              isIpadInterface: UIDevice.current.userInterfaceIdiom == .pad,
                                              allowLocalCameraPreview: localOptions?.audioVideoMode
-                                             != CallCompositeAudioVideoMode.audioOnly)
+                                            != CallCompositeAudioVideoMode.audioOnly,
+                                            leaveCallConfirmationMode: self.leaveCallConfirmationMode ?? .alwaysEnabled)
             self.setupViewModel = nil
             self.callingViewModel = viewModel
             return viewModel
@@ -194,14 +198,17 @@ extension CompositeViewModelFactory {
     }
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),
-                                 localUserState: LocalUserState) -> ControlBarViewModel {
+                                 localUserState: LocalUserState,
+                                 leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled)
+    -> ControlBarViewModel {
         ControlBarViewModel(compositeViewModelFactory: self,
                             logger: logger,
                             localizationProvider: localizationProvider,
                             dispatchAction: dispatchAction,
                             endCallConfirm: endCallConfirm,
                             localUserState: localUserState,
-                            audioVideoMode: localOptions?.audioVideoMode ?? .audioAndVideo)
+                            audioVideoMode: localOptions?.audioVideoMode ?? .audioAndVideo,
+                            leaveCallConfirmationMode: self.leaveCallConfirmationMode ?? .alwaysEnabled)
     }
 
     func makeInfoHeaderViewModel(dispatchAction: @escaping ActionDispatch,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactory.swift
@@ -35,8 +35,8 @@ class CompositeViewModelFactory: CompositeViewModelFactoryProtocol {
          enableMultitasking: Bool,
          enableSystemPipWhenMultitasking: Bool,
          eventsHandler: CallComposite.Events,
-         retrieveLogFiles: @escaping () -> [URL],
-         leaveCallConfirmationMode: LeaveCallConfirmationMode
+         leaveCallConfirmationMode: LeaveCallConfirmationMode,
+         retrieveLogFiles: @escaping () -> [URL]
          ) {
         self.logger = logger
         self.store = store

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactoryProtocols.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Factories/CompositeViewModelFactoryProtocols.swift
@@ -39,7 +39,8 @@ protocol CompositeViewModelFactoryProtocol {
     func makeOnHoldOverlayViewModel(resumeAction: @escaping (() -> Void)) -> OnHoldOverlayViewModel
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),
-                                 localUserState: LocalUserState) -> ControlBarViewModel
+                                 localUserState: LocalUserState,
+                                 leaveCallConfirmationMode: LeaveCallConfirmationMode) -> ControlBarViewModel
     func makeInfoHeaderViewModel(dispatchAction: @escaping ActionDispatch,
                                  localUserState: LocalUserState) -> InfoHeaderViewModel
     func makeLobbyWaitingHeaderViewModel(localUserState: LocalUserState,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModelExtension.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewComponent/ControlBarViewModelExtension.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+extension ControlBarViewModel {
+    func dismissConfirmLeaveDrawerList() {
+        self.isConfirmLeaveListDisplayed = false
+    }
+
+    func isMoreButtonDisabled() -> Bool {
+        isBypassLoadingOverlay()
+    }
+
+    func isMicDisabled() -> Bool {
+        audioState.operation == .pending || callingStatus == .localHold || isBypassLoadingOverlay()
+    }
+
+    func isAudioDeviceDisabled() -> Bool {
+        callingStatus == .localHold || isBypassLoadingOverlay()
+    }
+
+    func isBypassLoadingOverlay() -> Bool {
+        operationStatus == .skipSetupRequested && callingStatus != .connected &&
+        callingStatus != .inLobby
+    }
+}

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/CallingViewModel.swift
@@ -25,6 +25,7 @@ class CallingViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var callHasConnected: Bool = false
     private var callClientRequested: Bool = false
+    private var leaveCallConfirmationMode: LeaveCallConfirmationMode?
 
     let localVideoViewModel: LocalVideoViewModel
     let participantGridsViewModel: ParticipantGridViewModel
@@ -48,7 +49,8 @@ class CallingViewModel: ObservableObject {
          localizationProvider: LocalizationProviderProtocol,
          accessibilityProvider: AccessibilityProviderProtocol,
          isIpadInterface: Bool,
-         allowLocalCameraPreview: Bool
+         allowLocalCameraPreview: Bool,
+         leaveCallConfirmationMode: LeaveCallConfirmationMode
     ) {
         self.logger = logger
         self.store = store
@@ -57,6 +59,7 @@ class CallingViewModel: ObservableObject {
         self.isRightToLeft = localizationProvider.isRightToLeft
         self.accessibilityProvider = accessibilityProvider
         self.allowLocalCameraPreview = allowLocalCameraPreview
+        self.leaveCallConfirmationMode = leaveCallConfirmationMode
         let actionDispatch: ActionDispatch = store.dispatch
 
         supportFormViewModel = compositeViewModelFactory.makeSupportFormViewModel()
@@ -90,7 +93,8 @@ class CallingViewModel: ObservableObject {
                     return
                 }
                 self.endCall()
-            }, localUserState: store.state.localUserState)
+            }, localUserState: store.state.localUserState,
+            leaveCallConfirmationMode: leaveCallConfirmationMode)
 
         onHoldOverlayViewModel = compositeViewModelFactory.makeOnHoldOverlayViewModel(resumeAction: { [weak self] in
             guard let self = self else {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/CompositeViewModelFactoryMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/CompositeViewModelFactoryMocking.swift
@@ -78,7 +78,8 @@ struct CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
                                                     localizationProvider: localizationProvider,
                                                     accessibilityProvider: accessibilityProvider,
                                                     isIpadInterface: false,
-                                                    allowLocalCameraPreview: true)
+                                                    allowLocalCameraPreview: true,
+                                                    leaveCallConfirmationMode: .alwaysEnabled)
     }
 
     func makeIconButtonViewModel(iconName: CompositeIcon,
@@ -189,14 +190,16 @@ struct CompositeViewModelFactoryMocking: CompositeViewModelFactoryProtocol {
 
     func makeControlBarViewModel(dispatchAction: @escaping ActionDispatch,
                                  endCallConfirm: @escaping (() -> Void),
-                                 localUserState: LocalUserState) -> ControlBarViewModel {
+                                 localUserState: LocalUserState,
+                                 leaveCallConfirmationMode: LeaveCallConfirmationMode) -> ControlBarViewModel {
         return controlBarViewModel ?? ControlBarViewModel(compositeViewModelFactory: self,
                                                           logger: logger,
                                                           localizationProvider: localizationProvider,
                                                           dispatchAction: dispatchAction,
                                                           endCallConfirm: endCallConfirm,
                                                           localUserState: localUserState,
-                                                          audioVideoMode: .audioAndVideo)
+                                                          audioVideoMode: .audioAndVideo,
+                                                          leaveCallConfirmationMode: leaveCallConfirmationMode)
     }
 
     func makeInfoHeaderViewModel(dispatchAction: @escaping AzureCommunicationUICalling.ActionDispatch,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Mocking/ViewModels/ControlBarViewModelMocking.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Mocking/ViewModels/ControlBarViewModelMocking.swift
@@ -15,7 +15,8 @@ class ControlBarViewModelMocking: ControlBarViewModel {
          dispatchAction: @escaping ActionDispatch,
          endCallConfirm: @escaping (() -> Void),
          localUserState: LocalUserState,
-         updateState: ((LocalUserState, PermissionState, VisibilityState) -> Void)? = nil) {
+         updateState: ((LocalUserState, PermissionState, VisibilityState) -> Void)? = nil,
+         leaveCallConfirmationMode: LeaveCallConfirmationMode = .alwaysEnabled) {
         self.updateState = updateState
         super.init(compositeViewModelFactory: compositeViewModelFactory,
                    logger: logger,
@@ -23,7 +24,8 @@ class ControlBarViewModelMocking: ControlBarViewModel {
                    dispatchAction: dispatchAction,
                    endCallConfirm: endCallConfirm,
                    localUserState: localUserState,
-                   audioVideoMode: .audioAndVideo)
+                   audioVideoMode: .audioAndVideo,
+                   leaveCallConfirmationMode: leaveCallConfirmationMode)
     }
 
     override func update(localUserState: LocalUserState,

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/CallingViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/CallingViewModelTests.swift
@@ -57,6 +57,28 @@ class CallingViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isConfirmLeaveListDisplayed)
         wait(for: [expectation], timeout: timeout)
     }
+    func test_callingViewModel_endCall_when_NoConfirmLeaveOverlayIsDisplayed() {
+        factoryMocking.controlBarViewModel = ControlBarViewModelMocking(compositeViewModelFactory: factoryMocking,
+                                                                        logger: logger,
+                                                                        localizationProvider: localizationProvider,
+                                                                        dispatchAction: storeFactory.store.dispatch,
+                                                                        endCallConfirm: {},
+                                                                        localUserState: storeFactory.store.state.localUserState,
+                                                                        leaveCallConfirmationMode: .alwaysDisabled)
+        let sut = makeSUT()
+        let expectation = XCTestExpectation(description: "Verify Call End is Requested")
+        storeFactory.store.$state
+            .dropFirst(1)
+            .sink { [weak storeFactory] _ in
+                XCTAssertEqual(storeFactory?.actions.count, 3)
+                XCTAssertTrue(storeFactory?.actions.first != Action.callingAction(.callEndRequested))
+
+                expectation.fulfill()
+            }.store(in: cancellable)
+        sut.endCall()
+        XCTAssertFalse(sut.isConfirmLeaveListDisplayed)
+        wait(for: [expectation], timeout: timeout)
+    }
 
     func test_callingViewModel_update_when_callStatusIsInLobby_then_isLobbyOverlayDisplayed_shouldBecomeTrue() {
         let sut = makeSUT()
@@ -286,6 +308,7 @@ extension CallingViewModelTests {
                                 localizationProvider: LocalizationProvider(logger: logger),
                                 accessibilityProvider: accessibilityProvider,
                                 isIpadInterface: false,
-                                allowLocalCameraPreview: true)
+                                allowLocalCameraPreview: true,
+                                leaveCallConfirmationMode: .alwaysEnabled)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ControlBarViewModelTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Calling/ControlBarViewModelTests.swift
@@ -84,6 +84,12 @@ class ControlBarViewModelTests: XCTestCase {
         sut.endCallButtonTapped()
         XCTAssertTrue(sut.isConfirmLeaveListDisplayed)
     }
+    func test_controlBarViewModel_endCall_when_No_confirmLeaveListIsDisplayed_ShouldRemainFalse() {
+        let sut = makeSUTWhenDisplayLeaveDiabled()
+        sut.isConfirmLeaveListDisplayed = false
+        sut.endCallButtonTapped()
+        XCTAssertFalse(sut.isConfirmLeaveListDisplayed)
+    }
 
     // MARK: Microphone tests
     func test_controlBarViewModel_microphoneButtonTapped_when_micStatusOff_then_shouldMicrophoneOnRequested() {
@@ -659,7 +665,18 @@ extension ControlBarViewModelTests {
                                    dispatchAction: storeFactory.store.dispatch,
                                    endCallConfirm: {},
                                    localUserState: storeFactory.store.state.localUserState,
-                                   audioVideoMode: audioVideoMode)
+                                   audioVideoMode: audioVideoMode,
+                                   leaveCallConfirmationMode: .alwaysEnabled)
+    }
+    func makeSUTWhenDisplayLeaveDiabled(localizationProvider: LocalizationProviderMocking? = nil, audioVideoMode: CallCompositeAudioVideoMode = .audioAndVideo) -> ControlBarViewModel {
+        return ControlBarViewModel(compositeViewModelFactory: factoryMocking,
+                                   logger: logger,
+                                   localizationProvider: localizationProvider ?? LocalizationProvider(logger: logger),
+                                   dispatchAction: storeFactory.store.dispatch,
+                                   endCallConfirm: {},
+                                   localUserState: storeFactory.store.state.localUserState,
+                                   audioVideoMode: audioVideoMode,
+                                   leaveCallConfirmationMode: .alwaysDisabled)
     }
 
     func makeSUTLocalizationMocking() -> ControlBarViewModel {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Factories/CompositeViewModelFactoryTests.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Tests/Presentation/Factories/CompositeViewModelFactoryTests.swift
@@ -46,7 +46,8 @@ extension CompositeViewModelFactoryTests {
                                          debugInfoManager: DebugInfoManagerMocking(),
                                          enableMultitasking: true,
                                          enableSystemPipWhenMultitasking: true,
-                                         eventsHandler: CallComposite.Events()) { [] }
+                                         eventsHandler: CallComposite.Events(),
+                                         leaveCallConfirmationMode: LeaveCallConfirmationMode.alwaysEnabled) { [] }
     }
 }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This feature introduce an option into CallCompositeBuilder to enable/disable the "Leave Call?" confirmation dialog. If disable, the "End Call" button will directly end the call without prompt.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
