### PR TITLE
[Calling][Bug] Override the backgroud color with primary

### DIFF
--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeButton.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeButton.swift
@@ -57,7 +57,7 @@ struct CompositeButton: UIViewRepresentable {
                                    buttonStyle == .primaryOutline)
                                    ? themeOptions.primaryColor.dynamicColor
                                    : themeOptions.foregroundOnPrimaryColor.dynamicColor
-                let overrideTokens: [ButtonTokenSet.Tokens: ControlTokenValue] = [
+                var overrideTokens: [ButtonTokenSet.Tokens: ControlTokenValue] = [
                     .foregroundColor: ControlTokenValue.dynamicColor({
                         dynamicColor!
                     }),
@@ -69,11 +69,13 @@ struct CompositeButton: UIViewRepresentable {
                     }),
                     .borderColor: ControlTokenValue.dynamicColor({
                         themeOptions.primaryColor.dynamicColor!
-                    }),
-                    .backgroundColor: ControlTokenValue.dynamicColor({
-                        themeOptions.primaryColor.dynamicColor!
                     })
                 ]
+                if buttonStyle == .primaryFilled {
+                    overrideTokens[.backgroundColor] = .dynamicColor {
+                        themeOptions.primaryColor.dynamicColor!
+                    }
+                }
                 button.tokenSet.replaceAllOverrides(with: overrideTokens)
          /* </CUSTOM_COLOR_FEATURE> */
                  if let paddings = paddings {

--- a/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeButton.swift
+++ b/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Presentation/FluentUI/Wrapper/CompositeButton.swift
@@ -68,7 +68,10 @@ struct CompositeButton: UIViewRepresentable {
                         Colors.gray300.dynamicColor!
                     }),
                     .borderColor: ControlTokenValue.dynamicColor({
-                        dynamicColor!
+                        themeOptions.primaryColor.dynamicColor!
+                    }),
+                    .backgroundColor: ControlTokenValue.dynamicColor({
+                        themeOptions.primaryColor.dynamicColor!
                     })
                 ]
                 button.tokenSet.replaceAllOverrides(with: overrideTokens)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Override the button background with primary color 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Pull request checklist

This PR has considered:
- [ ] Color Theming
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] View Data Injection
- [ ] Demo App UI/UX update

## How to Test
<!-- Add steps to run the tests suite and/or manually test -->

* Open...
* Click on...


## What to Check
<!-- How the change was tested, including both manual and automated tests -->
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

## Other Information
<!-- Add any other helpful information that may be needed here. -->
