### PR TITLE
[Calling][Bugfix] Add accessibility announcement for remote participant onhold and resume

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Localization/en.lproj/Localizable.strings
@@ -70,6 +70,8 @@
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsUnmuted"="Unmuted";
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsSpeaking"="Speaking";
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold"="On hold";
+"AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold.AccessibilityLabel"="%@ is On hold";
+"AzureCommunicationUICalling.CallingView.ParticipantDrawer.Resume.AccessibilityLabel"="%@ resumed the call";
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.LobbyAction"="Tap to admit or decline";
 
 "AzureCommunicationUICalling.CallingView.ParticipantDrawer.WaitingInLobby"="Waiting in lobby (%d)";

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -186,13 +186,9 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
     }
 
     private func postParticipantStatusAccessibilityAnnouncements(isHold: Bool, participantModel: ParticipantInfoModel) {
-        if isHold {
-            accessibilityProvider.postQueuedAnnouncement(
-                localizationProvider.getLocalizedString(.onHoldAccessibilityLabel, participantModel.displayName))
-        } else {
-            accessibilityProvider.postQueuedAnnouncement(
-                localizationProvider.getLocalizedString(.participantResumeAccessibilityLabel,
-                                                        participantModel.displayName))
-        }
+        let holdResumeAccessibilityLabel = isHold ?
+            localizationProvider.getLocalizedString(.onHoldAccessibilityLabel, participantModel.displayName) :
+            localizationProvider.getLocalizedString(.participantResumeAccessibilityLabel, participantModel.displayName)
+        accessibilityProvider.postQueuedAnnouncement(holdResumeAccessibilityLabel)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -114,6 +114,7 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
 
         if self.isHold != isOnHold {
             self.isHold = isOnHold
+            postParticipantStatusAccessibilityAnnouncements(isHold: self.isHold, participantModel: participantModel)
         }
 
         self.isInBackground = lifeCycleState.currentStatus == .background
@@ -182,5 +183,16 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
                                                         participantStatus: ParticipantStatus?) -> Bool {
         return callType == .oneToNOutgoing &&
                (participantStatus == nil || participantStatus == .connecting || participantStatus == .ringing)
+    }
+
+    private func postParticipantStatusAccessibilityAnnouncements(isHold: Bool, participantModel: ParticipantInfoModel) {
+        if isHold {
+            accessibilityProvider.postQueuedAnnouncement(
+                localizationProvider.getLocalizedString(.onHoldAccessibilityLabel, participantModel.displayName))
+        } else {
+            accessibilityProvider.postQueuedAnnouncement(
+                localizationProvider.getLocalizedString(.participantResumeAccessibilityLabel,
+                                                        participantModel.displayName))
+        }
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/Cell/ParticipantGridCellViewModel.swift
@@ -186,9 +186,9 @@ class ParticipantGridCellViewModel: ObservableObject, Identifiable {
     }
 
     private func postParticipantStatusAccessibilityAnnouncements(isHold: Bool, participantModel: ParticipantInfoModel) {
-        let holdResumeAccessibilityLabel = isHold ?
+        let holdResumeAccessibilityAnnouncement = isHold ?
             localizationProvider.getLocalizedString(.onHoldAccessibilityLabel, participantModel.displayName) :
             localizationProvider.getLocalizedString(.participantResumeAccessibilityLabel, participantModel.displayName)
-        accessibilityProvider.postQueuedAnnouncement(holdResumeAccessibilityLabel)
+        accessibilityProvider.postQueuedAnnouncement(holdResumeAccessibilityAnnouncement)
     }
 }

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridView.swift
@@ -25,6 +25,7 @@ struct ParticipantGridView: View {
             .onReceive(viewModel.$displayedParticipantInfoModelArr) {
                 updateVideoViewManager(displayedRemoteInfoModelArr: $0)
             }
+            .accessibilityElement(children: .contain)
     }
 
     func updateVideoViewManager(displayedRemoteInfoModelArr: [ParticipantInfoModel]) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridView.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/SwiftUI/Calling/Grid/ParticipantGridView.swift
@@ -25,7 +25,6 @@ struct ParticipantGridView: View {
             .onReceive(viewModel.$displayedParticipantInfoModelArr) {
                 updateVideoViewManager(displayedRemoteInfoModelArr: $0)
             }
-            .accessibilityElement(children: .contain)
     }
 
     func updateVideoViewManager(displayedRemoteInfoModelArr: [ParticipantInfoModel]) {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Utilities/LocalizationKey.swift
@@ -89,6 +89,10 @@ enum LocalizationKey: String {
     case unmuted = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsUnmuted"
     case speaking = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.IsSpeaking"
     case onHold = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold"
+    case onHoldAccessibilityLabel =
+            "AzureCommunicationUICalling.CallingView.ParticipantDrawer.OnHold.AccessibilityLabel"
+    case participantResumeAccessibilityLabel =
+            "AzureCommunicationUICalling.CallingView.ParticipantDrawer.Resume.AccessibilityLabel"
     case participantListLobbyAction = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.LobbyAction"
     case participantListWaitingInLobby = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.WaitingInLobby"
     case participantListInTheCall = "AzureCommunicationUICalling.CallingView.ParticipantDrawer.InTheCall"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Fix the issue where voice over doesn't have announcement when remote participant is on hold

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

Turn on Voiceover
Open Application using double tap.
Navigate to 'Start Experience' button using swipe gesture and double tap to activate it.
Call setup screen will appear
Now activate 'Join Call' using swipe gesture and double tap to activate it
Meeting will be joined.
Observed the voiceover announcement when other person in meeting is on hold.


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
