### PR TITLE
[Calling][Bug] Fix the selected device not correct after join the call 

### DIFF
--- a/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
+++ b/AzureCommunicationUI/AzureCommunicationUIDemoApp/Sources/Views/CallingDemoView.swift
@@ -997,13 +997,24 @@ extension CallingDemoView {
 
     public func configureAudioSession() -> Error? {
         let audioSession = AVAudioSession.sharedInstance()
-        let options: AVAudioSession.CategoryOptions = .allowBluetooth
         var configError: Error?
-        do {
-            try audioSession.setCategory(.playAndRecord, options: options)
-        } catch {
-            configError = error
+
+        // Check the current audio output route
+        let currentRoute = audioSession.currentRoute
+        let isUsingSpeaker = currentRoute.outputs.contains { $0.portType == .builtInSpeaker }
+        let isUsingReceiver = currentRoute.outputs.contains { $0.portType == .builtInReceiver }
+
+        // Only configure the session if necessary (e.g., when not on speaker/receiver)
+        if !isUsingSpeaker && !isUsingReceiver {
+            do {
+                // Keeping default .playAndRecord without forcing speaker
+                try audioSession.setCategory(.playAndRecord, options: [.allowBluetooth])
+                try audioSession.setActive(true)
+            } catch {
+                configError = error
+            }
         }
+
         return configError
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The audio session in demo app changed the audio selection when joining the call 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
