### PR TITLE
Support for "Quick jumping" into the Mocked Composite

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/EnvConfig.swift
@@ -19,6 +19,7 @@ enum EnvConfig: String {
     case teamsMeetingLink
     case threadId
     case endpointUrl
+    case skipTo
     /* <ROOMS_SUPPORT:12> */
     case roomId
     case roomRole

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Info.plist
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Info.plist
@@ -60,5 +60,7 @@
 	<string>$(threadId)</string>
 	<key>userId</key>
 	<string>${userId}</string>
+    <key>skipTo</key>
+    <string>${skipTo}</string>
 </dict>
 </plist>

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
@@ -91,6 +91,7 @@ struct CallingDemoView: View {
         .sheet(isPresented: $isSettingsDisplayed) {
             SettingsView(envConfigSubject: envConfigSubject)
         }
+        #if DEBUG
         .onAppear(perform: {
             // Dev helper to jump through to mocked experiences
             Task {
@@ -105,6 +106,7 @@ struct CallingDemoView: View {
                 }
             }
         })
+        #endif
     }
 
     var acsTokenSelector: some View {

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
@@ -91,6 +91,20 @@ struct CallingDemoView: View {
         .sheet(isPresented: $isSettingsDisplayed) {
             SettingsView(envConfigSubject: envConfigSubject)
         }
+        .onAppear(perform: {
+            // Dev helper to jump through to mocked experiences
+            Task {
+                if EnvConfig.skipTo.value() == "MockCallScreen" {
+                    envConfigSubject.useMockCallingSDKHandler = true
+                    envConfigSubject.skipSetupScreen = true
+                    await startCallComposite()
+                } else if EnvConfig.skipTo.value() == "MockSetupScreen" {
+                    envConfigSubject.useMockCallingSDKHandler = true
+                    envConfigSubject.skipSetupScreen = false
+                    await startCallComposite()
+                }
+            }
+        })
     }
 
     var acsTokenSelector: some View {

--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/EntryViewController.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/EntryViewController.swift
@@ -32,6 +32,11 @@ class EntryViewController: UIViewController {
             window?.makeKeyAndVisible()
             window?.isHidden = true
         }
+
+        if EnvConfig.skipTo.value() != "" {
+            // Jump into The SwiftUI launcher if this is set
+            onCallingSwiftUIPressed()
+        }
 #endif
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* In development, time can be drained getting to the setup/call screen. This introduces "jumpTo" for EnvConfig.xcconfig, it can be set to "MockCallScreen", "MockSetupScreen" and will get into the composite faster if setup locally.
* Debug builds only

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
