### PR TITLE
[Calling][Bugfix] Initial switch to speaker fails, causing the audio device drawer to not populate

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
@@ -174,8 +174,7 @@ class AudioSessionManager: AudioSessionManagerProtocol {
         } catch let error {
             logger.error("Failed to select audio device, reason: \(error.localizedDescription)")
             store.dispatch(action: .localUserAction(.audioDeviceChangeFailed(error: error)))
-            let currentType = getCurrentAudioDevice()
-            store.dispatch(action: .localUserAction(.audioDeviceChangeSucceeded(device: currentType)))
+            store.dispatch(action: .localUserAction(.audioDeviceChangeSucceeded(device: getCurrentAudioDevice())))
         }
     }
 

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/Manager/AudioSessionManager.swift
@@ -174,6 +174,8 @@ class AudioSessionManager: AudioSessionManagerProtocol {
         } catch let error {
             logger.error("Failed to select audio device, reason: \(error.localizedDescription)")
             store.dispatch(action: .localUserAction(.audioDeviceChangeFailed(error: error)))
+            let currentType = getCurrentAudioDevice()
+            store.dispatch(action: .localUserAction(.audioDeviceChangeSucceeded(device: currentType)))
         }
     }
 


### PR DESCRIPTION


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* State gets stuck in "requesting" mode, which prevents the VM from populating the list. Dispatch additional action on error for "audioDeviceChangeSucceeded", with the currently detected device, to set the state back into the proper mode.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
